### PR TITLE
Catch TCP i/o timeouts properly

### DIFF
--- a/layout/sunspec.go
+++ b/layout/sunspec.go
@@ -27,7 +27,7 @@ func (s *SunSpecLayout) Open(a AddressSpaceDriver) (spi.ArraySPI, error) {
 		if id, err := a.ReadWords(b, 2); err != nil {
 			// if one query fails with network error including timeout,
 			// then assume they all will.
-			if err, ok := err.(net.Error); ok && !err.Temporary() {
+			if err, ok := err.(net.Error); ok {
 				return nil, err
 			}
 			continue


### PR DESCRIPTION
Currently: If i/o timeout is thrown after attempting to connect to a TCP endpoint, the error falls through, resulting in a misleading "not a SunSpec device" error.

I discovered this only through debugging and noticing a SYN flood with no TCP ACK when using Wireshark.

As previously discussed with @andig, we remove the `net.Error.Temporary` check and keep observing it in case the change leads to weird, unexpected behaviors.