### PR TITLE
types/xml: drop redundant len=1 on scalar struct tags

### DIFF
--- a/models/model1/model.go
+++ b/models/model1/model.go
@@ -33,8 +33,8 @@ type Block1 struct {
 	Opt string      `sunspec:"offset=32,len=8"`
 	Vr  string      `sunspec:"offset=40,len=8"`
 	SN  string      `sunspec:"offset=48,len=16"`
-	DA  uint16      `sunspec:"offset=64,len=1,access=rw"`
-	Pad sunspec.Pad `sunspec:"offset=65,len=1"`
+	DA  uint16      `sunspec:"offset=64,access=rw"`
+	Pad sunspec.Pad `sunspec:"offset=65"`
 }
 
 func (block *Block1) GetId() sunspec.ModelId {
@@ -58,8 +58,8 @@ func init() {
 					{Id: Opt, Offset: 32, Type: typelabel.String, Length: 8, Label: "Options", Description: "Manufacturer specific value (16 chars)"},
 					{Id: Vr, Offset: 40, Type: typelabel.String, Length: 8, Label: "Version", Description: "Manufacturer specific value (16 chars)"},
 					{Id: SN, Offset: 48, Type: typelabel.String, Length: 16, Mandatory: true, Label: "Serial Number", Description: "Manufacturer specific value (32 chars)"},
-					{Id: DA, Offset: 64, Type: typelabel.Uint16, Access: "rw", Length: 1, Label: "Device Address", Description: "Modbus device address"},
-					{Id: Pad, Offset: 65, Type: typelabel.Pad, Length: 1},
+					{Id: DA, Offset: 64, Type: typelabel.Uint16, Access: "rw", Label: "Device Address", Description: "Modbus device address"},
+					{Id: Pad, Offset: 65, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model10/model.go
+++ b/models/model10/model.go
@@ -25,10 +25,10 @@ const (
 )
 
 type Block10 struct {
-	St  sunspec.Enum16 `sunspec:"offset=0,len=1"`
-	Ctl uint16         `sunspec:"offset=1,len=1,access=rw"`
-	Typ sunspec.Enum16 `sunspec:"offset=2,len=1"`
-	Pad sunspec.Pad    `sunspec:"offset=3,len=1"`
+	St  sunspec.Enum16 `sunspec:"offset=0"`
+	Ctl uint16         `sunspec:"offset=1,access=rw"`
+	Typ sunspec.Enum16 `sunspec:"offset=2"`
+	Pad sunspec.Pad    `sunspec:"offset=3"`
 }
 
 func (block *Block10) GetId() sunspec.ModelId {
@@ -47,10 +47,10 @@ func init() {
 				Length: 4,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: St, Offset: 0, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Interface Status", Description: "Overall interface status"},
-					{Id: Ctl, Offset: 1, Type: typelabel.Uint16, Access: "rw", Length: 1, Label: "Interface Control", Description: "Overall interface control (TBD)"},
-					{Id: Typ, Offset: 2, Type: typelabel.Enum16, Length: 1, Label: "Physical Access Type", Description: "Enumerated value.  Type of physical media"},
-					{Id: Pad, Offset: 3, Type: typelabel.Pad, Length: 1},
+					{Id: St, Offset: 0, Type: typelabel.Enum16, Mandatory: true, Label: "Interface Status", Description: "Overall interface status"},
+					{Id: Ctl, Offset: 1, Type: typelabel.Uint16, Access: "rw", Label: "Interface Control", Description: "Overall interface control (TBD)"},
+					{Id: Typ, Offset: 2, Type: typelabel.Enum16, Label: "Physical Access Type", Description: "Enumerated value.  Type of physical media"},
+					{Id: Pad, Offset: 3, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model101/model.go
+++ b/models/model101/model.go
@@ -64,49 +64,49 @@ const (
 )
 
 type Block101 struct {
-	A       uint16              `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA    uint16              `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB    uint16              `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC    uint16              `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF    sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PPVphAB uint16              `sunspec:"offset=5,len=1,sf=V_SF"`
-	PPVphBC uint16              `sunspec:"offset=6,len=1,sf=V_SF"`
-	PPVphCA uint16              `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphA  uint16              `sunspec:"offset=8,len=1,sf=V_SF"`
-	PhVphB  uint16              `sunspec:"offset=9,len=1,sf=V_SF"`
-	PhVphC  uint16              `sunspec:"offset=10,len=1,sf=V_SF"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=11,len=1"`
-	W       int16               `sunspec:"offset=12,len=1,sf=W_SF"`
-	W_SF    sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz      uint16              `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	VA      int16               `sunspec:"offset=16,len=1,sf=VA_SF"`
-	VA_SF   sunspec.ScaleFactor `sunspec:"offset=17,len=1"`
-	VAr     int16               `sunspec:"offset=18,len=1,sf=VAr_SF"`
-	VAr_SF  sunspec.ScaleFactor `sunspec:"offset=19,len=1"`
-	PF      int16               `sunspec:"offset=20,len=1,sf=PF_SF"`
-	PF_SF   sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	WH      sunspec.Acc32       `sunspec:"offset=22,len=2,sf=WH_SF"`
-	WH_SF   sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	DCA     uint16              `sunspec:"offset=25,len=1,sf=DCA_SF"`
-	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=26,len=1"`
-	DCV     uint16              `sunspec:"offset=27,len=1,sf=DCV_SF"`
-	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=28,len=1"`
-	DCW     int16               `sunspec:"offset=29,len=1,sf=DCW_SF"`
-	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	TmpCab  int16               `sunspec:"offset=31,len=1,sf=Tmp_SF"`
-	TmpSnk  int16               `sunspec:"offset=32,len=1,sf=Tmp_SF"`
-	TmpTrns int16               `sunspec:"offset=33,len=1,sf=Tmp_SF"`
-	TmpOt   int16               `sunspec:"offset=34,len=1,sf=Tmp_SF"`
-	Tmp_SF  sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	St      sunspec.Enum16      `sunspec:"offset=36,len=1"`
-	StVnd   sunspec.Enum16      `sunspec:"offset=37,len=1"`
-	Evt1    sunspec.Bitfield32  `sunspec:"offset=38,len=2"`
-	Evt2    sunspec.Bitfield32  `sunspec:"offset=40,len=2"`
-	EvtVnd1 sunspec.Bitfield32  `sunspec:"offset=42,len=2"`
-	EvtVnd2 sunspec.Bitfield32  `sunspec:"offset=44,len=2"`
-	EvtVnd3 sunspec.Bitfield32  `sunspec:"offset=46,len=2"`
-	EvtVnd4 sunspec.Bitfield32  `sunspec:"offset=48,len=2"`
+	A       uint16              `sunspec:"offset=0,sf=A_SF"`
+	AphA    uint16              `sunspec:"offset=1,sf=A_SF"`
+	AphB    uint16              `sunspec:"offset=2,sf=A_SF"`
+	AphC    uint16              `sunspec:"offset=3,sf=A_SF"`
+	A_SF    sunspec.ScaleFactor `sunspec:"offset=4"`
+	PPVphAB uint16              `sunspec:"offset=5,sf=V_SF"`
+	PPVphBC uint16              `sunspec:"offset=6,sf=V_SF"`
+	PPVphCA uint16              `sunspec:"offset=7,sf=V_SF"`
+	PhVphA  uint16              `sunspec:"offset=8,sf=V_SF"`
+	PhVphB  uint16              `sunspec:"offset=9,sf=V_SF"`
+	PhVphC  uint16              `sunspec:"offset=10,sf=V_SF"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=11"`
+	W       int16               `sunspec:"offset=12,sf=W_SF"`
+	W_SF    sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz      uint16              `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=15"`
+	VA      int16               `sunspec:"offset=16,sf=VA_SF"`
+	VA_SF   sunspec.ScaleFactor `sunspec:"offset=17"`
+	VAr     int16               `sunspec:"offset=18,sf=VAr_SF"`
+	VAr_SF  sunspec.ScaleFactor `sunspec:"offset=19"`
+	PF      int16               `sunspec:"offset=20,sf=PF_SF"`
+	PF_SF   sunspec.ScaleFactor `sunspec:"offset=21"`
+	WH      sunspec.Acc32       `sunspec:"offset=22,sf=WH_SF"`
+	WH_SF   sunspec.ScaleFactor `sunspec:"offset=24"`
+	DCA     uint16              `sunspec:"offset=25,sf=DCA_SF"`
+	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=26"`
+	DCV     uint16              `sunspec:"offset=27,sf=DCV_SF"`
+	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=28"`
+	DCW     int16               `sunspec:"offset=29,sf=DCW_SF"`
+	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=30"`
+	TmpCab  int16               `sunspec:"offset=31,sf=Tmp_SF"`
+	TmpSnk  int16               `sunspec:"offset=32,sf=Tmp_SF"`
+	TmpTrns int16               `sunspec:"offset=33,sf=Tmp_SF"`
+	TmpOt   int16               `sunspec:"offset=34,sf=Tmp_SF"`
+	Tmp_SF  sunspec.ScaleFactor `sunspec:"offset=35"`
+	St      sunspec.Enum16      `sunspec:"offset=36"`
+	StVnd   sunspec.Enum16      `sunspec:"offset=37"`
+	Evt1    sunspec.Bitfield32  `sunspec:"offset=38"`
+	Evt2    sunspec.Bitfield32  `sunspec:"offset=40"`
+	EvtVnd1 sunspec.Bitfield32  `sunspec:"offset=42"`
+	EvtVnd2 sunspec.Bitfield32  `sunspec:"offset=44"`
+	EvtVnd3 sunspec.Bitfield32  `sunspec:"offset=46"`
+	EvtVnd4 sunspec.Bitfield32  `sunspec:"offset=48"`
 }
 
 func (block *Block101) GetId() sunspec.ModelId {
@@ -125,49 +125,49 @@ func init() {
 				Length: 50,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PPVphAB, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: PhVphA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: V_SF, Offset: 11, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: W, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "AC Power"},
-					{Id: W_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Line Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 16, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VA_SF, Offset: 17, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAr, Offset: 18, Type: typelabel.Int16, ScaleFactor: "VAr_SF", Units: "var", Length: 1, Label: "VAr", Description: "AC Reactive Power"},
-					{Id: VAr_SF, Offset: 19, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "AC Power Factor"},
-					{Id: PF_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: WH, Offset: 22, Type: typelabel.Acc32, ScaleFactor: "WH_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "WattHours", Description: "AC Energy"},
-					{Id: WH_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCA, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Label: "DC Amps", Description: "DC Current"},
-					{Id: DCA_SF, Offset: 26, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "DC Voltage", Description: "DC Voltage"},
-					{Id: DCV_SF, Offset: 28, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCW, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Length: 1, Label: "DC Watts", Description: "DC Power"},
-					{Id: DCW_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TmpCab, Offset: 31, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
-					{Id: TmpSnk, Offset: 32, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
-					{Id: TmpTrns, Offset: 33, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Transformer Temperature", Description: "Transformer Temperature"},
-					{Id: TmpOt, Offset: 34, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Other Temperature", Description: "Other Temperature"},
-					{Id: Tmp_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: St, Offset: 36, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
-					{Id: StVnd, Offset: 37, Type: typelabel.Enum16, Length: 1, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
-					{Id: Evt1, Offset: 38, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
-					{Id: Evt2, Offset: 40, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
-					{Id: EvtVnd1, Offset: 42, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
-					{Id: EvtVnd2, Offset: 44, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
-					{Id: EvtVnd3, Offset: 46, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
-					{Id: EvtVnd4, Offset: 48, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
+					{Id: A, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PPVphAB, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: PhVphA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: V_SF, Offset: 11, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: W, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "AC Power"},
+					{Id: W_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Line Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 16, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VA_SF, Offset: 17, Type: typelabel.ScaleFactor},
+					{Id: VAr, Offset: 18, Type: typelabel.Int16, ScaleFactor: "VAr_SF", Units: "var", Label: "VAr", Description: "AC Reactive Power"},
+					{Id: VAr_SF, Offset: 19, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "AC Power Factor"},
+					{Id: PF_SF, Offset: 21, Type: typelabel.ScaleFactor},
+					{Id: WH, Offset: 22, Type: typelabel.Acc32, ScaleFactor: "WH_SF", Units: "Wh", Mandatory: true, Label: "WattHours", Description: "AC Energy"},
+					{Id: WH_SF, Offset: 24, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCA, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Label: "DC Amps", Description: "DC Current"},
+					{Id: DCA_SF, Offset: 26, Type: typelabel.ScaleFactor},
+					{Id: DCV, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "DC Voltage", Description: "DC Voltage"},
+					{Id: DCV_SF, Offset: 28, Type: typelabel.ScaleFactor},
+					{Id: DCW, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Label: "DC Watts", Description: "DC Power"},
+					{Id: DCW_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: TmpCab, Offset: 31, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
+					{Id: TmpSnk, Offset: 32, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
+					{Id: TmpTrns, Offset: 33, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Transformer Temperature", Description: "Transformer Temperature"},
+					{Id: TmpOt, Offset: 34, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Other Temperature", Description: "Other Temperature"},
+					{Id: Tmp_SF, Offset: 35, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: St, Offset: 36, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
+					{Id: StVnd, Offset: 37, Type: typelabel.Enum16, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
+					{Id: Evt1, Offset: 38, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
+					{Id: Evt2, Offset: 40, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
+					{Id: EvtVnd1, Offset: 42, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
+					{Id: EvtVnd2, Offset: 44, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
+					{Id: EvtVnd3, Offset: 46, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
+					{Id: EvtVnd4, Offset: 48, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
 				},
 			},
 		}})

--- a/models/model102/model.go
+++ b/models/model102/model.go
@@ -64,49 +64,49 @@ const (
 )
 
 type Block102 struct {
-	A       uint16              `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA    uint16              `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB    uint16              `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC    uint16              `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF    sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PPVphAB uint16              `sunspec:"offset=5,len=1,sf=V_SF"`
-	PPVphBC uint16              `sunspec:"offset=6,len=1,sf=V_SF"`
-	PPVphCA uint16              `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphA  uint16              `sunspec:"offset=8,len=1,sf=V_SF"`
-	PhVphB  uint16              `sunspec:"offset=9,len=1,sf=V_SF"`
-	PhVphC  uint16              `sunspec:"offset=10,len=1,sf=V_SF"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=11,len=1"`
-	W       int16               `sunspec:"offset=12,len=1,sf=W_SF"`
-	W_SF    sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz      uint16              `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	VA      int16               `sunspec:"offset=16,len=1,sf=VA_SF"`
-	VA_SF   sunspec.ScaleFactor `sunspec:"offset=17,len=1"`
-	VAr     int16               `sunspec:"offset=18,len=1,sf=VAr_SF"`
-	VAr_SF  sunspec.ScaleFactor `sunspec:"offset=19,len=1"`
-	PF      int16               `sunspec:"offset=20,len=1,sf=PF_SF"`
-	PF_SF   sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	WH      sunspec.Acc32       `sunspec:"offset=22,len=2,sf=WH_SF"`
-	WH_SF   sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	DCA     uint16              `sunspec:"offset=25,len=1,sf=DCA_SF"`
-	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=26,len=1"`
-	DCV     uint16              `sunspec:"offset=27,len=1,sf=DCV_SF"`
-	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=28,len=1"`
-	DCW     int16               `sunspec:"offset=29,len=1,sf=DCW_SF"`
-	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	TmpCab  int16               `sunspec:"offset=31,len=1,sf=Tmp_SF"`
-	TmpSnk  int16               `sunspec:"offset=32,len=1,sf=Tmp_SF"`
-	TmpTrns int16               `sunspec:"offset=33,len=1,sf=Tmp_SF"`
-	TmpOt   int16               `sunspec:"offset=34,len=1,sf=Tmp_SF"`
-	Tmp_SF  sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	St      sunspec.Enum16      `sunspec:"offset=36,len=1"`
-	StVnd   sunspec.Enum16      `sunspec:"offset=37,len=1"`
-	Evt1    sunspec.Bitfield32  `sunspec:"offset=38,len=2"`
-	Evt2    sunspec.Bitfield32  `sunspec:"offset=40,len=2"`
-	EvtVnd1 sunspec.Bitfield32  `sunspec:"offset=42,len=2"`
-	EvtVnd2 sunspec.Bitfield32  `sunspec:"offset=44,len=2"`
-	EvtVnd3 sunspec.Bitfield32  `sunspec:"offset=46,len=2"`
-	EvtVnd4 sunspec.Bitfield32  `sunspec:"offset=48,len=2"`
+	A       uint16              `sunspec:"offset=0,sf=A_SF"`
+	AphA    uint16              `sunspec:"offset=1,sf=A_SF"`
+	AphB    uint16              `sunspec:"offset=2,sf=A_SF"`
+	AphC    uint16              `sunspec:"offset=3,sf=A_SF"`
+	A_SF    sunspec.ScaleFactor `sunspec:"offset=4"`
+	PPVphAB uint16              `sunspec:"offset=5,sf=V_SF"`
+	PPVphBC uint16              `sunspec:"offset=6,sf=V_SF"`
+	PPVphCA uint16              `sunspec:"offset=7,sf=V_SF"`
+	PhVphA  uint16              `sunspec:"offset=8,sf=V_SF"`
+	PhVphB  uint16              `sunspec:"offset=9,sf=V_SF"`
+	PhVphC  uint16              `sunspec:"offset=10,sf=V_SF"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=11"`
+	W       int16               `sunspec:"offset=12,sf=W_SF"`
+	W_SF    sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz      uint16              `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=15"`
+	VA      int16               `sunspec:"offset=16,sf=VA_SF"`
+	VA_SF   sunspec.ScaleFactor `sunspec:"offset=17"`
+	VAr     int16               `sunspec:"offset=18,sf=VAr_SF"`
+	VAr_SF  sunspec.ScaleFactor `sunspec:"offset=19"`
+	PF      int16               `sunspec:"offset=20,sf=PF_SF"`
+	PF_SF   sunspec.ScaleFactor `sunspec:"offset=21"`
+	WH      sunspec.Acc32       `sunspec:"offset=22,sf=WH_SF"`
+	WH_SF   sunspec.ScaleFactor `sunspec:"offset=24"`
+	DCA     uint16              `sunspec:"offset=25,sf=DCA_SF"`
+	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=26"`
+	DCV     uint16              `sunspec:"offset=27,sf=DCV_SF"`
+	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=28"`
+	DCW     int16               `sunspec:"offset=29,sf=DCW_SF"`
+	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=30"`
+	TmpCab  int16               `sunspec:"offset=31,sf=Tmp_SF"`
+	TmpSnk  int16               `sunspec:"offset=32,sf=Tmp_SF"`
+	TmpTrns int16               `sunspec:"offset=33,sf=Tmp_SF"`
+	TmpOt   int16               `sunspec:"offset=34,sf=Tmp_SF"`
+	Tmp_SF  sunspec.ScaleFactor `sunspec:"offset=35"`
+	St      sunspec.Enum16      `sunspec:"offset=36"`
+	StVnd   sunspec.Enum16      `sunspec:"offset=37"`
+	Evt1    sunspec.Bitfield32  `sunspec:"offset=38"`
+	Evt2    sunspec.Bitfield32  `sunspec:"offset=40"`
+	EvtVnd1 sunspec.Bitfield32  `sunspec:"offset=42"`
+	EvtVnd2 sunspec.Bitfield32  `sunspec:"offset=44"`
+	EvtVnd3 sunspec.Bitfield32  `sunspec:"offset=46"`
+	EvtVnd4 sunspec.Bitfield32  `sunspec:"offset=48"`
 }
 
 func (block *Block102) GetId() sunspec.ModelId {
@@ -125,49 +125,49 @@ func init() {
 				Length: 50,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PPVphAB, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: PhVphA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: V_SF, Offset: 11, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: W, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "AC Power"},
-					{Id: W_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Line Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 16, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VA_SF, Offset: 17, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAr, Offset: 18, Type: typelabel.Int16, ScaleFactor: "VAr_SF", Units: "var", Length: 1, Label: "VAr", Description: "AC Reactive Power"},
-					{Id: VAr_SF, Offset: 19, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "AC Power Factor"},
-					{Id: PF_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: WH, Offset: 22, Type: typelabel.Acc32, ScaleFactor: "WH_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "WattHours", Description: "AC Energy"},
-					{Id: WH_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCA, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Label: "DC Amps", Description: "DC Current"},
-					{Id: DCA_SF, Offset: 26, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "DC Voltage", Description: "DC Voltage"},
-					{Id: DCV_SF, Offset: 28, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCW, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Length: 1, Label: "DC Watts", Description: "DC Power"},
-					{Id: DCW_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TmpCab, Offset: 31, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
-					{Id: TmpSnk, Offset: 32, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
-					{Id: TmpTrns, Offset: 33, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Transformer Temperature", Description: "Transformer Temperature"},
-					{Id: TmpOt, Offset: 34, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Other Temperature", Description: "Other Temperature"},
-					{Id: Tmp_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: St, Offset: 36, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
-					{Id: StVnd, Offset: 37, Type: typelabel.Enum16, Length: 1, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
-					{Id: Evt1, Offset: 38, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
-					{Id: Evt2, Offset: 40, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
-					{Id: EvtVnd1, Offset: 42, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
-					{Id: EvtVnd2, Offset: 44, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
-					{Id: EvtVnd3, Offset: 46, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
-					{Id: EvtVnd4, Offset: 48, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
+					{Id: A, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PPVphAB, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: PhVphA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: V_SF, Offset: 11, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: W, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "AC Power"},
+					{Id: W_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Line Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 16, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VA_SF, Offset: 17, Type: typelabel.ScaleFactor},
+					{Id: VAr, Offset: 18, Type: typelabel.Int16, ScaleFactor: "VAr_SF", Units: "var", Label: "VAr", Description: "AC Reactive Power"},
+					{Id: VAr_SF, Offset: 19, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "AC Power Factor"},
+					{Id: PF_SF, Offset: 21, Type: typelabel.ScaleFactor},
+					{Id: WH, Offset: 22, Type: typelabel.Acc32, ScaleFactor: "WH_SF", Units: "Wh", Mandatory: true, Label: "WattHours", Description: "AC Energy"},
+					{Id: WH_SF, Offset: 24, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCA, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Label: "DC Amps", Description: "DC Current"},
+					{Id: DCA_SF, Offset: 26, Type: typelabel.ScaleFactor},
+					{Id: DCV, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "DC Voltage", Description: "DC Voltage"},
+					{Id: DCV_SF, Offset: 28, Type: typelabel.ScaleFactor},
+					{Id: DCW, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Label: "DC Watts", Description: "DC Power"},
+					{Id: DCW_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: TmpCab, Offset: 31, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
+					{Id: TmpSnk, Offset: 32, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
+					{Id: TmpTrns, Offset: 33, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Transformer Temperature", Description: "Transformer Temperature"},
+					{Id: TmpOt, Offset: 34, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Other Temperature", Description: "Other Temperature"},
+					{Id: Tmp_SF, Offset: 35, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: St, Offset: 36, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
+					{Id: StVnd, Offset: 37, Type: typelabel.Enum16, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
+					{Id: Evt1, Offset: 38, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
+					{Id: Evt2, Offset: 40, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
+					{Id: EvtVnd1, Offset: 42, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
+					{Id: EvtVnd2, Offset: 44, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
+					{Id: EvtVnd3, Offset: 46, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
+					{Id: EvtVnd4, Offset: 48, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
 				},
 			},
 		}})

--- a/models/model103/model.go
+++ b/models/model103/model.go
@@ -64,49 +64,49 @@ const (
 )
 
 type Block103 struct {
-	A       uint16              `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA    uint16              `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB    uint16              `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC    uint16              `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF    sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PPVphAB uint16              `sunspec:"offset=5,len=1,sf=V_SF"`
-	PPVphBC uint16              `sunspec:"offset=6,len=1,sf=V_SF"`
-	PPVphCA uint16              `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphA  uint16              `sunspec:"offset=8,len=1,sf=V_SF"`
-	PhVphB  uint16              `sunspec:"offset=9,len=1,sf=V_SF"`
-	PhVphC  uint16              `sunspec:"offset=10,len=1,sf=V_SF"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=11,len=1"`
-	W       int16               `sunspec:"offset=12,len=1,sf=W_SF"`
-	W_SF    sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz      uint16              `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	VA      int16               `sunspec:"offset=16,len=1,sf=VA_SF"`
-	VA_SF   sunspec.ScaleFactor `sunspec:"offset=17,len=1"`
-	VAr     int16               `sunspec:"offset=18,len=1,sf=VAr_SF"`
-	VAr_SF  sunspec.ScaleFactor `sunspec:"offset=19,len=1"`
-	PF      int16               `sunspec:"offset=20,len=1,sf=PF_SF"`
-	PF_SF   sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	WH      sunspec.Acc32       `sunspec:"offset=22,len=2,sf=WH_SF"`
-	WH_SF   sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	DCA     uint16              `sunspec:"offset=25,len=1,sf=DCA_SF"`
-	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=26,len=1"`
-	DCV     uint16              `sunspec:"offset=27,len=1,sf=DCV_SF"`
-	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=28,len=1"`
-	DCW     int16               `sunspec:"offset=29,len=1,sf=DCW_SF"`
-	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	TmpCab  int16               `sunspec:"offset=31,len=1,sf=Tmp_SF"`
-	TmpSnk  int16               `sunspec:"offset=32,len=1,sf=Tmp_SF"`
-	TmpTrns int16               `sunspec:"offset=33,len=1,sf=Tmp_SF"`
-	TmpOt   int16               `sunspec:"offset=34,len=1,sf=Tmp_SF"`
-	Tmp_SF  sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	St      sunspec.Enum16      `sunspec:"offset=36,len=1"`
-	StVnd   sunspec.Enum16      `sunspec:"offset=37,len=1"`
-	Evt1    sunspec.Bitfield32  `sunspec:"offset=38,len=2"`
-	Evt2    sunspec.Bitfield32  `sunspec:"offset=40,len=2"`
-	EvtVnd1 sunspec.Bitfield32  `sunspec:"offset=42,len=2"`
-	EvtVnd2 sunspec.Bitfield32  `sunspec:"offset=44,len=2"`
-	EvtVnd3 sunspec.Bitfield32  `sunspec:"offset=46,len=2"`
-	EvtVnd4 sunspec.Bitfield32  `sunspec:"offset=48,len=2"`
+	A       uint16              `sunspec:"offset=0,sf=A_SF"`
+	AphA    uint16              `sunspec:"offset=1,sf=A_SF"`
+	AphB    uint16              `sunspec:"offset=2,sf=A_SF"`
+	AphC    uint16              `sunspec:"offset=3,sf=A_SF"`
+	A_SF    sunspec.ScaleFactor `sunspec:"offset=4"`
+	PPVphAB uint16              `sunspec:"offset=5,sf=V_SF"`
+	PPVphBC uint16              `sunspec:"offset=6,sf=V_SF"`
+	PPVphCA uint16              `sunspec:"offset=7,sf=V_SF"`
+	PhVphA  uint16              `sunspec:"offset=8,sf=V_SF"`
+	PhVphB  uint16              `sunspec:"offset=9,sf=V_SF"`
+	PhVphC  uint16              `sunspec:"offset=10,sf=V_SF"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=11"`
+	W       int16               `sunspec:"offset=12,sf=W_SF"`
+	W_SF    sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz      uint16              `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=15"`
+	VA      int16               `sunspec:"offset=16,sf=VA_SF"`
+	VA_SF   sunspec.ScaleFactor `sunspec:"offset=17"`
+	VAr     int16               `sunspec:"offset=18,sf=VAr_SF"`
+	VAr_SF  sunspec.ScaleFactor `sunspec:"offset=19"`
+	PF      int16               `sunspec:"offset=20,sf=PF_SF"`
+	PF_SF   sunspec.ScaleFactor `sunspec:"offset=21"`
+	WH      sunspec.Acc32       `sunspec:"offset=22,sf=WH_SF"`
+	WH_SF   sunspec.ScaleFactor `sunspec:"offset=24"`
+	DCA     uint16              `sunspec:"offset=25,sf=DCA_SF"`
+	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=26"`
+	DCV     uint16              `sunspec:"offset=27,sf=DCV_SF"`
+	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=28"`
+	DCW     int16               `sunspec:"offset=29,sf=DCW_SF"`
+	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=30"`
+	TmpCab  int16               `sunspec:"offset=31,sf=Tmp_SF"`
+	TmpSnk  int16               `sunspec:"offset=32,sf=Tmp_SF"`
+	TmpTrns int16               `sunspec:"offset=33,sf=Tmp_SF"`
+	TmpOt   int16               `sunspec:"offset=34,sf=Tmp_SF"`
+	Tmp_SF  sunspec.ScaleFactor `sunspec:"offset=35"`
+	St      sunspec.Enum16      `sunspec:"offset=36"`
+	StVnd   sunspec.Enum16      `sunspec:"offset=37"`
+	Evt1    sunspec.Bitfield32  `sunspec:"offset=38"`
+	Evt2    sunspec.Bitfield32  `sunspec:"offset=40"`
+	EvtVnd1 sunspec.Bitfield32  `sunspec:"offset=42"`
+	EvtVnd2 sunspec.Bitfield32  `sunspec:"offset=44"`
+	EvtVnd3 sunspec.Bitfield32  `sunspec:"offset=46"`
+	EvtVnd4 sunspec.Bitfield32  `sunspec:"offset=48"`
 }
 
 func (block *Block103) GetId() sunspec.ModelId {
@@ -125,49 +125,49 @@ func init() {
 				Length: 50,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PPVphAB, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: PhVphA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: V_SF, Offset: 11, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: W, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "AC Power"},
-					{Id: W_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Line Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 16, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VA_SF, Offset: 17, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAr, Offset: 18, Type: typelabel.Int16, ScaleFactor: "VAr_SF", Units: "var", Length: 1, Label: "VAr", Description: "AC Reactive Power"},
-					{Id: VAr_SF, Offset: 19, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "AC Power Factor"},
-					{Id: PF_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: WH, Offset: 22, Type: typelabel.Acc32, ScaleFactor: "WH_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "WattHours", Description: "AC Energy"},
-					{Id: WH_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCA, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Label: "DC Amps", Description: "DC Current"},
-					{Id: DCA_SF, Offset: 26, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "DC Voltage", Description: "DC Voltage"},
-					{Id: DCV_SF, Offset: 28, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCW, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Length: 1, Label: "DC Watts", Description: "DC Power"},
-					{Id: DCW_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TmpCab, Offset: 31, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
-					{Id: TmpSnk, Offset: 32, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
-					{Id: TmpTrns, Offset: 33, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Transformer Temperature", Description: "Transformer Temperature"},
-					{Id: TmpOt, Offset: 34, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Other Temperature", Description: "Other Temperature"},
-					{Id: Tmp_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: St, Offset: 36, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
-					{Id: StVnd, Offset: 37, Type: typelabel.Enum16, Length: 1, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
-					{Id: Evt1, Offset: 38, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
-					{Id: Evt2, Offset: 40, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
-					{Id: EvtVnd1, Offset: 42, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
-					{Id: EvtVnd2, Offset: 44, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
-					{Id: EvtVnd3, Offset: 46, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
-					{Id: EvtVnd4, Offset: 48, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
+					{Id: A, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PPVphAB, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: PhVphA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: V_SF, Offset: 11, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: W, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "AC Power"},
+					{Id: W_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Line Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 16, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VA_SF, Offset: 17, Type: typelabel.ScaleFactor},
+					{Id: VAr, Offset: 18, Type: typelabel.Int16, ScaleFactor: "VAr_SF", Units: "var", Label: "VAr", Description: "AC Reactive Power"},
+					{Id: VAr_SF, Offset: 19, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "AC Power Factor"},
+					{Id: PF_SF, Offset: 21, Type: typelabel.ScaleFactor},
+					{Id: WH, Offset: 22, Type: typelabel.Acc32, ScaleFactor: "WH_SF", Units: "Wh", Mandatory: true, Label: "WattHours", Description: "AC Energy"},
+					{Id: WH_SF, Offset: 24, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCA, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Label: "DC Amps", Description: "DC Current"},
+					{Id: DCA_SF, Offset: 26, Type: typelabel.ScaleFactor},
+					{Id: DCV, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "DC Voltage", Description: "DC Voltage"},
+					{Id: DCV_SF, Offset: 28, Type: typelabel.ScaleFactor},
+					{Id: DCW, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Label: "DC Watts", Description: "DC Power"},
+					{Id: DCW_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: TmpCab, Offset: 31, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
+					{Id: TmpSnk, Offset: 32, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
+					{Id: TmpTrns, Offset: 33, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Transformer Temperature", Description: "Transformer Temperature"},
+					{Id: TmpOt, Offset: 34, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Other Temperature", Description: "Other Temperature"},
+					{Id: Tmp_SF, Offset: 35, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: St, Offset: 36, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
+					{Id: StVnd, Offset: 37, Type: typelabel.Enum16, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
+					{Id: Evt1, Offset: 38, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
+					{Id: Evt2, Offset: 40, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
+					{Id: EvtVnd1, Offset: 42, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
+					{Id: EvtVnd2, Offset: 44, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
+					{Id: EvtVnd3, Offset: 46, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
+					{Id: EvtVnd4, Offset: 48, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
 				},
 			},
 		}})

--- a/models/model11/model.go
+++ b/models/model11/model.go
@@ -28,13 +28,13 @@ const (
 )
 
 type Block11 struct {
-	Spd    uint16             `sunspec:"offset=0,len=1"`
-	CfgSt  sunspec.Bitfield16 `sunspec:"offset=1,len=1"`
-	St     sunspec.Enum16     `sunspec:"offset=2,len=1"`
-	MAC    sunspec.Eui48      `sunspec:"offset=3,len=4"`
+	Spd    uint16             `sunspec:"offset=0"`
+	CfgSt  sunspec.Bitfield16 `sunspec:"offset=1"`
+	St     sunspec.Enum16     `sunspec:"offset=2"`
+	MAC    sunspec.Eui48      `sunspec:"offset=3"`
 	Nam    string             `sunspec:"offset=7,len=4,access=rw"`
-	Ctl    sunspec.Bitfield16 `sunspec:"offset=11,len=1,access=rw"`
-	FrcSpd uint16             `sunspec:"offset=12,len=1,access=rw"`
+	Ctl    sunspec.Bitfield16 `sunspec:"offset=11,access=rw"`
+	FrcSpd uint16             `sunspec:"offset=12,access=rw"`
 }
 
 func (block *Block11) GetId() sunspec.ModelId {
@@ -53,13 +53,13 @@ func init() {
 				Length: 13,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Spd, Offset: 0, Type: typelabel.Uint16, Units: "Mbps", Length: 1, Mandatory: true, Label: "Ethernet Link Speed", Description: "Interface speed in Mb/s"},
-					{Id: CfgSt, Offset: 1, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "Interface Status Flags", Description: "Bitmask values Interface flags."},
-					{Id: St, Offset: 2, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Link State", Description: "Enumerated value. State information for this interface"},
-					{Id: MAC, Offset: 3, Type: typelabel.Eui48, Length: 4, Label: "MAC", Description: "IEEE MAC address of this interface"},
+					{Id: Spd, Offset: 0, Type: typelabel.Uint16, Units: "Mbps", Mandatory: true, Label: "Ethernet Link Speed", Description: "Interface speed in Mb/s"},
+					{Id: CfgSt, Offset: 1, Type: typelabel.Bitfield16, Mandatory: true, Label: "Interface Status Flags", Description: "Bitmask values Interface flags."},
+					{Id: St, Offset: 2, Type: typelabel.Enum16, Mandatory: true, Label: "Link State", Description: "Enumerated value. State information for this interface"},
+					{Id: MAC, Offset: 3, Type: typelabel.Eui48, Label: "MAC", Description: "IEEE MAC address of this interface"},
 					{Id: Nam, Offset: 7, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name (8 chars)"},
-					{Id: Ctl, Offset: 11, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Label: "Control", Description: "Control flags"},
-					{Id: FrcSpd, Offset: 12, Type: typelabel.Uint16, Units: "Mbps", Access: "rw", Length: 1, Label: "Forced Speed", Description: "Forced interface speed in Mb/s when AUTO is disabled"},
+					{Id: Ctl, Offset: 11, Type: typelabel.Bitfield16, Access: "rw", Label: "Control", Description: "Control flags"},
+					{Id: FrcSpd, Offset: 12, Type: typelabel.Uint16, Units: "Mbps", Access: "rw", Label: "Forced Speed", Description: "Forced interface speed in Mb/s when AUTO is disabled"},
 				},
 			},
 		}})

--- a/models/model111/model.go
+++ b/models/model111/model.go
@@ -52,37 +52,37 @@ const (
 )
 
 type Block111 struct {
-	A       float32            `sunspec:"offset=0,len=2"`
-	AphA    float32            `sunspec:"offset=2,len=2"`
-	AphB    float32            `sunspec:"offset=4,len=2"`
-	AphC    float32            `sunspec:"offset=6,len=2"`
-	PPVphAB float32            `sunspec:"offset=8,len=2"`
-	PPVphBC float32            `sunspec:"offset=10,len=2"`
-	PPVphCA float32            `sunspec:"offset=12,len=2"`
-	PhVphA  float32            `sunspec:"offset=14,len=2"`
-	PhVphB  float32            `sunspec:"offset=16,len=2"`
-	PhVphC  float32            `sunspec:"offset=18,len=2"`
-	W       float32            `sunspec:"offset=20,len=2"`
-	Hz      float32            `sunspec:"offset=22,len=2"`
-	VA      float32            `sunspec:"offset=24,len=2"`
-	VAr     float32            `sunspec:"offset=26,len=2"`
-	PF      float32            `sunspec:"offset=28,len=2"`
-	WH      float32            `sunspec:"offset=30,len=2"`
-	DCA     float32            `sunspec:"offset=32,len=2"`
-	DCV     float32            `sunspec:"offset=34,len=2"`
-	DCW     float32            `sunspec:"offset=36,len=2"`
-	TmpCab  float32            `sunspec:"offset=38,len=2"`
-	TmpSnk  float32            `sunspec:"offset=40,len=2"`
-	TmpTrns float32            `sunspec:"offset=42,len=2"`
-	TmpOt   float32            `sunspec:"offset=44,len=2"`
-	St      sunspec.Enum16     `sunspec:"offset=46,len=1"`
-	StVnd   sunspec.Enum16     `sunspec:"offset=47,len=1"`
-	Evt1    sunspec.Bitfield32 `sunspec:"offset=48,len=2"`
-	Evt2    sunspec.Bitfield32 `sunspec:"offset=50,len=2"`
-	EvtVnd1 sunspec.Bitfield32 `sunspec:"offset=52,len=2"`
-	EvtVnd2 sunspec.Bitfield32 `sunspec:"offset=54,len=2"`
-	EvtVnd3 sunspec.Bitfield32 `sunspec:"offset=56,len=2"`
-	EvtVnd4 sunspec.Bitfield32 `sunspec:"offset=58,len=2"`
+	A       float32            `sunspec:"offset=0"`
+	AphA    float32            `sunspec:"offset=2"`
+	AphB    float32            `sunspec:"offset=4"`
+	AphC    float32            `sunspec:"offset=6"`
+	PPVphAB float32            `sunspec:"offset=8"`
+	PPVphBC float32            `sunspec:"offset=10"`
+	PPVphCA float32            `sunspec:"offset=12"`
+	PhVphA  float32            `sunspec:"offset=14"`
+	PhVphB  float32            `sunspec:"offset=16"`
+	PhVphC  float32            `sunspec:"offset=18"`
+	W       float32            `sunspec:"offset=20"`
+	Hz      float32            `sunspec:"offset=22"`
+	VA      float32            `sunspec:"offset=24"`
+	VAr     float32            `sunspec:"offset=26"`
+	PF      float32            `sunspec:"offset=28"`
+	WH      float32            `sunspec:"offset=30"`
+	DCA     float32            `sunspec:"offset=32"`
+	DCV     float32            `sunspec:"offset=34"`
+	DCW     float32            `sunspec:"offset=36"`
+	TmpCab  float32            `sunspec:"offset=38"`
+	TmpSnk  float32            `sunspec:"offset=40"`
+	TmpTrns float32            `sunspec:"offset=42"`
+	TmpOt   float32            `sunspec:"offset=44"`
+	St      sunspec.Enum16     `sunspec:"offset=46"`
+	StVnd   sunspec.Enum16     `sunspec:"offset=47"`
+	Evt1    sunspec.Bitfield32 `sunspec:"offset=48"`
+	Evt2    sunspec.Bitfield32 `sunspec:"offset=50"`
+	EvtVnd1 sunspec.Bitfield32 `sunspec:"offset=52"`
+	EvtVnd2 sunspec.Bitfield32 `sunspec:"offset=54"`
+	EvtVnd3 sunspec.Bitfield32 `sunspec:"offset=56"`
+	EvtVnd4 sunspec.Bitfield32 `sunspec:"offset=58"`
 }
 
 func (block *Block111) GetId() sunspec.ModelId {
@@ -101,37 +101,37 @@ func init() {
 				Length: 60,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PPVphAB, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: PhVphA, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: W, Offset: 20, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "AC Power"},
-					{Id: Hz, Offset: 22, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Line Frequency"},
-					{Id: VA, Offset: 24, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAr, Offset: 26, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAr", Description: "AC Reactive Power"},
-					{Id: PF, Offset: 28, Type: typelabel.Float32, Units: "Pct", Length: 2, Label: "PF", Description: "AC Power Factor"},
-					{Id: WH, Offset: 30, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "WattHours", Description: "AC Energy"},
-					{Id: DCA, Offset: 32, Type: typelabel.Float32, Units: "A", Length: 2, Label: "DC Amps", Description: "DC Current"},
-					{Id: DCV, Offset: 34, Type: typelabel.Float32, Units: "V", Length: 2, Label: "DC Voltage", Description: "DC Voltage"},
-					{Id: DCW, Offset: 36, Type: typelabel.Float32, Units: "W", Length: 2, Label: "DC Watts", Description: "DC Power"},
-					{Id: TmpCab, Offset: 38, Type: typelabel.Float32, Units: "C", Length: 2, Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
-					{Id: TmpSnk, Offset: 40, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
-					{Id: TmpTrns, Offset: 42, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Transformer Temperature", Description: "Transformer Temperature"},
-					{Id: TmpOt, Offset: 44, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Other Temperature", Description: "Other Temperature"},
-					{Id: St, Offset: 46, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
-					{Id: StVnd, Offset: 47, Type: typelabel.Enum16, Length: 1, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
-					{Id: Evt1, Offset: 48, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
-					{Id: Evt2, Offset: 50, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
-					{Id: EvtVnd1, Offset: 52, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
-					{Id: EvtVnd2, Offset: 54, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
-					{Id: EvtVnd3, Offset: 56, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
-					{Id: EvtVnd4, Offset: 58, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PPVphAB, Offset: 8, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 10, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 12, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: PhVphA, Offset: 14, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 16, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 18, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: W, Offset: 20, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "AC Power"},
+					{Id: Hz, Offset: 22, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Line Frequency"},
+					{Id: VA, Offset: 24, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAr, Offset: 26, Type: typelabel.Float32, Units: "var", Label: "VAr", Description: "AC Reactive Power"},
+					{Id: PF, Offset: 28, Type: typelabel.Float32, Units: "Pct", Label: "PF", Description: "AC Power Factor"},
+					{Id: WH, Offset: 30, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "WattHours", Description: "AC Energy"},
+					{Id: DCA, Offset: 32, Type: typelabel.Float32, Units: "A", Label: "DC Amps", Description: "DC Current"},
+					{Id: DCV, Offset: 34, Type: typelabel.Float32, Units: "V", Label: "DC Voltage", Description: "DC Voltage"},
+					{Id: DCW, Offset: 36, Type: typelabel.Float32, Units: "W", Label: "DC Watts", Description: "DC Power"},
+					{Id: TmpCab, Offset: 38, Type: typelabel.Float32, Units: "C", Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
+					{Id: TmpSnk, Offset: 40, Type: typelabel.Float32, Units: "C", Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
+					{Id: TmpTrns, Offset: 42, Type: typelabel.Float32, Units: "C", Label: "Transformer Temperature", Description: "Transformer Temperature"},
+					{Id: TmpOt, Offset: 44, Type: typelabel.Float32, Units: "C", Label: "Other Temperature", Description: "Other Temperature"},
+					{Id: St, Offset: 46, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
+					{Id: StVnd, Offset: 47, Type: typelabel.Enum16, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
+					{Id: Evt1, Offset: 48, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
+					{Id: Evt2, Offset: 50, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
+					{Id: EvtVnd1, Offset: 52, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
+					{Id: EvtVnd2, Offset: 54, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
+					{Id: EvtVnd3, Offset: 56, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
+					{Id: EvtVnd4, Offset: 58, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
 				},
 			},
 		}})

--- a/models/model112/model.go
+++ b/models/model112/model.go
@@ -52,37 +52,37 @@ const (
 )
 
 type Block112 struct {
-	A       float32            `sunspec:"offset=0,len=2"`
-	AphA    float32            `sunspec:"offset=2,len=2"`
-	AphB    float32            `sunspec:"offset=4,len=2"`
-	AphC    float32            `sunspec:"offset=6,len=2"`
-	PPVphAB float32            `sunspec:"offset=8,len=2"`
-	PPVphBC float32            `sunspec:"offset=10,len=2"`
-	PPVphCA float32            `sunspec:"offset=12,len=2"`
-	PhVphA  float32            `sunspec:"offset=14,len=2"`
-	PhVphB  float32            `sunspec:"offset=16,len=2"`
-	PhVphC  float32            `sunspec:"offset=18,len=2"`
-	W       float32            `sunspec:"offset=20,len=2"`
-	Hz      float32            `sunspec:"offset=22,len=2"`
-	VA      float32            `sunspec:"offset=24,len=2"`
-	VAr     float32            `sunspec:"offset=26,len=2"`
-	PF      float32            `sunspec:"offset=28,len=2"`
-	WH      float32            `sunspec:"offset=30,len=2"`
-	DCA     float32            `sunspec:"offset=32,len=2"`
-	DCV     float32            `sunspec:"offset=34,len=2"`
-	DCW     float32            `sunspec:"offset=36,len=2"`
-	TmpCab  float32            `sunspec:"offset=38,len=2"`
-	TmpSnk  float32            `sunspec:"offset=40,len=2"`
-	TmpTrns float32            `sunspec:"offset=42,len=2"`
-	TmpOt   float32            `sunspec:"offset=44,len=2"`
-	St      sunspec.Enum16     `sunspec:"offset=46,len=1"`
-	StVnd   sunspec.Enum16     `sunspec:"offset=47,len=1"`
-	Evt1    sunspec.Bitfield32 `sunspec:"offset=48,len=2"`
-	Evt2    sunspec.Bitfield32 `sunspec:"offset=50,len=2"`
-	EvtVnd1 sunspec.Bitfield32 `sunspec:"offset=52,len=2"`
-	EvtVnd2 sunspec.Bitfield32 `sunspec:"offset=54,len=2"`
-	EvtVnd3 sunspec.Bitfield32 `sunspec:"offset=56,len=2"`
-	EvtVnd4 sunspec.Bitfield32 `sunspec:"offset=58,len=2"`
+	A       float32            `sunspec:"offset=0"`
+	AphA    float32            `sunspec:"offset=2"`
+	AphB    float32            `sunspec:"offset=4"`
+	AphC    float32            `sunspec:"offset=6"`
+	PPVphAB float32            `sunspec:"offset=8"`
+	PPVphBC float32            `sunspec:"offset=10"`
+	PPVphCA float32            `sunspec:"offset=12"`
+	PhVphA  float32            `sunspec:"offset=14"`
+	PhVphB  float32            `sunspec:"offset=16"`
+	PhVphC  float32            `sunspec:"offset=18"`
+	W       float32            `sunspec:"offset=20"`
+	Hz      float32            `sunspec:"offset=22"`
+	VA      float32            `sunspec:"offset=24"`
+	VAr     float32            `sunspec:"offset=26"`
+	PF      float32            `sunspec:"offset=28"`
+	WH      float32            `sunspec:"offset=30"`
+	DCA     float32            `sunspec:"offset=32"`
+	DCV     float32            `sunspec:"offset=34"`
+	DCW     float32            `sunspec:"offset=36"`
+	TmpCab  float32            `sunspec:"offset=38"`
+	TmpSnk  float32            `sunspec:"offset=40"`
+	TmpTrns float32            `sunspec:"offset=42"`
+	TmpOt   float32            `sunspec:"offset=44"`
+	St      sunspec.Enum16     `sunspec:"offset=46"`
+	StVnd   sunspec.Enum16     `sunspec:"offset=47"`
+	Evt1    sunspec.Bitfield32 `sunspec:"offset=48"`
+	Evt2    sunspec.Bitfield32 `sunspec:"offset=50"`
+	EvtVnd1 sunspec.Bitfield32 `sunspec:"offset=52"`
+	EvtVnd2 sunspec.Bitfield32 `sunspec:"offset=54"`
+	EvtVnd3 sunspec.Bitfield32 `sunspec:"offset=56"`
+	EvtVnd4 sunspec.Bitfield32 `sunspec:"offset=58"`
 }
 
 func (block *Block112) GetId() sunspec.ModelId {
@@ -101,37 +101,37 @@ func init() {
 				Length: 60,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PPVphAB, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: PhVphA, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: W, Offset: 20, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "AC Power"},
-					{Id: Hz, Offset: 22, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Line Frequency"},
-					{Id: VA, Offset: 24, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAr, Offset: 26, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAr", Description: "AC Reactive Power"},
-					{Id: PF, Offset: 28, Type: typelabel.Float32, Units: "Pct", Length: 2, Label: "PF", Description: "AC Power Factor"},
-					{Id: WH, Offset: 30, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "WattHours", Description: "AC Energy"},
-					{Id: DCA, Offset: 32, Type: typelabel.Float32, Units: "A", Length: 2, Label: "DC Amps", Description: "DC Current"},
-					{Id: DCV, Offset: 34, Type: typelabel.Float32, Units: "V", Length: 2, Label: "DC Voltage", Description: "DC Voltage"},
-					{Id: DCW, Offset: 36, Type: typelabel.Float32, Units: "W", Length: 2, Label: "DC Watts", Description: "DC Power"},
-					{Id: TmpCab, Offset: 38, Type: typelabel.Float32, Units: "C", Length: 2, Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
-					{Id: TmpSnk, Offset: 40, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
-					{Id: TmpTrns, Offset: 42, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Transformer Temperature", Description: "Transformer Temperature"},
-					{Id: TmpOt, Offset: 44, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Other Temperature", Description: "Other Temperature"},
-					{Id: St, Offset: 46, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
-					{Id: StVnd, Offset: 47, Type: typelabel.Enum16, Length: 1, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
-					{Id: Evt1, Offset: 48, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
-					{Id: Evt2, Offset: 50, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
-					{Id: EvtVnd1, Offset: 52, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
-					{Id: EvtVnd2, Offset: 54, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
-					{Id: EvtVnd3, Offset: 56, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
-					{Id: EvtVnd4, Offset: 58, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PPVphAB, Offset: 8, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 10, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 12, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: PhVphA, Offset: 14, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 16, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 18, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: W, Offset: 20, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "AC Power"},
+					{Id: Hz, Offset: 22, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Line Frequency"},
+					{Id: VA, Offset: 24, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAr, Offset: 26, Type: typelabel.Float32, Units: "var", Label: "VAr", Description: "AC Reactive Power"},
+					{Id: PF, Offset: 28, Type: typelabel.Float32, Units: "Pct", Label: "PF", Description: "AC Power Factor"},
+					{Id: WH, Offset: 30, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "WattHours", Description: "AC Energy"},
+					{Id: DCA, Offset: 32, Type: typelabel.Float32, Units: "A", Label: "DC Amps", Description: "DC Current"},
+					{Id: DCV, Offset: 34, Type: typelabel.Float32, Units: "V", Label: "DC Voltage", Description: "DC Voltage"},
+					{Id: DCW, Offset: 36, Type: typelabel.Float32, Units: "W", Label: "DC Watts", Description: "DC Power"},
+					{Id: TmpCab, Offset: 38, Type: typelabel.Float32, Units: "C", Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
+					{Id: TmpSnk, Offset: 40, Type: typelabel.Float32, Units: "C", Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
+					{Id: TmpTrns, Offset: 42, Type: typelabel.Float32, Units: "C", Label: "Transformer Temperature", Description: "Transformer Temperature"},
+					{Id: TmpOt, Offset: 44, Type: typelabel.Float32, Units: "C", Label: "Other Temperature", Description: "Other Temperature"},
+					{Id: St, Offset: 46, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
+					{Id: StVnd, Offset: 47, Type: typelabel.Enum16, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
+					{Id: Evt1, Offset: 48, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
+					{Id: Evt2, Offset: 50, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
+					{Id: EvtVnd1, Offset: 52, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
+					{Id: EvtVnd2, Offset: 54, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
+					{Id: EvtVnd3, Offset: 56, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
+					{Id: EvtVnd4, Offset: 58, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
 				},
 			},
 		}})

--- a/models/model113/model.go
+++ b/models/model113/model.go
@@ -52,37 +52,37 @@ const (
 )
 
 type Block113 struct {
-	A       float32            `sunspec:"offset=0,len=2"`
-	AphA    float32            `sunspec:"offset=2,len=2"`
-	AphB    float32            `sunspec:"offset=4,len=2"`
-	AphC    float32            `sunspec:"offset=6,len=2"`
-	PPVphAB float32            `sunspec:"offset=8,len=2"`
-	PPVphBC float32            `sunspec:"offset=10,len=2"`
-	PPVphCA float32            `sunspec:"offset=12,len=2"`
-	PhVphA  float32            `sunspec:"offset=14,len=2"`
-	PhVphB  float32            `sunspec:"offset=16,len=2"`
-	PhVphC  float32            `sunspec:"offset=18,len=2"`
-	W       float32            `sunspec:"offset=20,len=2"`
-	Hz      float32            `sunspec:"offset=22,len=2"`
-	VA      float32            `sunspec:"offset=24,len=2"`
-	VAr     float32            `sunspec:"offset=26,len=2"`
-	PF      float32            `sunspec:"offset=28,len=2"`
-	WH      float32            `sunspec:"offset=30,len=2"`
-	DCA     float32            `sunspec:"offset=32,len=2"`
-	DCV     float32            `sunspec:"offset=34,len=2"`
-	DCW     float32            `sunspec:"offset=36,len=2"`
-	TmpCab  float32            `sunspec:"offset=38,len=2"`
-	TmpSnk  float32            `sunspec:"offset=40,len=2"`
-	TmpTrns float32            `sunspec:"offset=42,len=2"`
-	TmpOt   float32            `sunspec:"offset=44,len=2"`
-	St      sunspec.Enum16     `sunspec:"offset=46,len=1"`
-	StVnd   sunspec.Enum16     `sunspec:"offset=47,len=1"`
-	Evt1    sunspec.Bitfield32 `sunspec:"offset=48,len=2"`
-	Evt2    sunspec.Bitfield32 `sunspec:"offset=50,len=2"`
-	EvtVnd1 sunspec.Bitfield32 `sunspec:"offset=52,len=2"`
-	EvtVnd2 sunspec.Bitfield32 `sunspec:"offset=54,len=2"`
-	EvtVnd3 sunspec.Bitfield32 `sunspec:"offset=56,len=2"`
-	EvtVnd4 sunspec.Bitfield32 `sunspec:"offset=58,len=2"`
+	A       float32            `sunspec:"offset=0"`
+	AphA    float32            `sunspec:"offset=2"`
+	AphB    float32            `sunspec:"offset=4"`
+	AphC    float32            `sunspec:"offset=6"`
+	PPVphAB float32            `sunspec:"offset=8"`
+	PPVphBC float32            `sunspec:"offset=10"`
+	PPVphCA float32            `sunspec:"offset=12"`
+	PhVphA  float32            `sunspec:"offset=14"`
+	PhVphB  float32            `sunspec:"offset=16"`
+	PhVphC  float32            `sunspec:"offset=18"`
+	W       float32            `sunspec:"offset=20"`
+	Hz      float32            `sunspec:"offset=22"`
+	VA      float32            `sunspec:"offset=24"`
+	VAr     float32            `sunspec:"offset=26"`
+	PF      float32            `sunspec:"offset=28"`
+	WH      float32            `sunspec:"offset=30"`
+	DCA     float32            `sunspec:"offset=32"`
+	DCV     float32            `sunspec:"offset=34"`
+	DCW     float32            `sunspec:"offset=36"`
+	TmpCab  float32            `sunspec:"offset=38"`
+	TmpSnk  float32            `sunspec:"offset=40"`
+	TmpTrns float32            `sunspec:"offset=42"`
+	TmpOt   float32            `sunspec:"offset=44"`
+	St      sunspec.Enum16     `sunspec:"offset=46"`
+	StVnd   sunspec.Enum16     `sunspec:"offset=47"`
+	Evt1    sunspec.Bitfield32 `sunspec:"offset=48"`
+	Evt2    sunspec.Bitfield32 `sunspec:"offset=50"`
+	EvtVnd1 sunspec.Bitfield32 `sunspec:"offset=52"`
+	EvtVnd2 sunspec.Bitfield32 `sunspec:"offset=54"`
+	EvtVnd3 sunspec.Bitfield32 `sunspec:"offset=56"`
+	EvtVnd4 sunspec.Bitfield32 `sunspec:"offset=58"`
 }
 
 func (block *Block113) GetId() sunspec.ModelId {
@@ -101,37 +101,37 @@ func init() {
 				Length: 60,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PPVphAB, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: PhVphA, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: W, Offset: 20, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "AC Power"},
-					{Id: Hz, Offset: 22, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Line Frequency"},
-					{Id: VA, Offset: 24, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAr, Offset: 26, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAr", Description: "AC Reactive Power"},
-					{Id: PF, Offset: 28, Type: typelabel.Float32, Units: "Pct", Length: 2, Label: "PF", Description: "AC Power Factor"},
-					{Id: WH, Offset: 30, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "WattHours", Description: "AC Energy"},
-					{Id: DCA, Offset: 32, Type: typelabel.Float32, Units: "A", Length: 2, Label: "DC Amps", Description: "DC Current"},
-					{Id: DCV, Offset: 34, Type: typelabel.Float32, Units: "V", Length: 2, Label: "DC Voltage", Description: "DC Voltage"},
-					{Id: DCW, Offset: 36, Type: typelabel.Float32, Units: "W", Length: 2, Label: "DC Watts", Description: "DC Power"},
-					{Id: TmpCab, Offset: 38, Type: typelabel.Float32, Units: "C", Length: 2, Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
-					{Id: TmpSnk, Offset: 40, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
-					{Id: TmpTrns, Offset: 42, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Transformer Temperature", Description: "Transformer Temperature"},
-					{Id: TmpOt, Offset: 44, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Other Temperature", Description: "Other Temperature"},
-					{Id: St, Offset: 46, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
-					{Id: StVnd, Offset: 47, Type: typelabel.Enum16, Length: 1, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
-					{Id: Evt1, Offset: 48, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
-					{Id: Evt2, Offset: 50, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
-					{Id: EvtVnd1, Offset: 52, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
-					{Id: EvtVnd2, Offset: 54, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
-					{Id: EvtVnd3, Offset: 56, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
-					{Id: EvtVnd4, Offset: 58, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PPVphAB, Offset: 8, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 10, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 12, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: PhVphA, Offset: 14, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 16, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 18, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: W, Offset: 20, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "AC Power"},
+					{Id: Hz, Offset: 22, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Line Frequency"},
+					{Id: VA, Offset: 24, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAr, Offset: 26, Type: typelabel.Float32, Units: "var", Label: "VAr", Description: "AC Reactive Power"},
+					{Id: PF, Offset: 28, Type: typelabel.Float32, Units: "Pct", Label: "PF", Description: "AC Power Factor"},
+					{Id: WH, Offset: 30, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "WattHours", Description: "AC Energy"},
+					{Id: DCA, Offset: 32, Type: typelabel.Float32, Units: "A", Label: "DC Amps", Description: "DC Current"},
+					{Id: DCV, Offset: 34, Type: typelabel.Float32, Units: "V", Label: "DC Voltage", Description: "DC Voltage"},
+					{Id: DCW, Offset: 36, Type: typelabel.Float32, Units: "W", Label: "DC Watts", Description: "DC Power"},
+					{Id: TmpCab, Offset: 38, Type: typelabel.Float32, Units: "C", Mandatory: true, Label: "Cabinet Temperature", Description: "Cabinet Temperature"},
+					{Id: TmpSnk, Offset: 40, Type: typelabel.Float32, Units: "C", Label: "Heat Sink Temperature", Description: "Heat Sink Temperature"},
+					{Id: TmpTrns, Offset: 42, Type: typelabel.Float32, Units: "C", Label: "Transformer Temperature", Description: "Transformer Temperature"},
+					{Id: TmpOt, Offset: 44, Type: typelabel.Float32, Units: "C", Label: "Other Temperature", Description: "Other Temperature"},
+					{Id: St, Offset: 46, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: "Enumerated value.  Operating state"},
+					{Id: StVnd, Offset: 47, Type: typelabel.Enum16, Label: "Vendor Operating State", Description: "Vendor specific operating state code"},
+					{Id: Evt1, Offset: 48, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event1", Description: "Bitmask value. Event fields"},
+					{Id: Evt2, Offset: 50, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Bitfield 2", Description: "Reserved for future use"},
+					{Id: EvtVnd1, Offset: 52, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events"},
+					{Id: EvtVnd2, Offset: 54, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events"},
+					{Id: EvtVnd3, Offset: 56, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 3", Description: "Vendor defined events"},
+					{Id: EvtVnd4, Offset: 58, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 4", Description: "Vendor defined events"},
 				},
 			},
 		}})

--- a/models/model12/model.go
+++ b/models/model12/model.go
@@ -38,11 +38,11 @@ const (
 
 type Block12 struct {
 	Nam     string             `sunspec:"offset=0,len=4,access=rw"`
-	CfgSt   sunspec.Enum16     `sunspec:"offset=4,len=1"`
-	ChgSt   sunspec.Bitfield16 `sunspec:"offset=5,len=1"`
-	Cap     sunspec.Bitfield16 `sunspec:"offset=6,len=1"`
-	Cfg     sunspec.Enum16     `sunspec:"offset=7,len=1,access=rw"`
-	Ctl     sunspec.Enum16     `sunspec:"offset=8,len=1,access=rw"`
+	CfgSt   sunspec.Enum16     `sunspec:"offset=4"`
+	ChgSt   sunspec.Bitfield16 `sunspec:"offset=5"`
+	Cap     sunspec.Bitfield16 `sunspec:"offset=6"`
+	Cfg     sunspec.Enum16     `sunspec:"offset=7,access=rw"`
+	Ctl     sunspec.Enum16     `sunspec:"offset=8,access=rw"`
 	Addr    string             `sunspec:"offset=9,len=8,access=rw"`
 	Msk     string             `sunspec:"offset=17,len=8,access=rw"`
 	Gw      string             `sunspec:"offset=25,len=8,access=rw"`
@@ -52,7 +52,7 @@ type Block12 struct {
 	NTP2    string             `sunspec:"offset=61,len=12,access=rw"`
 	DomNam  string             `sunspec:"offset=73,len=12,access=rw"`
 	HostNam string             `sunspec:"offset=85,len=12,access=rw"`
-	Pad     sunspec.Pad        `sunspec:"offset=97,len=1"`
+	Pad     sunspec.Pad        `sunspec:"offset=97"`
 }
 
 func (block *Block12) GetId() sunspec.ModelId {
@@ -72,11 +72,11 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name"},
-					{Id: CfgSt, Offset: 4, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Config Status", Description: "Enumerated value.  Configuration status"},
-					{Id: ChgSt, Offset: 5, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "Change Status", Description: "Bitmask value.  A configuration change is pending"},
-					{Id: Cap, Offset: 6, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "Config Capability", Description: "Bitmask value. Identify capable sources of configuration"},
-					{Id: Cfg, Offset: 7, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "IPv4 Config", Description: "Enumerated value.  Configuration method used."},
-					{Id: Ctl, Offset: 8, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Control", Description: "Configure use of services"},
+					{Id: CfgSt, Offset: 4, Type: typelabel.Enum16, Mandatory: true, Label: "Config Status", Description: "Enumerated value.  Configuration status"},
+					{Id: ChgSt, Offset: 5, Type: typelabel.Bitfield16, Mandatory: true, Label: "Change Status", Description: "Bitmask value.  A configuration change is pending"},
+					{Id: Cap, Offset: 6, Type: typelabel.Bitfield16, Mandatory: true, Label: "Config Capability", Description: "Bitmask value. Identify capable sources of configuration"},
+					{Id: Cfg, Offset: 7, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "IPv4 Config", Description: "Enumerated value.  Configuration method used."},
+					{Id: Ctl, Offset: 8, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Control", Description: "Configure use of services"},
 					{Id: Addr, Offset: 9, Type: typelabel.String, Access: "rw", Length: 8, Mandatory: true, Label: "IP", Description: "IPv4 numeric address as a dotted string xxx.xxx.xxx.xxx"},
 					{Id: Msk, Offset: 17, Type: typelabel.String, Access: "rw", Length: 8, Mandatory: true, Label: "Netmask", Description: "IPv4 numeric netmask as a dotted string xxx.xxx.xxx.xxx"},
 					{Id: Gw, Offset: 25, Type: typelabel.String, Access: "rw", Length: 8, Label: "Gateway", Description: "IPv4 numeric gateway address as a dotted string xxx.xxx.xxx.xxx"},
@@ -86,7 +86,7 @@ func init() {
 					{Id: NTP2, Offset: 61, Type: typelabel.String, Access: "rw", Length: 12, Label: "NTP2", Description: "IPv4 numeric NTP address as a dotted string xxx.xxx.xxx.xxx"},
 					{Id: DomNam, Offset: 73, Type: typelabel.String, Access: "rw", Length: 12, Label: "Domain", Description: "Domain name (24 chars max)"},
 					{Id: HostNam, Offset: 85, Type: typelabel.String, Access: "rw", Length: 12, Label: "Host Name", Description: "Host name (24 chars max)"},
-					{Id: Pad, Offset: 97, Type: typelabel.Pad, Length: 1},
+					{Id: Pad, Offset: 97, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model120/model.go
+++ b/models/model120/model.go
@@ -47,32 +47,32 @@ const (
 )
 
 type Block120 struct {
-	DERTyp          sunspec.Enum16      `sunspec:"offset=0,len=1"`
-	WRtg            uint16              `sunspec:"offset=1,len=1,sf=WRtg_SF"`
-	WRtg_SF         sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	VARtg           uint16              `sunspec:"offset=3,len=1,sf=VARtg_SF"`
-	VARtg_SF        sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	VArRtgQ1        int16               `sunspec:"offset=5,len=1,sf=VArRtg_SF"`
-	VArRtgQ2        int16               `sunspec:"offset=6,len=1,sf=VArRtg_SF"`
-	VArRtgQ3        int16               `sunspec:"offset=7,len=1,sf=VArRtg_SF"`
-	VArRtgQ4        int16               `sunspec:"offset=8,len=1,sf=VArRtg_SF"`
-	VArRtg_SF       sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
-	ARtg            uint16              `sunspec:"offset=10,len=1,sf=ARtg_SF"`
-	ARtg_SF         sunspec.ScaleFactor `sunspec:"offset=11,len=1"`
-	PFRtgQ1         int16               `sunspec:"offset=12,len=1,sf=PFRtg_SF"`
-	PFRtgQ2         int16               `sunspec:"offset=13,len=1,sf=PFRtg_SF"`
-	PFRtgQ3         int16               `sunspec:"offset=14,len=1,sf=PFRtg_SF"`
-	PFRtgQ4         int16               `sunspec:"offset=15,len=1,sf=PFRtg_SF"`
-	PFRtg_SF        sunspec.ScaleFactor `sunspec:"offset=16,len=1"`
-	WHRtg           uint16              `sunspec:"offset=17,len=1,sf=WHRtg_SF"`
-	WHRtg_SF        sunspec.ScaleFactor `sunspec:"offset=18,len=1"`
-	AhrRtg          uint16              `sunspec:"offset=19,len=1,sf=AhrRtg_SF"`
-	AhrRtg_SF       sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	MaxChaRte       uint16              `sunspec:"offset=21,len=1,sf=MaxChaRte_SF"`
-	MaxChaRte_SF    sunspec.ScaleFactor `sunspec:"offset=22,len=1"`
-	MaxDisChaRte    uint16              `sunspec:"offset=23,len=1,sf=MaxDisChaRte_SF"`
-	MaxDisChaRte_SF sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	Pad             sunspec.Pad         `sunspec:"offset=25,len=1"`
+	DERTyp          sunspec.Enum16      `sunspec:"offset=0"`
+	WRtg            uint16              `sunspec:"offset=1,sf=WRtg_SF"`
+	WRtg_SF         sunspec.ScaleFactor `sunspec:"offset=2"`
+	VARtg           uint16              `sunspec:"offset=3,sf=VARtg_SF"`
+	VARtg_SF        sunspec.ScaleFactor `sunspec:"offset=4"`
+	VArRtgQ1        int16               `sunspec:"offset=5,sf=VArRtg_SF"`
+	VArRtgQ2        int16               `sunspec:"offset=6,sf=VArRtg_SF"`
+	VArRtgQ3        int16               `sunspec:"offset=7,sf=VArRtg_SF"`
+	VArRtgQ4        int16               `sunspec:"offset=8,sf=VArRtg_SF"`
+	VArRtg_SF       sunspec.ScaleFactor `sunspec:"offset=9"`
+	ARtg            uint16              `sunspec:"offset=10,sf=ARtg_SF"`
+	ARtg_SF         sunspec.ScaleFactor `sunspec:"offset=11"`
+	PFRtgQ1         int16               `sunspec:"offset=12,sf=PFRtg_SF"`
+	PFRtgQ2         int16               `sunspec:"offset=13,sf=PFRtg_SF"`
+	PFRtgQ3         int16               `sunspec:"offset=14,sf=PFRtg_SF"`
+	PFRtgQ4         int16               `sunspec:"offset=15,sf=PFRtg_SF"`
+	PFRtg_SF        sunspec.ScaleFactor `sunspec:"offset=16"`
+	WHRtg           uint16              `sunspec:"offset=17,sf=WHRtg_SF"`
+	WHRtg_SF        sunspec.ScaleFactor `sunspec:"offset=18"`
+	AhrRtg          uint16              `sunspec:"offset=19,sf=AhrRtg_SF"`
+	AhrRtg_SF       sunspec.ScaleFactor `sunspec:"offset=20"`
+	MaxChaRte       uint16              `sunspec:"offset=21,sf=MaxChaRte_SF"`
+	MaxChaRte_SF    sunspec.ScaleFactor `sunspec:"offset=22"`
+	MaxDisChaRte    uint16              `sunspec:"offset=23,sf=MaxDisChaRte_SF"`
+	MaxDisChaRte_SF sunspec.ScaleFactor `sunspec:"offset=24"`
+	Pad             sunspec.Pad         `sunspec:"offset=25"`
 }
 
 func (block *Block120) GetId() sunspec.ModelId {
@@ -91,32 +91,32 @@ func init() {
 				Length: 26,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DERTyp, Offset: 0, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "DERTyp", Description: "Type of DER device. Default value is 4 to indicate PV device."},
-					{Id: WRtg, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "WRtg_SF", Units: "W", Length: 1, Mandatory: true, Label: "WRtg", Description: "Continuous power output capability of the inverter."},
-					{Id: WRtg_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "WRtg_SF", Description: "Scale factor"},
-					{Id: VARtg, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "VARtg_SF", Units: "VA", Length: 1, Mandatory: true, Label: "VARtg", Description: "Continuous Volt-Ampere capability of the inverter."},
-					{Id: VARtg_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "VARtg_SF", Description: "Scale factor"},
-					{Id: VArRtgQ1, Offset: 5, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Length: 1, Mandatory: true, Label: "VArRtgQ1", Description: "Continuous VAR capability of the inverter in quadrant 1."},
-					{Id: VArRtgQ2, Offset: 6, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Length: 1, Mandatory: true, Label: "VArRtgQ2", Description: "Continuous VAR capability of the inverter in quadrant 2."},
-					{Id: VArRtgQ3, Offset: 7, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Length: 1, Mandatory: true, Label: "VArRtgQ3", Description: "Continuous VAR capability of the inverter in quadrant 3."},
-					{Id: VArRtgQ4, Offset: 8, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Length: 1, Mandatory: true, Label: "VArRtgQ4", Description: "Continuous VAR capability of the inverter in quadrant 4."},
-					{Id: VArRtg_SF, Offset: 9, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "VArRtg_SF", Description: "Scale factor"},
-					{Id: ARtg, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "ARtg_SF", Units: "A", Length: 1, Mandatory: true, Label: "ARtg", Description: "Maximum RMS AC current level capability of the inverter."},
-					{Id: ARtg_SF, Offset: 11, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "ARtg_SF", Description: "Scale factor"},
-					{Id: PFRtgQ1, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Length: 1, Mandatory: true, Label: "PFRtgQ1", Description: "Minimum power factor capability of the inverter in quadrant 1."},
-					{Id: PFRtgQ2, Offset: 13, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Length: 1, Mandatory: true, Label: "PFRtgQ2", Description: "Minimum power factor capability of the inverter in quadrant 2."},
-					{Id: PFRtgQ3, Offset: 14, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Length: 1, Mandatory: true, Label: "PFRtgQ3", Description: "Minimum power factor capability of the inverter in quadrant 3."},
-					{Id: PFRtgQ4, Offset: 15, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Length: 1, Mandatory: true, Label: "PFRtgQ4", Description: "Minimum power factor capability of the inverter in quadrant 4."},
-					{Id: PFRtg_SF, Offset: 16, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "PFRtg_SF", Description: "Scale factor"},
-					{Id: WHRtg, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "WHRtg_SF", Units: "Wh", Length: 1, Label: "WHRtg", Description: "Nominal energy rating of storage device."},
-					{Id: WHRtg_SF, Offset: 18, Type: typelabel.ScaleFactor, Length: 1, Label: "WHRtg_SF", Description: "Scale factor"},
-					{Id: AhrRtg, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "AhrRtg_SF", Units: "AH", Length: 1, Label: "AhrRtg", Description: "The usable capacity of the battery.  Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating)."},
-					{Id: AhrRtg_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Label: "AhrRtg_SF", Description: "Scale factor for amp-hour rating."},
-					{Id: MaxChaRte, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "MaxChaRte_SF", Units: "W", Length: 1, Label: "MaxChaRte", Description: "Maximum rate of energy transfer into the storage device."},
-					{Id: MaxChaRte_SF, Offset: 22, Type: typelabel.ScaleFactor, Length: 1, Label: "MaxChaRte_SF", Description: "Scale factor"},
-					{Id: MaxDisChaRte, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "MaxDisChaRte_SF", Units: "W", Length: 1, Label: "MaxDisChaRte", Description: "Maximum rate of energy transfer out of the storage device."},
-					{Id: MaxDisChaRte_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Label: "MaxDisChaRte_SF", Description: "Scale factor"},
-					{Id: Pad, Offset: 25, Type: typelabel.Pad, Length: 1, Label: "Pad", Description: "Pad register."},
+					{Id: DERTyp, Offset: 0, Type: typelabel.Enum16, Mandatory: true, Label: "DERTyp", Description: "Type of DER device. Default value is 4 to indicate PV device."},
+					{Id: WRtg, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "WRtg_SF", Units: "W", Mandatory: true, Label: "WRtg", Description: "Continuous power output capability of the inverter."},
+					{Id: WRtg_SF, Offset: 2, Type: typelabel.ScaleFactor, Mandatory: true, Label: "WRtg_SF", Description: "Scale factor"},
+					{Id: VARtg, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "VARtg_SF", Units: "VA", Mandatory: true, Label: "VARtg", Description: "Continuous Volt-Ampere capability of the inverter."},
+					{Id: VARtg_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true, Label: "VARtg_SF", Description: "Scale factor"},
+					{Id: VArRtgQ1, Offset: 5, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Mandatory: true, Label: "VArRtgQ1", Description: "Continuous VAR capability of the inverter in quadrant 1."},
+					{Id: VArRtgQ2, Offset: 6, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Mandatory: true, Label: "VArRtgQ2", Description: "Continuous VAR capability of the inverter in quadrant 2."},
+					{Id: VArRtgQ3, Offset: 7, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Mandatory: true, Label: "VArRtgQ3", Description: "Continuous VAR capability of the inverter in quadrant 3."},
+					{Id: VArRtgQ4, Offset: 8, Type: typelabel.Int16, ScaleFactor: "VArRtg_SF", Units: "var", Mandatory: true, Label: "VArRtgQ4", Description: "Continuous VAR capability of the inverter in quadrant 4."},
+					{Id: VArRtg_SF, Offset: 9, Type: typelabel.ScaleFactor, Mandatory: true, Label: "VArRtg_SF", Description: "Scale factor"},
+					{Id: ARtg, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "ARtg_SF", Units: "A", Mandatory: true, Label: "ARtg", Description: "Maximum RMS AC current level capability of the inverter."},
+					{Id: ARtg_SF, Offset: 11, Type: typelabel.ScaleFactor, Mandatory: true, Label: "ARtg_SF", Description: "Scale factor"},
+					{Id: PFRtgQ1, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Mandatory: true, Label: "PFRtgQ1", Description: "Minimum power factor capability of the inverter in quadrant 1."},
+					{Id: PFRtgQ2, Offset: 13, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Mandatory: true, Label: "PFRtgQ2", Description: "Minimum power factor capability of the inverter in quadrant 2."},
+					{Id: PFRtgQ3, Offset: 14, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Mandatory: true, Label: "PFRtgQ3", Description: "Minimum power factor capability of the inverter in quadrant 3."},
+					{Id: PFRtgQ4, Offset: 15, Type: typelabel.Int16, ScaleFactor: "PFRtg_SF", Units: "cos()", Mandatory: true, Label: "PFRtgQ4", Description: "Minimum power factor capability of the inverter in quadrant 4."},
+					{Id: PFRtg_SF, Offset: 16, Type: typelabel.ScaleFactor, Mandatory: true, Label: "PFRtg_SF", Description: "Scale factor"},
+					{Id: WHRtg, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "WHRtg_SF", Units: "Wh", Label: "WHRtg", Description: "Nominal energy rating of storage device."},
+					{Id: WHRtg_SF, Offset: 18, Type: typelabel.ScaleFactor, Label: "WHRtg_SF", Description: "Scale factor"},
+					{Id: AhrRtg, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "AhrRtg_SF", Units: "AH", Label: "AhrRtg", Description: "The usable capacity of the battery.  Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating)."},
+					{Id: AhrRtg_SF, Offset: 20, Type: typelabel.ScaleFactor, Label: "AhrRtg_SF", Description: "Scale factor for amp-hour rating."},
+					{Id: MaxChaRte, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "MaxChaRte_SF", Units: "W", Label: "MaxChaRte", Description: "Maximum rate of energy transfer into the storage device."},
+					{Id: MaxChaRte_SF, Offset: 22, Type: typelabel.ScaleFactor, Label: "MaxChaRte_SF", Description: "Scale factor"},
+					{Id: MaxDisChaRte, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "MaxDisChaRte_SF", Units: "W", Label: "MaxDisChaRte", Description: "Maximum rate of energy transfer out of the storage device."},
+					{Id: MaxDisChaRte_SF, Offset: 24, Type: typelabel.ScaleFactor, Label: "MaxDisChaRte_SF", Description: "Scale factor"},
+					{Id: Pad, Offset: 25, Type: typelabel.Pad, Label: "Pad", Description: "Pad register."},
 				},
 			},
 		}})

--- a/models/model121/model.go
+++ b/models/model121/model.go
@@ -51,36 +51,36 @@ const (
 )
 
 type Block121 struct {
-	WMax         uint16              `sunspec:"offset=0,len=1,sf=WMax_SF,access=rw"`
-	VRef         uint16              `sunspec:"offset=1,len=1,sf=VRef_SF,access=rw"`
-	VRefOfs      int16               `sunspec:"offset=2,len=1,sf=VRefOfs_SF,access=rw"`
-	VMax         uint16              `sunspec:"offset=3,len=1,sf=VMinMax_SF,access=rw"`
-	VMin         uint16              `sunspec:"offset=4,len=1,sf=VMinMax_SF,access=rw"`
-	VAMax        uint16              `sunspec:"offset=5,len=1,sf=VAMax_SF,access=rw"`
-	VArMaxQ1     int16               `sunspec:"offset=6,len=1,sf=VArMax_SF,access=rw"`
-	VArMaxQ2     int16               `sunspec:"offset=7,len=1,sf=VArMax_SF,access=rw"`
-	VArMaxQ3     int16               `sunspec:"offset=8,len=1,sf=VArMax_SF,access=rw"`
-	VArMaxQ4     int16               `sunspec:"offset=9,len=1,sf=VArMax_SF,access=rw"`
-	WGra         uint16              `sunspec:"offset=10,len=1,sf=WGra_SF,access=rw"`
-	PFMinQ1      int16               `sunspec:"offset=11,len=1,sf=PFMin_SF,access=rw"`
-	PFMinQ2      int16               `sunspec:"offset=12,len=1,sf=PFMin_SF,access=rw"`
-	PFMinQ3      int16               `sunspec:"offset=13,len=1,sf=PFMin_SF,access=rw"`
-	PFMinQ4      int16               `sunspec:"offset=14,len=1,sf=PFMin_SF,access=rw"`
-	VArAct       sunspec.Enum16      `sunspec:"offset=15,len=1,access=rw"`
-	ClcTotVA     sunspec.Enum16      `sunspec:"offset=16,len=1,access=rw"`
-	MaxRmpRte    uint16              `sunspec:"offset=17,len=1,sf=MaxRmpRte_SF,access=rw"`
-	ECPNomHz     uint16              `sunspec:"offset=18,len=1,sf=ECPNomHz_SF,access=rw"`
-	ConnPh       sunspec.Enum16      `sunspec:"offset=19,len=1,access=rw"`
-	WMax_SF      sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	VRef_SF      sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	VRefOfs_SF   sunspec.ScaleFactor `sunspec:"offset=22,len=1"`
-	VMinMax_SF   sunspec.ScaleFactor `sunspec:"offset=23,len=1"`
-	VAMax_SF     sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	VArMax_SF    sunspec.ScaleFactor `sunspec:"offset=25,len=1"`
-	WGra_SF      sunspec.ScaleFactor `sunspec:"offset=26,len=1"`
-	PFMin_SF     sunspec.ScaleFactor `sunspec:"offset=27,len=1"`
-	MaxRmpRte_SF sunspec.ScaleFactor `sunspec:"offset=28,len=1"`
-	ECPNomHz_SF  sunspec.ScaleFactor `sunspec:"offset=29,len=1"`
+	WMax         uint16              `sunspec:"offset=0,sf=WMax_SF,access=rw"`
+	VRef         uint16              `sunspec:"offset=1,sf=VRef_SF,access=rw"`
+	VRefOfs      int16               `sunspec:"offset=2,sf=VRefOfs_SF,access=rw"`
+	VMax         uint16              `sunspec:"offset=3,sf=VMinMax_SF,access=rw"`
+	VMin         uint16              `sunspec:"offset=4,sf=VMinMax_SF,access=rw"`
+	VAMax        uint16              `sunspec:"offset=5,sf=VAMax_SF,access=rw"`
+	VArMaxQ1     int16               `sunspec:"offset=6,sf=VArMax_SF,access=rw"`
+	VArMaxQ2     int16               `sunspec:"offset=7,sf=VArMax_SF,access=rw"`
+	VArMaxQ3     int16               `sunspec:"offset=8,sf=VArMax_SF,access=rw"`
+	VArMaxQ4     int16               `sunspec:"offset=9,sf=VArMax_SF,access=rw"`
+	WGra         uint16              `sunspec:"offset=10,sf=WGra_SF,access=rw"`
+	PFMinQ1      int16               `sunspec:"offset=11,sf=PFMin_SF,access=rw"`
+	PFMinQ2      int16               `sunspec:"offset=12,sf=PFMin_SF,access=rw"`
+	PFMinQ3      int16               `sunspec:"offset=13,sf=PFMin_SF,access=rw"`
+	PFMinQ4      int16               `sunspec:"offset=14,sf=PFMin_SF,access=rw"`
+	VArAct       sunspec.Enum16      `sunspec:"offset=15,access=rw"`
+	ClcTotVA     sunspec.Enum16      `sunspec:"offset=16,access=rw"`
+	MaxRmpRte    uint16              `sunspec:"offset=17,sf=MaxRmpRte_SF,access=rw"`
+	ECPNomHz     uint16              `sunspec:"offset=18,sf=ECPNomHz_SF,access=rw"`
+	ConnPh       sunspec.Enum16      `sunspec:"offset=19,access=rw"`
+	WMax_SF      sunspec.ScaleFactor `sunspec:"offset=20"`
+	VRef_SF      sunspec.ScaleFactor `sunspec:"offset=21"`
+	VRefOfs_SF   sunspec.ScaleFactor `sunspec:"offset=22"`
+	VMinMax_SF   sunspec.ScaleFactor `sunspec:"offset=23"`
+	VAMax_SF     sunspec.ScaleFactor `sunspec:"offset=24"`
+	VArMax_SF    sunspec.ScaleFactor `sunspec:"offset=25"`
+	WGra_SF      sunspec.ScaleFactor `sunspec:"offset=26"`
+	PFMin_SF     sunspec.ScaleFactor `sunspec:"offset=27"`
+	MaxRmpRte_SF sunspec.ScaleFactor `sunspec:"offset=28"`
+	ECPNomHz_SF  sunspec.ScaleFactor `sunspec:"offset=29"`
 }
 
 func (block *Block121) GetId() sunspec.ModelId {
@@ -99,36 +99,36 @@ func init() {
 				Length: 30,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: WMax, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "WMax_SF", Units: "W", Access: "rw", Length: 1, Mandatory: true, Label: "WMax", Description: "Setting for maximum power output. Default to WRtg."},
-					{Id: VRef, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "VRef_SF", Units: "V", Access: "rw", Length: 1, Mandatory: true, Label: "VRef", Description: "Voltage at the PCC."},
-					{Id: VRefOfs, Offset: 2, Type: typelabel.Int16, ScaleFactor: "VRefOfs_SF", Units: "V", Access: "rw", Length: 1, Mandatory: true, Label: "VRefOfs", Description: "Offset  from PCC to inverter."},
-					{Id: VMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "VMinMax_SF", Units: "V", Access: "rw", Length: 1, Label: "VMax", Description: "Setpoint for maximum voltage."},
-					{Id: VMin, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "VMinMax_SF", Units: "V", Access: "rw", Length: 1, Label: "VMin", Description: "Setpoint for minimum voltage."},
-					{Id: VAMax, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "VAMax_SF", Units: "VA", Access: "rw", Length: 1, Label: "VAMax", Description: "Setpoint for maximum apparent power. Default to VARtg."},
-					{Id: VArMaxQ1, Offset: 6, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Length: 1, Label: "VArMaxQ1", Description: "Setting for maximum reactive power in quadrant 1. Default to VArRtgQ1."},
-					{Id: VArMaxQ2, Offset: 7, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Length: 1, Label: "VArMaxQ2", Description: "Setting for maximum reactive power in quadrant 2. Default to VArRtgQ2."},
-					{Id: VArMaxQ3, Offset: 8, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Length: 1, Label: "VArMaxQ3", Description: "Setting for maximum reactive power in quadrant 3. Default to VArRtgQ3."},
-					{Id: VArMaxQ4, Offset: 9, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Length: 1, Label: "VArMaxQ4", Description: "Setting for maximum reactive power in quadrant 4. Default to VArRtgQ4."},
-					{Id: WGra, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "WGra_SF", Units: "% WMax/sec", Access: "rw", Length: 1, Label: "WGra", Description: "Default ramp rate of change of active power due to command or internal action."},
-					{Id: PFMinQ1, Offset: 11, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PFMinQ1", Description: "Setpoint for minimum power factor value in quadrant 1. Default to PFRtgQ1."},
-					{Id: PFMinQ2, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PFMinQ2", Description: "Setpoint for minimum power factor value in quadrant 2. Default to PFRtgQ2."},
-					{Id: PFMinQ3, Offset: 13, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PFMinQ3", Description: "Setpoint for minimum power factor value in quadrant 3. Default to PFRtgQ3."},
-					{Id: PFMinQ4, Offset: 14, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PFMinQ4", Description: "Setpoint for minimum power factor value in quadrant 4. Default to PFRtgQ4."},
-					{Id: VArAct, Offset: 15, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "VArAct", Description: "VAR action on change between charging and discharging: 1=switch 2=maintain VAR characterization."},
-					{Id: ClcTotVA, Offset: 16, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "ClcTotVA", Description: "Calculation method for total apparent power. 1=vector 2=arithmetic."},
-					{Id: MaxRmpRte, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "MaxRmpRte_SF", Units: "% WGra", Access: "rw", Length: 1, Label: "MaxRmpRte", Description: "Setpoint for maximum ramp rate as percentage of nominal maximum ramp rate. This setting will limit the rate that watts delivery to the grid can increase or decrease in response to intermittent PV generation."},
-					{Id: ECPNomHz, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "ECPNomHz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "ECPNomHz", Description: "Setpoint for nominal frequency at the ECP."},
-					{Id: ConnPh, Offset: 19, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "ConnPh", Description: "Identity of connected phase for single phase inverters. A=1 B=2 C=3."},
-					{Id: WMax_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "WMax_SF", Description: "Scale factor for real power."},
-					{Id: VRef_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "VRef_SF", Description: "Scale factor for voltage at the PCC."},
-					{Id: VRefOfs_SF, Offset: 22, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "VRefOfs_SF", Description: "Scale factor for offset voltage."},
-					{Id: VMinMax_SF, Offset: 23, Type: typelabel.ScaleFactor, Length: 1, Label: "VMinMax_SF", Description: "Scale factor for min/max voltages."},
-					{Id: VAMax_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Label: "VAMax_SF", Description: "Scale factor for apparent power."},
-					{Id: VArMax_SF, Offset: 25, Type: typelabel.ScaleFactor, Length: 1, Label: "VArMax_SF", Description: "Scale factor for reactive power."},
-					{Id: WGra_SF, Offset: 26, Type: typelabel.ScaleFactor, Length: 1, Label: "WGra_SF", Description: "Scale factor for default ramp rate."},
-					{Id: PFMin_SF, Offset: 27, Type: typelabel.ScaleFactor, Length: 1, Label: "PFMin_SF", Description: "Scale factor for minimum power factor."},
-					{Id: MaxRmpRte_SF, Offset: 28, Type: typelabel.ScaleFactor, Length: 1, Label: "MaxRmpRte_SF", Description: "Scale factor for maximum ramp percentage."},
-					{Id: ECPNomHz_SF, Offset: 29, Type: typelabel.ScaleFactor, Length: 1, Label: "ECPNomHz_SF", Description: "Scale factor for nominal frequency."},
+					{Id: WMax, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "WMax_SF", Units: "W", Access: "rw", Mandatory: true, Label: "WMax", Description: "Setting for maximum power output. Default to WRtg."},
+					{Id: VRef, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "VRef_SF", Units: "V", Access: "rw", Mandatory: true, Label: "VRef", Description: "Voltage at the PCC."},
+					{Id: VRefOfs, Offset: 2, Type: typelabel.Int16, ScaleFactor: "VRefOfs_SF", Units: "V", Access: "rw", Mandatory: true, Label: "VRefOfs", Description: "Offset  from PCC to inverter."},
+					{Id: VMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "VMinMax_SF", Units: "V", Access: "rw", Label: "VMax", Description: "Setpoint for maximum voltage."},
+					{Id: VMin, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "VMinMax_SF", Units: "V", Access: "rw", Label: "VMin", Description: "Setpoint for minimum voltage."},
+					{Id: VAMax, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "VAMax_SF", Units: "VA", Access: "rw", Label: "VAMax", Description: "Setpoint for maximum apparent power. Default to VARtg."},
+					{Id: VArMaxQ1, Offset: 6, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Label: "VArMaxQ1", Description: "Setting for maximum reactive power in quadrant 1. Default to VArRtgQ1."},
+					{Id: VArMaxQ2, Offset: 7, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Label: "VArMaxQ2", Description: "Setting for maximum reactive power in quadrant 2. Default to VArRtgQ2."},
+					{Id: VArMaxQ3, Offset: 8, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Label: "VArMaxQ3", Description: "Setting for maximum reactive power in quadrant 3. Default to VArRtgQ3."},
+					{Id: VArMaxQ4, Offset: 9, Type: typelabel.Int16, ScaleFactor: "VArMax_SF", Units: "var", Access: "rw", Label: "VArMaxQ4", Description: "Setting for maximum reactive power in quadrant 4. Default to VArRtgQ4."},
+					{Id: WGra, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "WGra_SF", Units: "% WMax/sec", Access: "rw", Label: "WGra", Description: "Default ramp rate of change of active power due to command or internal action."},
+					{Id: PFMinQ1, Offset: 11, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Label: "PFMinQ1", Description: "Setpoint for minimum power factor value in quadrant 1. Default to PFRtgQ1."},
+					{Id: PFMinQ2, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Label: "PFMinQ2", Description: "Setpoint for minimum power factor value in quadrant 2. Default to PFRtgQ2."},
+					{Id: PFMinQ3, Offset: 13, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Label: "PFMinQ3", Description: "Setpoint for minimum power factor value in quadrant 3. Default to PFRtgQ3."},
+					{Id: PFMinQ4, Offset: 14, Type: typelabel.Int16, ScaleFactor: "PFMin_SF", Units: "cos()", Access: "rw", Label: "PFMinQ4", Description: "Setpoint for minimum power factor value in quadrant 4. Default to PFRtgQ4."},
+					{Id: VArAct, Offset: 15, Type: typelabel.Enum16, Access: "rw", Label: "VArAct", Description: "VAR action on change between charging and discharging: 1=switch 2=maintain VAR characterization."},
+					{Id: ClcTotVA, Offset: 16, Type: typelabel.Enum16, Access: "rw", Label: "ClcTotVA", Description: "Calculation method for total apparent power. 1=vector 2=arithmetic."},
+					{Id: MaxRmpRte, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "MaxRmpRte_SF", Units: "% WGra", Access: "rw", Label: "MaxRmpRte", Description: "Setpoint for maximum ramp rate as percentage of nominal maximum ramp rate. This setting will limit the rate that watts delivery to the grid can increase or decrease in response to intermittent PV generation."},
+					{Id: ECPNomHz, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "ECPNomHz_SF", Units: "Hz", Access: "rw", Label: "ECPNomHz", Description: "Setpoint for nominal frequency at the ECP."},
+					{Id: ConnPh, Offset: 19, Type: typelabel.Enum16, Access: "rw", Label: "ConnPh", Description: "Identity of connected phase for single phase inverters. A=1 B=2 C=3."},
+					{Id: WMax_SF, Offset: 20, Type: typelabel.ScaleFactor, Mandatory: true, Label: "WMax_SF", Description: "Scale factor for real power."},
+					{Id: VRef_SF, Offset: 21, Type: typelabel.ScaleFactor, Mandatory: true, Label: "VRef_SF", Description: "Scale factor for voltage at the PCC."},
+					{Id: VRefOfs_SF, Offset: 22, Type: typelabel.ScaleFactor, Mandatory: true, Label: "VRefOfs_SF", Description: "Scale factor for offset voltage."},
+					{Id: VMinMax_SF, Offset: 23, Type: typelabel.ScaleFactor, Label: "VMinMax_SF", Description: "Scale factor for min/max voltages."},
+					{Id: VAMax_SF, Offset: 24, Type: typelabel.ScaleFactor, Label: "VAMax_SF", Description: "Scale factor for apparent power."},
+					{Id: VArMax_SF, Offset: 25, Type: typelabel.ScaleFactor, Label: "VArMax_SF", Description: "Scale factor for reactive power."},
+					{Id: WGra_SF, Offset: 26, Type: typelabel.ScaleFactor, Label: "WGra_SF", Description: "Scale factor for default ramp rate."},
+					{Id: PFMin_SF, Offset: 27, Type: typelabel.ScaleFactor, Label: "PFMin_SF", Description: "Scale factor for minimum power factor."},
+					{Id: MaxRmpRte_SF, Offset: 28, Type: typelabel.ScaleFactor, Label: "MaxRmpRte_SF", Description: "Scale factor for maximum ramp percentage."},
+					{Id: ECPNomHz_SF, Offset: 29, Type: typelabel.ScaleFactor, Label: "ECPNomHz_SF", Description: "Scale factor for nominal frequency."},
 				},
 			},
 		}})

--- a/models/model122/model.go
+++ b/models/model122/model.go
@@ -41,26 +41,26 @@ const (
 )
 
 type Block122 struct {
-	PVConn      sunspec.Bitfield16  `sunspec:"offset=0,len=1"`
-	StorConn    sunspec.Bitfield16  `sunspec:"offset=1,len=1"`
-	ECPConn     sunspec.Bitfield16  `sunspec:"offset=2,len=1"`
-	ActWh       sunspec.Acc64       `sunspec:"offset=3,len=4"`
-	ActVAh      sunspec.Acc64       `sunspec:"offset=7,len=4"`
-	ActVArhQ1   sunspec.Acc64       `sunspec:"offset=11,len=4"`
-	ActVArhQ2   sunspec.Acc64       `sunspec:"offset=15,len=4"`
-	ActVArhQ3   sunspec.Acc64       `sunspec:"offset=19,len=4"`
-	ActVArhQ4   sunspec.Acc64       `sunspec:"offset=23,len=4"`
-	VArAval     int16               `sunspec:"offset=27,len=1,sf=VArAval_SF"`
-	VArAval_SF  sunspec.ScaleFactor `sunspec:"offset=28,len=1"`
-	WAval       uint16              `sunspec:"offset=29,len=1,sf=WAval_SF"`
-	WAval_SF    sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	StSetLimMsk sunspec.Bitfield32  `sunspec:"offset=31,len=2"`
-	StActCtl    sunspec.Bitfield32  `sunspec:"offset=33,len=2"`
+	PVConn      sunspec.Bitfield16  `sunspec:"offset=0"`
+	StorConn    sunspec.Bitfield16  `sunspec:"offset=1"`
+	ECPConn     sunspec.Bitfield16  `sunspec:"offset=2"`
+	ActWh       sunspec.Acc64       `sunspec:"offset=3"`
+	ActVAh      sunspec.Acc64       `sunspec:"offset=7"`
+	ActVArhQ1   sunspec.Acc64       `sunspec:"offset=11"`
+	ActVArhQ2   sunspec.Acc64       `sunspec:"offset=15"`
+	ActVArhQ3   sunspec.Acc64       `sunspec:"offset=19"`
+	ActVArhQ4   sunspec.Acc64       `sunspec:"offset=23"`
+	VArAval     int16               `sunspec:"offset=27,sf=VArAval_SF"`
+	VArAval_SF  sunspec.ScaleFactor `sunspec:"offset=28"`
+	WAval       uint16              `sunspec:"offset=29,sf=WAval_SF"`
+	WAval_SF    sunspec.ScaleFactor `sunspec:"offset=30"`
+	StSetLimMsk sunspec.Bitfield32  `sunspec:"offset=31"`
+	StActCtl    sunspec.Bitfield32  `sunspec:"offset=33"`
 	TmSrc       string              `sunspec:"offset=35,len=4"`
-	Tms         uint32              `sunspec:"offset=39,len=2"`
-	RtSt        sunspec.Bitfield16  `sunspec:"offset=41,len=1"`
-	Ris         uint16              `sunspec:"offset=42,len=1,sf=Ris_SF"`
-	Ris_SF      sunspec.ScaleFactor `sunspec:"offset=43,len=1"`
+	Tms         uint32              `sunspec:"offset=39"`
+	RtSt        sunspec.Bitfield16  `sunspec:"offset=41"`
+	Ris         uint16              `sunspec:"offset=42,sf=Ris_SF"`
+	Ris_SF      sunspec.ScaleFactor `sunspec:"offset=43"`
 }
 
 func (block *Block122) GetId() sunspec.ModelId {
@@ -79,26 +79,26 @@ func init() {
 				Length: 44,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: PVConn, Offset: 0, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "PVConn", Description: "PV inverter present/available status. Enumerated value."},
-					{Id: StorConn, Offset: 1, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "StorConn", Description: "Storage inverter present/available status. Enumerated value."},
-					{Id: ECPConn, Offset: 2, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "ECPConn", Description: "ECP connection status: disconnected=0  connected=1."},
-					{Id: ActWh, Offset: 3, Type: typelabel.Acc64, Units: "Wh", Length: 4, Label: "ActWh", Description: "AC lifetime active (real) energy output."},
-					{Id: ActVAh, Offset: 7, Type: typelabel.Acc64, Units: "VAh", Length: 4, Label: "ActVAh", Description: "AC lifetime apparent energy output."},
-					{Id: ActVArhQ1, Offset: 11, Type: typelabel.Acc64, Units: "varh", Length: 4, Label: "ActVArhQ1", Description: "AC lifetime reactive energy output in quadrant 1."},
-					{Id: ActVArhQ2, Offset: 15, Type: typelabel.Acc64, Units: "varh", Length: 4, Label: "ActVArhQ2", Description: "AC lifetime reactive energy output in quadrant 2."},
-					{Id: ActVArhQ3, Offset: 19, Type: typelabel.Acc64, Units: "varh", Length: 4, Label: "ActVArhQ3", Description: "AC lifetime negative energy output  in quadrant 3."},
-					{Id: ActVArhQ4, Offset: 23, Type: typelabel.Acc64, Units: "varh", Length: 4, Label: "ActVArhQ4", Description: "AC lifetime reactive energy output  in quadrant 4."},
-					{Id: VArAval, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VArAval_SF", Units: "var", Length: 1, Label: "VArAval", Description: "Amount of VARs available without impacting watts output."},
-					{Id: VArAval_SF, Offset: 28, Type: typelabel.ScaleFactor, Length: 1, Label: "VArAval_SF", Description: "Scale factor for available VARs."},
-					{Id: WAval, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "WAval_SF", Units: "var", Length: 1, Label: "WAval", Description: "Amount of Watts available."},
-					{Id: WAval_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1, Label: "WAval_SF", Description: "Scale factor for available Watts."},
-					{Id: StSetLimMsk, Offset: 31, Type: typelabel.Bitfield32, Length: 2, Label: "StSetLimMsk", Description: "Bit Mask indicating setpoint limit(s) reached."},
-					{Id: StActCtl, Offset: 33, Type: typelabel.Bitfield32, Length: 2, Label: "StActCtl", Description: "Bit Mask indicating which inverter controls are currently active."},
+					{Id: PVConn, Offset: 0, Type: typelabel.Bitfield16, Mandatory: true, Label: "PVConn", Description: "PV inverter present/available status. Enumerated value."},
+					{Id: StorConn, Offset: 1, Type: typelabel.Bitfield16, Mandatory: true, Label: "StorConn", Description: "Storage inverter present/available status. Enumerated value."},
+					{Id: ECPConn, Offset: 2, Type: typelabel.Bitfield16, Mandatory: true, Label: "ECPConn", Description: "ECP connection status: disconnected=0  connected=1."},
+					{Id: ActWh, Offset: 3, Type: typelabel.Acc64, Units: "Wh", Label: "ActWh", Description: "AC lifetime active (real) energy output."},
+					{Id: ActVAh, Offset: 7, Type: typelabel.Acc64, Units: "VAh", Label: "ActVAh", Description: "AC lifetime apparent energy output."},
+					{Id: ActVArhQ1, Offset: 11, Type: typelabel.Acc64, Units: "varh", Label: "ActVArhQ1", Description: "AC lifetime reactive energy output in quadrant 1."},
+					{Id: ActVArhQ2, Offset: 15, Type: typelabel.Acc64, Units: "varh", Label: "ActVArhQ2", Description: "AC lifetime reactive energy output in quadrant 2."},
+					{Id: ActVArhQ3, Offset: 19, Type: typelabel.Acc64, Units: "varh", Label: "ActVArhQ3", Description: "AC lifetime negative energy output  in quadrant 3."},
+					{Id: ActVArhQ4, Offset: 23, Type: typelabel.Acc64, Units: "varh", Label: "ActVArhQ4", Description: "AC lifetime reactive energy output  in quadrant 4."},
+					{Id: VArAval, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VArAval_SF", Units: "var", Label: "VArAval", Description: "Amount of VARs available without impacting watts output."},
+					{Id: VArAval_SF, Offset: 28, Type: typelabel.ScaleFactor, Label: "VArAval_SF", Description: "Scale factor for available VARs."},
+					{Id: WAval, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "WAval_SF", Units: "var", Label: "WAval", Description: "Amount of Watts available."},
+					{Id: WAval_SF, Offset: 30, Type: typelabel.ScaleFactor, Label: "WAval_SF", Description: "Scale factor for available Watts."},
+					{Id: StSetLimMsk, Offset: 31, Type: typelabel.Bitfield32, Label: "StSetLimMsk", Description: "Bit Mask indicating setpoint limit(s) reached."},
+					{Id: StActCtl, Offset: 33, Type: typelabel.Bitfield32, Label: "StActCtl", Description: "Bit Mask indicating which inverter controls are currently active."},
 					{Id: TmSrc, Offset: 35, Type: typelabel.String, Length: 4, Label: "TmSrc", Description: "Source of time synchronization."},
-					{Id: Tms, Offset: 39, Type: typelabel.Uint32, Units: "Secs", Length: 2, Label: "Tms", Description: "Seconds since 01-01-2000 00:00 UTC"},
-					{Id: RtSt, Offset: 41, Type: typelabel.Bitfield16, Length: 1, Label: "RtSt", Description: "Bit Mask indicating active ride-through status."},
-					{Id: Ris, Offset: 42, Type: typelabel.Uint16, ScaleFactor: "Ris_SF", Units: "ohms", Length: 1, Label: "Ris", Description: "Isolation resistance."},
-					{Id: Ris_SF, Offset: 43, Type: typelabel.ScaleFactor, Length: 1, Label: "Ris_SF", Description: "Scale factor for isolation resistance."},
+					{Id: Tms, Offset: 39, Type: typelabel.Uint32, Units: "Secs", Label: "Tms", Description: "Seconds since 01-01-2000 00:00 UTC"},
+					{Id: RtSt, Offset: 41, Type: typelabel.Bitfield16, Label: "RtSt", Description: "Bit Mask indicating active ride-through status."},
+					{Id: Ris, Offset: 42, Type: typelabel.Uint16, ScaleFactor: "Ris_SF", Units: "ohms", Label: "Ris", Description: "Isolation resistance."},
+					{Id: Ris_SF, Offset: 43, Type: typelabel.ScaleFactor, Label: "Ris_SF", Description: "Scale factor for isolation resistance."},
 				},
 			},
 		}})

--- a/models/model123/model.go
+++ b/models/model123/model.go
@@ -45,30 +45,30 @@ const (
 )
 
 type Block123 struct {
-	Conn_WinTms        uint16              `sunspec:"offset=0,len=1,access=rw"`
-	Conn_RvrtTms       uint16              `sunspec:"offset=1,len=1,access=rw"`
-	Conn               sunspec.Enum16      `sunspec:"offset=2,len=1,access=rw"`
-	WMaxLimPct         uint16              `sunspec:"offset=3,len=1,sf=WMaxLimPct_SF,access=rw"`
-	WMaxLimPct_WinTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	WMaxLimPct_RvrtTms uint16              `sunspec:"offset=5,len=1,access=rw"`
-	WMaxLimPct_RmpTms  uint16              `sunspec:"offset=6,len=1,access=rw"`
-	WMaxLim_Ena        sunspec.Enum16      `sunspec:"offset=7,len=1,access=rw"`
-	OutPFSet           int16               `sunspec:"offset=8,len=1,sf=OutPFSet_SF,access=rw"`
-	OutPFSet_WinTms    uint16              `sunspec:"offset=9,len=1,access=rw"`
-	OutPFSet_RvrtTms   uint16              `sunspec:"offset=10,len=1,access=rw"`
-	OutPFSet_RmpTms    uint16              `sunspec:"offset=11,len=1,access=rw"`
-	OutPFSet_Ena       sunspec.Enum16      `sunspec:"offset=12,len=1,access=rw"`
-	VArWMaxPct         int16               `sunspec:"offset=13,len=1,sf=VArPct_SF,access=rw"`
-	VArMaxPct          int16               `sunspec:"offset=14,len=1,sf=VArPct_SF,access=rw"`
-	VArAvalPct         int16               `sunspec:"offset=15,len=1,sf=VArPct_SF,access=rw"`
-	VArPct_WinTms      uint16              `sunspec:"offset=16,len=1,access=rw"`
-	VArPct_RvrtTms     uint16              `sunspec:"offset=17,len=1,access=rw"`
-	VArPct_RmpTms      uint16              `sunspec:"offset=18,len=1,access=rw"`
-	VArPct_Mod         sunspec.Enum16      `sunspec:"offset=19,len=1,access=rw"`
-	VArPct_Ena         sunspec.Enum16      `sunspec:"offset=20,len=1,access=rw"`
-	WMaxLimPct_SF      sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	OutPFSet_SF        sunspec.ScaleFactor `sunspec:"offset=22,len=1"`
-	VArPct_SF          sunspec.ScaleFactor `sunspec:"offset=23,len=1"`
+	Conn_WinTms        uint16              `sunspec:"offset=0,access=rw"`
+	Conn_RvrtTms       uint16              `sunspec:"offset=1,access=rw"`
+	Conn               sunspec.Enum16      `sunspec:"offset=2,access=rw"`
+	WMaxLimPct         uint16              `sunspec:"offset=3,sf=WMaxLimPct_SF,access=rw"`
+	WMaxLimPct_WinTms  uint16              `sunspec:"offset=4,access=rw"`
+	WMaxLimPct_RvrtTms uint16              `sunspec:"offset=5,access=rw"`
+	WMaxLimPct_RmpTms  uint16              `sunspec:"offset=6,access=rw"`
+	WMaxLim_Ena        sunspec.Enum16      `sunspec:"offset=7,access=rw"`
+	OutPFSet           int16               `sunspec:"offset=8,sf=OutPFSet_SF,access=rw"`
+	OutPFSet_WinTms    uint16              `sunspec:"offset=9,access=rw"`
+	OutPFSet_RvrtTms   uint16              `sunspec:"offset=10,access=rw"`
+	OutPFSet_RmpTms    uint16              `sunspec:"offset=11,access=rw"`
+	OutPFSet_Ena       sunspec.Enum16      `sunspec:"offset=12,access=rw"`
+	VArWMaxPct         int16               `sunspec:"offset=13,sf=VArPct_SF,access=rw"`
+	VArMaxPct          int16               `sunspec:"offset=14,sf=VArPct_SF,access=rw"`
+	VArAvalPct         int16               `sunspec:"offset=15,sf=VArPct_SF,access=rw"`
+	VArPct_WinTms      uint16              `sunspec:"offset=16,access=rw"`
+	VArPct_RvrtTms     uint16              `sunspec:"offset=17,access=rw"`
+	VArPct_RmpTms      uint16              `sunspec:"offset=18,access=rw"`
+	VArPct_Mod         sunspec.Enum16      `sunspec:"offset=19,access=rw"`
+	VArPct_Ena         sunspec.Enum16      `sunspec:"offset=20,access=rw"`
+	WMaxLimPct_SF      sunspec.ScaleFactor `sunspec:"offset=21"`
+	OutPFSet_SF        sunspec.ScaleFactor `sunspec:"offset=22"`
+	VArPct_SF          sunspec.ScaleFactor `sunspec:"offset=23"`
 }
 
 func (block *Block123) GetId() sunspec.ModelId {
@@ -87,30 +87,30 @@ func init() {
 				Length: 24,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Conn_WinTms, Offset: 0, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "Conn_WinTms", Description: "Time window for connect/disconnect."},
-					{Id: Conn_RvrtTms, Offset: 1, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "Conn_RvrtTms", Description: "Timeout period for connect/disconnect."},
-					{Id: Conn, Offset: 2, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Conn", Description: "Enumerated valued.  Connection control."},
-					{Id: WMaxLimPct, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "WMaxLimPct_SF", Units: "% WMax", Access: "rw", Length: 1, Mandatory: true, Label: "WMaxLimPct", Description: "Set power output to specified level."},
-					{Id: WMaxLimPct_WinTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WMaxLimPct_WinTms", Description: "Time window for power limit change."},
-					{Id: WMaxLimPct_RvrtTms, Offset: 5, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WMaxLimPct_RvrtTms", Description: "Timeout period for power limit."},
-					{Id: WMaxLimPct_RmpTms, Offset: 6, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WMaxLimPct_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
-					{Id: WMaxLim_Ena, Offset: 7, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "WMaxLim_Ena", Description: "Enumerated valued.  Throttle enable/disable control."},
-					{Id: OutPFSet, Offset: 8, Type: typelabel.Int16, ScaleFactor: "OutPFSet_SF", Units: "cos()", Access: "rw", Length: 1, Mandatory: true, Label: "OutPFSet", Description: "Set power factor to specific value - cosine of angle."},
-					{Id: OutPFSet_WinTms, Offset: 9, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "OutPFSet_WinTms", Description: "Time window for power factor change."},
-					{Id: OutPFSet_RvrtTms, Offset: 10, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "OutPFSet_RvrtTms", Description: "Timeout period for power factor."},
-					{Id: OutPFSet_RmpTms, Offset: 11, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "OutPFSet_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
-					{Id: OutPFSet_Ena, Offset: 12, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "OutPFSet_Ena", Description: "Enumerated valued.  Fixed power factor enable/disable control."},
-					{Id: VArWMaxPct, Offset: 13, Type: typelabel.Int16, ScaleFactor: "VArPct_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "VArWMaxPct", Description: "Reactive power in percent of WMax."},
-					{Id: VArMaxPct, Offset: 14, Type: typelabel.Int16, ScaleFactor: "VArPct_SF", Units: "% VArMax", Access: "rw", Length: 1, Label: "VArMaxPct", Description: "Reactive power in percent of VArMax."},
-					{Id: VArAvalPct, Offset: 15, Type: typelabel.Int16, ScaleFactor: "VArPct_SF", Units: "% VArAval", Access: "rw", Length: 1, Label: "VArAvalPct", Description: "Reactive power in percent of VArAval."},
-					{Id: VArPct_WinTms, Offset: 16, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "VArPct_WinTms", Description: "Time window for VAR limit change."},
-					{Id: VArPct_RvrtTms, Offset: 17, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "VArPct_RvrtTms", Description: "Timeout period for VAR limit."},
-					{Id: VArPct_RmpTms, Offset: 18, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "VArPct_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
-					{Id: VArPct_Mod, Offset: 19, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "VArPct_Mod", Description: "Enumerated value. VAR percent limit mode."},
-					{Id: VArPct_Ena, Offset: 20, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "VArPct_Ena", Description: "Enumerated valued.  Percent limit VAr enable/disable control."},
-					{Id: WMaxLimPct_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "WMaxLimPct_SF", Description: "Scale factor for power output percent."},
-					{Id: OutPFSet_SF, Offset: 22, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "OutPFSet_SF", Description: "Scale factor for power factor."},
-					{Id: VArPct_SF, Offset: 23, Type: typelabel.ScaleFactor, Length: 1, Label: "VArPct_SF", Description: "Scale factor for reactive power percent."},
+					{Id: Conn_WinTms, Offset: 0, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "Conn_WinTms", Description: "Time window for connect/disconnect."},
+					{Id: Conn_RvrtTms, Offset: 1, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "Conn_RvrtTms", Description: "Timeout period for connect/disconnect."},
+					{Id: Conn, Offset: 2, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Conn", Description: "Enumerated valued.  Connection control."},
+					{Id: WMaxLimPct, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "WMaxLimPct_SF", Units: "% WMax", Access: "rw", Mandatory: true, Label: "WMaxLimPct", Description: "Set power output to specified level."},
+					{Id: WMaxLimPct_WinTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WMaxLimPct_WinTms", Description: "Time window for power limit change."},
+					{Id: WMaxLimPct_RvrtTms, Offset: 5, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WMaxLimPct_RvrtTms", Description: "Timeout period for power limit."},
+					{Id: WMaxLimPct_RmpTms, Offset: 6, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WMaxLimPct_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
+					{Id: WMaxLim_Ena, Offset: 7, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "WMaxLim_Ena", Description: "Enumerated valued.  Throttle enable/disable control."},
+					{Id: OutPFSet, Offset: 8, Type: typelabel.Int16, ScaleFactor: "OutPFSet_SF", Units: "cos()", Access: "rw", Mandatory: true, Label: "OutPFSet", Description: "Set power factor to specific value - cosine of angle."},
+					{Id: OutPFSet_WinTms, Offset: 9, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "OutPFSet_WinTms", Description: "Time window for power factor change."},
+					{Id: OutPFSet_RvrtTms, Offset: 10, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "OutPFSet_RvrtTms", Description: "Timeout period for power factor."},
+					{Id: OutPFSet_RmpTms, Offset: 11, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "OutPFSet_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
+					{Id: OutPFSet_Ena, Offset: 12, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "OutPFSet_Ena", Description: "Enumerated valued.  Fixed power factor enable/disable control."},
+					{Id: VArWMaxPct, Offset: 13, Type: typelabel.Int16, ScaleFactor: "VArPct_SF", Units: "% WMax", Access: "rw", Label: "VArWMaxPct", Description: "Reactive power in percent of WMax."},
+					{Id: VArMaxPct, Offset: 14, Type: typelabel.Int16, ScaleFactor: "VArPct_SF", Units: "% VArMax", Access: "rw", Label: "VArMaxPct", Description: "Reactive power in percent of VArMax."},
+					{Id: VArAvalPct, Offset: 15, Type: typelabel.Int16, ScaleFactor: "VArPct_SF", Units: "% VArAval", Access: "rw", Label: "VArAvalPct", Description: "Reactive power in percent of VArAval."},
+					{Id: VArPct_WinTms, Offset: 16, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "VArPct_WinTms", Description: "Time window for VAR limit change."},
+					{Id: VArPct_RvrtTms, Offset: 17, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "VArPct_RvrtTms", Description: "Timeout period for VAR limit."},
+					{Id: VArPct_RmpTms, Offset: 18, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "VArPct_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
+					{Id: VArPct_Mod, Offset: 19, Type: typelabel.Enum16, Access: "rw", Label: "VArPct_Mod", Description: "Enumerated value. VAR percent limit mode."},
+					{Id: VArPct_Ena, Offset: 20, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "VArPct_Ena", Description: "Enumerated valued.  Percent limit VAr enable/disable control."},
+					{Id: WMaxLimPct_SF, Offset: 21, Type: typelabel.ScaleFactor, Mandatory: true, Label: "WMaxLimPct_SF", Description: "Scale factor for power output percent."},
+					{Id: OutPFSet_SF, Offset: 22, Type: typelabel.ScaleFactor, Mandatory: true, Label: "OutPFSet_SF", Description: "Scale factor for power factor."},
+					{Id: VArPct_SF, Offset: 23, Type: typelabel.ScaleFactor, Label: "VArPct_SF", Description: "Scale factor for reactive power percent."},
 				},
 			},
 		}})

--- a/models/model124/model.go
+++ b/models/model124/model.go
@@ -45,30 +45,30 @@ const (
 )
 
 type Block124 struct {
-	WChaMax           uint16              `sunspec:"offset=0,len=1,sf=WChaMax_SF,access=rw"`
-	WChaGra           uint16              `sunspec:"offset=1,len=1,sf=WChaDisChaGra_SF,access=rw"`
-	WDisChaGra        uint16              `sunspec:"offset=2,len=1,sf=WChaDisChaGra_SF,access=rw"`
-	StorCtl_Mod       sunspec.Bitfield16  `sunspec:"offset=3,len=1,access=rw"`
-	VAChaMax          uint16              `sunspec:"offset=4,len=1,sf=VAChaMax_SF,access=rw"`
-	MinRsvPct         uint16              `sunspec:"offset=5,len=1,sf=MinRsvPct_SF,access=rw"`
-	ChaState          uint16              `sunspec:"offset=6,len=1,sf=ChaState_SF"`
-	StorAval          uint16              `sunspec:"offset=7,len=1,sf=StorAval_SF"`
-	InBatV            uint16              `sunspec:"offset=8,len=1,sf=InBatV_SF"`
-	ChaSt             sunspec.Enum16      `sunspec:"offset=9,len=1"`
-	OutWRte           int16               `sunspec:"offset=10,len=1,sf=InOutWRte_SF,access=rw"`
-	InWRte            int16               `sunspec:"offset=11,len=1,sf=InOutWRte_SF,access=rw"`
-	InOutWRte_WinTms  uint16              `sunspec:"offset=12,len=1,access=rw"`
-	InOutWRte_RvrtTms uint16              `sunspec:"offset=13,len=1,access=rw"`
-	InOutWRte_RmpTms  uint16              `sunspec:"offset=14,len=1,access=rw"`
-	ChaGriSet         sunspec.Enum16      `sunspec:"offset=15,len=1,access=rw"`
-	WChaMax_SF        sunspec.ScaleFactor `sunspec:"offset=16,len=1"`
-	WChaDisChaGra_SF  sunspec.ScaleFactor `sunspec:"offset=17,len=1"`
-	VAChaMax_SF       sunspec.ScaleFactor `sunspec:"offset=18,len=1"`
-	MinRsvPct_SF      sunspec.ScaleFactor `sunspec:"offset=19,len=1"`
-	ChaState_SF       sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	StorAval_SF       sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	InBatV_SF         sunspec.ScaleFactor `sunspec:"offset=22,len=1"`
-	InOutWRte_SF      sunspec.ScaleFactor `sunspec:"offset=23,len=1"`
+	WChaMax           uint16              `sunspec:"offset=0,sf=WChaMax_SF,access=rw"`
+	WChaGra           uint16              `sunspec:"offset=1,sf=WChaDisChaGra_SF,access=rw"`
+	WDisChaGra        uint16              `sunspec:"offset=2,sf=WChaDisChaGra_SF,access=rw"`
+	StorCtl_Mod       sunspec.Bitfield16  `sunspec:"offset=3,access=rw"`
+	VAChaMax          uint16              `sunspec:"offset=4,sf=VAChaMax_SF,access=rw"`
+	MinRsvPct         uint16              `sunspec:"offset=5,sf=MinRsvPct_SF,access=rw"`
+	ChaState          uint16              `sunspec:"offset=6,sf=ChaState_SF"`
+	StorAval          uint16              `sunspec:"offset=7,sf=StorAval_SF"`
+	InBatV            uint16              `sunspec:"offset=8,sf=InBatV_SF"`
+	ChaSt             sunspec.Enum16      `sunspec:"offset=9"`
+	OutWRte           int16               `sunspec:"offset=10,sf=InOutWRte_SF,access=rw"`
+	InWRte            int16               `sunspec:"offset=11,sf=InOutWRte_SF,access=rw"`
+	InOutWRte_WinTms  uint16              `sunspec:"offset=12,access=rw"`
+	InOutWRte_RvrtTms uint16              `sunspec:"offset=13,access=rw"`
+	InOutWRte_RmpTms  uint16              `sunspec:"offset=14,access=rw"`
+	ChaGriSet         sunspec.Enum16      `sunspec:"offset=15,access=rw"`
+	WChaMax_SF        sunspec.ScaleFactor `sunspec:"offset=16"`
+	WChaDisChaGra_SF  sunspec.ScaleFactor `sunspec:"offset=17"`
+	VAChaMax_SF       sunspec.ScaleFactor `sunspec:"offset=18"`
+	MinRsvPct_SF      sunspec.ScaleFactor `sunspec:"offset=19"`
+	ChaState_SF       sunspec.ScaleFactor `sunspec:"offset=20"`
+	StorAval_SF       sunspec.ScaleFactor `sunspec:"offset=21"`
+	InBatV_SF         sunspec.ScaleFactor `sunspec:"offset=22"`
+	InOutWRte_SF      sunspec.ScaleFactor `sunspec:"offset=23"`
 }
 
 func (block *Block124) GetId() sunspec.ModelId {
@@ -87,30 +87,30 @@ func init() {
 				Length: 24,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: WChaMax, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "WChaMax_SF", Units: "W", Access: "rw", Length: 1, Mandatory: true, Label: "WChaMax", Description: "Setpoint for maximum charge."},
-					{Id: WChaGra, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaGra_SF", Units: "% WChaMax/sec", Access: "rw", Length: 1, Mandatory: true, Label: "WChaGra", Description: "Setpoint for maximum charging rate. Default is MaxChaRte."},
-					{Id: WDisChaGra, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaGra_SF", Units: "% WChaMax/sec", Access: "rw", Length: 1, Mandatory: true, Label: "WDisChaGra", Description: "Setpoint for maximum discharge rate. Default is MaxDisChaRte."},
-					{Id: StorCtl_Mod, Offset: 3, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "StorCtl_Mod", Description: "Activate hold/discharge/charge storage control mode. Bitfield value."},
-					{Id: VAChaMax, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "VAChaMax_SF", Units: "VA", Access: "rw", Length: 1, Label: "VAChaMax", Description: "Setpoint for maximum charging VA."},
-					{Id: MinRsvPct, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "MinRsvPct_SF", Units: "% WChaMax", Access: "rw", Length: 1, Label: "MinRsvPct", Description: "Setpoint for minimum reserve for storage as a percentage of the nominal maximum storage."},
-					{Id: ChaState, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "ChaState_SF", Units: "% AhrRtg", Length: 1, Label: "ChaState", Description: "Currently available energy as a percent of the capacity rating."},
-					{Id: StorAval, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "StorAval_SF", Units: "AH", Length: 1, Label: "StorAval", Description: "State of charge (ChaState) minus storage reserve (MinRsvPct) times capacity rating (AhrRtg)."},
-					{Id: InBatV, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "InBatV_SF", Units: "V", Length: 1, Label: "InBatV", Description: "Internal battery voltage."},
-					{Id: ChaSt, Offset: 9, Type: typelabel.Enum16, Length: 1, Label: "ChaSt", Description: "Charge status of storage device. Enumerated value."},
-					{Id: OutWRte, Offset: 10, Type: typelabel.Int16, ScaleFactor: "InOutWRte_SF", Units: "% WDisChaMax", Access: "rw", Length: 1, Label: "OutWRte", Description: "Percent of max discharge rate."},
-					{Id: InWRte, Offset: 11, Type: typelabel.Int16, ScaleFactor: "InOutWRte_SF", Units: " % WChaMax", Access: "rw", Length: 1, Label: "InWRte", Description: "Percent of max charging rate."},
-					{Id: InOutWRte_WinTms, Offset: 12, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "InOutWRte_WinTms", Description: "Time window for charge/discharge rate change."},
-					{Id: InOutWRte_RvrtTms, Offset: 13, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "InOutWRte_RvrtTms", Description: "Timeout period for charge/discharge rate."},
-					{Id: InOutWRte_RmpTms, Offset: 14, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "InOutWRte_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
-					{Id: ChaGriSet, Offset: 15, Type: typelabel.Enum16, Access: "rw", Length: 1},
-					{Id: WChaMax_SF, Offset: 16, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "WChaMax_SF", Description: "Scale factor for maximum charge."},
-					{Id: WChaDisChaGra_SF, Offset: 17, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "WChaDisChaGra_SF", Description: "Scale factor for maximum charge and discharge rate."},
-					{Id: VAChaMax_SF, Offset: 18, Type: typelabel.ScaleFactor, Length: 1, Label: "VAChaMax_SF", Description: "Scale factor for maximum charging VA."},
-					{Id: MinRsvPct_SF, Offset: 19, Type: typelabel.ScaleFactor, Length: 1, Label: "MinRsvPct_SF", Description: "Scale factor for minimum reserve percentage."},
-					{Id: ChaState_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Label: "ChaState_SF", Description: "Scale factor for available energy percent."},
-					{Id: StorAval_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1, Label: "StorAval_SF", Description: "Scale factor for state of charge."},
-					{Id: InBatV_SF, Offset: 22, Type: typelabel.ScaleFactor, Length: 1, Label: "InBatV_SF", Description: "Scale factor for battery voltage."},
-					{Id: InOutWRte_SF, Offset: 23, Type: typelabel.ScaleFactor, Length: 1, Label: "InOutWRte_SF", Description: "Scale factor for percent charge/discharge rate."},
+					{Id: WChaMax, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "WChaMax_SF", Units: "W", Access: "rw", Mandatory: true, Label: "WChaMax", Description: "Setpoint for maximum charge."},
+					{Id: WChaGra, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaGra_SF", Units: "% WChaMax/sec", Access: "rw", Mandatory: true, Label: "WChaGra", Description: "Setpoint for maximum charging rate. Default is MaxChaRte."},
+					{Id: WDisChaGra, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaGra_SF", Units: "% WChaMax/sec", Access: "rw", Mandatory: true, Label: "WDisChaGra", Description: "Setpoint for maximum discharge rate. Default is MaxDisChaRte."},
+					{Id: StorCtl_Mod, Offset: 3, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "StorCtl_Mod", Description: "Activate hold/discharge/charge storage control mode. Bitfield value."},
+					{Id: VAChaMax, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "VAChaMax_SF", Units: "VA", Access: "rw", Label: "VAChaMax", Description: "Setpoint for maximum charging VA."},
+					{Id: MinRsvPct, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "MinRsvPct_SF", Units: "% WChaMax", Access: "rw", Label: "MinRsvPct", Description: "Setpoint for minimum reserve for storage as a percentage of the nominal maximum storage."},
+					{Id: ChaState, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "ChaState_SF", Units: "% AhrRtg", Label: "ChaState", Description: "Currently available energy as a percent of the capacity rating."},
+					{Id: StorAval, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "StorAval_SF", Units: "AH", Label: "StorAval", Description: "State of charge (ChaState) minus storage reserve (MinRsvPct) times capacity rating (AhrRtg)."},
+					{Id: InBatV, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "InBatV_SF", Units: "V", Label: "InBatV", Description: "Internal battery voltage."},
+					{Id: ChaSt, Offset: 9, Type: typelabel.Enum16, Label: "ChaSt", Description: "Charge status of storage device. Enumerated value."},
+					{Id: OutWRte, Offset: 10, Type: typelabel.Int16, ScaleFactor: "InOutWRte_SF", Units: "% WDisChaMax", Access: "rw", Label: "OutWRte", Description: "Percent of max discharge rate."},
+					{Id: InWRte, Offset: 11, Type: typelabel.Int16, ScaleFactor: "InOutWRte_SF", Units: " % WChaMax", Access: "rw", Label: "InWRte", Description: "Percent of max charging rate."},
+					{Id: InOutWRte_WinTms, Offset: 12, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "InOutWRte_WinTms", Description: "Time window for charge/discharge rate change."},
+					{Id: InOutWRte_RvrtTms, Offset: 13, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "InOutWRte_RvrtTms", Description: "Timeout period for charge/discharge rate."},
+					{Id: InOutWRte_RmpTms, Offset: 14, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "InOutWRte_RmpTms", Description: "Ramp time for moving from current setpoint to new setpoint."},
+					{Id: ChaGriSet, Offset: 15, Type: typelabel.Enum16, Access: "rw"},
+					{Id: WChaMax_SF, Offset: 16, Type: typelabel.ScaleFactor, Mandatory: true, Label: "WChaMax_SF", Description: "Scale factor for maximum charge."},
+					{Id: WChaDisChaGra_SF, Offset: 17, Type: typelabel.ScaleFactor, Mandatory: true, Label: "WChaDisChaGra_SF", Description: "Scale factor for maximum charge and discharge rate."},
+					{Id: VAChaMax_SF, Offset: 18, Type: typelabel.ScaleFactor, Label: "VAChaMax_SF", Description: "Scale factor for maximum charging VA."},
+					{Id: MinRsvPct_SF, Offset: 19, Type: typelabel.ScaleFactor, Label: "MinRsvPct_SF", Description: "Scale factor for minimum reserve percentage."},
+					{Id: ChaState_SF, Offset: 20, Type: typelabel.ScaleFactor, Label: "ChaState_SF", Description: "Scale factor for available energy percent."},
+					{Id: StorAval_SF, Offset: 21, Type: typelabel.ScaleFactor, Label: "StorAval_SF", Description: "Scale factor for state of charge."},
+					{Id: InBatV_SF, Offset: 22, Type: typelabel.ScaleFactor, Label: "InBatV_SF", Description: "Scale factor for battery voltage."},
+					{Id: InOutWRte_SF, Offset: 23, Type: typelabel.ScaleFactor, Label: "InOutWRte_SF", Description: "Scale factor for percent charge/discharge rate."},
 				},
 			},
 		}})

--- a/models/model125/model.go
+++ b/models/model125/model.go
@@ -29,14 +29,14 @@ const (
 )
 
 type Block125 struct {
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=0,len=1,access=rw"`
-	SigType sunspec.Enum16      `sunspec:"offset=1,len=1,access=rw"`
-	Sig     int16               `sunspec:"offset=2,len=1,sf=Sig_SF,access=rw"`
-	WinTms  uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RvtTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=5,len=1,access=rw"`
-	Sig_SF  sunspec.ScaleFactor `sunspec:"offset=6,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=7,len=1"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=0,access=rw"`
+	SigType sunspec.Enum16      `sunspec:"offset=1,access=rw"`
+	Sig     int16               `sunspec:"offset=2,sf=Sig_SF,access=rw"`
+	WinTms  uint16              `sunspec:"offset=3,access=rw"`
+	RvtTms  uint16              `sunspec:"offset=4,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=5,access=rw"`
+	Sig_SF  sunspec.ScaleFactor `sunspec:"offset=6"`
+	Pad     sunspec.Pad         `sunspec:"offset=7"`
 }
 
 func (block *Block125) GetId() sunspec.ModelId {
@@ -55,14 +55,14 @@ func init() {
 				Length: 8,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ModEna, Offset: 0, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is price-based charge/discharge mode active?"},
-					{Id: SigType, Offset: 1, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "SigType", Description: "Meaning of the pricing signal. When a Price schedule is used, type must match the schedule range variable description."},
-					{Id: Sig, Offset: 2, Type: typelabel.Int16, ScaleFactor: "Sig_SF", Access: "rw", Length: 1, Mandatory: true, Label: "Sig", Description: "Utility/ESP specific pricing signal. Content depends on pricing signal type. When H/M/L type is specified. Low=0; Med=1; High=2."},
-					{Id: WinTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for charge/discharge pricing change."},
-					{Id: RvtTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvtTms", Description: "Timeout period for charge/discharge pricing change."},
-					{Id: RmpTms, Offset: 5, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current charge or discharge level to new level."},
-					{Id: Sig_SF, Offset: 6, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Sig_SF", Description: "Pricing signal scale factor."},
-					{Id: Pad, Offset: 7, Type: typelabel.Pad, Length: 1},
+					{Id: ModEna, Offset: 0, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is price-based charge/discharge mode active?"},
+					{Id: SigType, Offset: 1, Type: typelabel.Enum16, Access: "rw", Label: "SigType", Description: "Meaning of the pricing signal. When a Price schedule is used, type must match the schedule range variable description."},
+					{Id: Sig, Offset: 2, Type: typelabel.Int16, ScaleFactor: "Sig_SF", Access: "rw", Mandatory: true, Label: "Sig", Description: "Utility/ESP specific pricing signal. Content depends on pricing signal type. When H/M/L type is specified. Low=0; Med=1; High=2."},
+					{Id: WinTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for charge/discharge pricing change."},
+					{Id: RvtTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvtTms", Description: "Timeout period for charge/discharge pricing change."},
+					{Id: RmpTms, Offset: 5, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current charge or discharge level to new level."},
+					{Id: Sig_SF, Offset: 6, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Sig_SF", Description: "Pricing signal scale factor."},
+					{Id: Pad, Offset: 7, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model126/model.go
+++ b/models/model126/model.go
@@ -77,66 +77,66 @@ const (
 )
 
 type Block126Repeat struct {
-	ActPt     uint16         `sunspec:"offset=0,len=1,access=rw"`
-	DeptRef   sunspec.Enum16 `sunspec:"offset=1,len=1,access=rw"`
-	V1        uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	VAr1      int16          `sunspec:"offset=3,len=1,sf=DeptRef_SF,access=rw"`
-	V2        uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	VAr2      int16          `sunspec:"offset=5,len=1,sf=DeptRef_SF,access=rw"`
-	V3        uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	VAr3      int16          `sunspec:"offset=7,len=1,sf=DeptRef_SF,access=rw"`
-	V4        uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	VAr4      int16          `sunspec:"offset=9,len=1,sf=DeptRef_SF,access=rw"`
-	V5        uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	VAr5      int16          `sunspec:"offset=11,len=1,sf=DeptRef_SF,access=rw"`
-	V6        uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	VAr6      int16          `sunspec:"offset=13,len=1,sf=DeptRef_SF,access=rw"`
-	V7        uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	VAr7      int16          `sunspec:"offset=15,len=1,sf=DeptRef_SF,access=rw"`
-	V8        uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	VAr8      int16          `sunspec:"offset=17,len=1,sf=DeptRef_SF,access=rw"`
-	V9        uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	VAr9      int16          `sunspec:"offset=19,len=1,sf=DeptRef_SF,access=rw"`
-	V10       uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	VAr10     int16          `sunspec:"offset=21,len=1,sf=DeptRef_SF,access=rw"`
-	V11       uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	VAr11     int16          `sunspec:"offset=23,len=1,sf=DeptRef_SF,access=rw"`
-	V12       uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	VAr12     int16          `sunspec:"offset=25,len=1,sf=DeptRef_SF,access=rw"`
-	V13       uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	VAr13     int16          `sunspec:"offset=27,len=1,sf=DeptRef_SF,access=rw"`
-	V14       uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	VAr14     int16          `sunspec:"offset=29,len=1,sf=DeptRef_SF,access=rw"`
-	V15       uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	VAr15     int16          `sunspec:"offset=31,len=1,sf=DeptRef_SF,access=rw"`
-	V16       uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	VAr16     int16          `sunspec:"offset=33,len=1,sf=DeptRef_SF,access=rw"`
-	V17       uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	VAr17     int16          `sunspec:"offset=35,len=1,sf=DeptRef_SF,access=rw"`
-	V18       uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	VAr18     int16          `sunspec:"offset=37,len=1,sf=DeptRef_SF,access=rw"`
-	V19       uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	VAr19     int16          `sunspec:"offset=39,len=1,sf=DeptRef_SF,access=rw"`
-	V20       uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
-	VAr20     int16          `sunspec:"offset=41,len=1,sf=DeptRef_SF,access=rw"`
+	ActPt     uint16         `sunspec:"offset=0,access=rw"`
+	DeptRef   sunspec.Enum16 `sunspec:"offset=1,access=rw"`
+	V1        uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	VAr1      int16          `sunspec:"offset=3,sf=DeptRef_SF,access=rw"`
+	V2        uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	VAr2      int16          `sunspec:"offset=5,sf=DeptRef_SF,access=rw"`
+	V3        uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	VAr3      int16          `sunspec:"offset=7,sf=DeptRef_SF,access=rw"`
+	V4        uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	VAr4      int16          `sunspec:"offset=9,sf=DeptRef_SF,access=rw"`
+	V5        uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	VAr5      int16          `sunspec:"offset=11,sf=DeptRef_SF,access=rw"`
+	V6        uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	VAr6      int16          `sunspec:"offset=13,sf=DeptRef_SF,access=rw"`
+	V7        uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	VAr7      int16          `sunspec:"offset=15,sf=DeptRef_SF,access=rw"`
+	V8        uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	VAr8      int16          `sunspec:"offset=17,sf=DeptRef_SF,access=rw"`
+	V9        uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	VAr9      int16          `sunspec:"offset=19,sf=DeptRef_SF,access=rw"`
+	V10       uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	VAr10     int16          `sunspec:"offset=21,sf=DeptRef_SF,access=rw"`
+	V11       uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	VAr11     int16          `sunspec:"offset=23,sf=DeptRef_SF,access=rw"`
+	V12       uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	VAr12     int16          `sunspec:"offset=25,sf=DeptRef_SF,access=rw"`
+	V13       uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	VAr13     int16          `sunspec:"offset=27,sf=DeptRef_SF,access=rw"`
+	V14       uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	VAr14     int16          `sunspec:"offset=29,sf=DeptRef_SF,access=rw"`
+	V15       uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	VAr15     int16          `sunspec:"offset=31,sf=DeptRef_SF,access=rw"`
+	V16       uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	VAr16     int16          `sunspec:"offset=33,sf=DeptRef_SF,access=rw"`
+	V17       uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	VAr17     int16          `sunspec:"offset=35,sf=DeptRef_SF,access=rw"`
+	V18       uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	VAr18     int16          `sunspec:"offset=37,sf=DeptRef_SF,access=rw"`
+	V19       uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	VAr19     int16          `sunspec:"offset=39,sf=DeptRef_SF,access=rw"`
+	V20       uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
+	VAr20     int16          `sunspec:"offset=41,sf=DeptRef_SF,access=rw"`
 	CrvNam    string         `sunspec:"offset=42,len=8,access=rw"`
-	RmpTms    uint16         `sunspec:"offset=50,len=1,access=rw"`
-	RmpDecTmm uint16         `sunspec:"offset=51,len=1,sf=RmpIncDec_SF,access=rw"`
-	RmpIncTmm uint16         `sunspec:"offset=52,len=1,sf=RmpIncDec_SF,access=rw"`
-	ReadOnly  sunspec.Enum16 `sunspec:"offset=53,len=1"`
+	RmpTms    uint16         `sunspec:"offset=50,access=rw"`
+	RmpDecTmm uint16         `sunspec:"offset=51,sf=RmpIncDec_SF,access=rw"`
+	RmpIncTmm uint16         `sunspec:"offset=52,sf=RmpIncDec_SF,access=rw"`
+	ReadOnly  sunspec.Enum16 `sunspec:"offset=53"`
 }
 
 type Block126 struct {
-	ActCrv       uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms       uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms      uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms       uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv         uint16              `sunspec:"offset=5,len=1"`
-	NPt          uint16              `sunspec:"offset=6,len=1"`
-	V_SF         sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	DeptRef_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
+	ActCrv       uint16              `sunspec:"offset=0,access=rw"`
+	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms       uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms      uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms       uint16              `sunspec:"offset=4,access=rw"`
+	NCrv         uint16              `sunspec:"offset=5"`
+	NPt          uint16              `sunspec:"offset=6"`
+	V_SF         sunspec.ScaleFactor `sunspec:"offset=7"`
+	DeptRef_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9"`
 
 	Repeats []Block126Repeat
 }
@@ -157,69 +157,69 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is Volt-VAR control active."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for volt-VAR change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for volt-VAR curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: V_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: DeptRef_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "DeptRef_SF", Description: "scale factor for dependent variable."},
-					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is Volt-VAR control active."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for volt-VAR change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for volt-VAR curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: V_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: DeptRef_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "DeptRef_SF", Description: "scale factor for dependent variable."},
+					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor},
 				},
 			},
 			{Name: "curve",
 				Length: 54,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: DeptRef, Offset: 1, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "DeptRef", Description: "Meaning of dependent variable: 1=%WMax 2=%VArMax 3=%VArAval."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 Volts."},
-					{Id: VAr1, Offset: 3, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Mandatory: true, Label: "VAr1", Description: "Point 1 VARs."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 Volts."},
-					{Id: VAr2, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr2", Description: "Point 2 VARs."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 2 Volts."},
-					{Id: VAr3, Offset: 7, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr3", Description: "Point 3 VARs."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 Volts."},
-					{Id: VAr4, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr4", Description: "Point 4 VARs."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 Volts."},
-					{Id: VAr5, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr5", Description: "Point 5 VARs."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 Volts."},
-					{Id: VAr6, Offset: 13, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr6", Description: "Point 6 VARs."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 Volts."},
-					{Id: VAr7, Offset: 15, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr7", Description: "Point 7 VARs."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 Volts."},
-					{Id: VAr8, Offset: 17, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr8", Description: "Point 8 VARs."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 Volts."},
-					{Id: VAr9, Offset: 19, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr9", Description: "Point 9 VARs."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 Volts."},
-					{Id: VAr10, Offset: 21, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr10", Description: "Point 10 VARs."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 Volts."},
-					{Id: VAr11, Offset: 23, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr11", Description: "Point 11 VARs."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 Volts."},
-					{Id: VAr12, Offset: 25, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr12", Description: "Point 12 VARs."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 Volts."},
-					{Id: VAr13, Offset: 27, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr13", Description: "Point 13 VARs."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 Volts."},
-					{Id: VAr14, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr14", Description: "Point 14 VARs."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 Volts."},
-					{Id: VAr15, Offset: 31, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr15", Description: "Point 15 VARs."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 Volts."},
-					{Id: VAr16, Offset: 33, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr16", Description: "Point 16 VARs."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 Volts."},
-					{Id: VAr17, Offset: 35, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr17", Description: "Point 17 VARs."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 Volts."},
-					{Id: VAr18, Offset: 37, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr18", Description: "Point 18 VARs."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 Volts."},
-					{Id: VAr19, Offset: 39, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr19", Description: "Point 19 VARs."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 Volts."},
-					{Id: VAr20, Offset: 41, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Length: 1, Label: "VAr20", Description: "Point 20 VARs."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: DeptRef, Offset: 1, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "DeptRef", Description: "Meaning of dependent variable: 1=%WMax 2=%VArMax 3=%VArAval."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 Volts."},
+					{Id: VAr1, Offset: 3, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Mandatory: true, Label: "VAr1", Description: "Point 1 VARs."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 Volts."},
+					{Id: VAr2, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr2", Description: "Point 2 VARs."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 2 Volts."},
+					{Id: VAr3, Offset: 7, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr3", Description: "Point 3 VARs."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 Volts."},
+					{Id: VAr4, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr4", Description: "Point 4 VARs."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 Volts."},
+					{Id: VAr5, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr5", Description: "Point 5 VARs."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 Volts."},
+					{Id: VAr6, Offset: 13, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr6", Description: "Point 6 VARs."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 Volts."},
+					{Id: VAr7, Offset: 15, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr7", Description: "Point 7 VARs."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 Volts."},
+					{Id: VAr8, Offset: 17, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr8", Description: "Point 8 VARs."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 Volts."},
+					{Id: VAr9, Offset: 19, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr9", Description: "Point 9 VARs."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 Volts."},
+					{Id: VAr10, Offset: 21, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr10", Description: "Point 10 VARs."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 Volts."},
+					{Id: VAr11, Offset: 23, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr11", Description: "Point 11 VARs."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 Volts."},
+					{Id: VAr12, Offset: 25, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr12", Description: "Point 12 VARs."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 Volts."},
+					{Id: VAr13, Offset: 27, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr13", Description: "Point 13 VARs."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 Volts."},
+					{Id: VAr14, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr14", Description: "Point 14 VARs."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 Volts."},
+					{Id: VAr15, Offset: 31, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr15", Description: "Point 15 VARs."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 Volts."},
+					{Id: VAr16, Offset: 33, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr16", Description: "Point 16 VARs."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 Volts."},
+					{Id: VAr17, Offset: 35, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr17", Description: "Point 17 VARs."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 Volts."},
+					{Id: VAr18, Offset: 37, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr18", Description: "Point 18 VARs."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 Volts."},
+					{Id: VAr19, Offset: 39, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr19", Description: "Point 19 VARs."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 Volts."},
+					{Id: VAr20, Offset: 41, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Access: "rw", Label: "VAr20", Description: "Point 20 VARs."},
 					{Id: CrvNam, Offset: 42, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve. (Max 16 chars)"},
-					{Id: RmpTms, Offset: 50, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
-					{Id: RmpDecTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% ref_value/min", Access: "rw", Length: 1, Label: "RmpDecTmm", Description: "The maximum rate at which the VAR value may be reduced in response to changes in the voltage value. %refVal is %WMax %VArMax or %VArAval depending on value of DeptRef."},
-					{Id: RmpIncTmm, Offset: 52, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% ref_value/min", Access: "rw", Length: 1, Label: "RmpIncTmm", Description: "The maximum rate at which the VAR value may be increased in response to changes in the voltage value. %refVal is %WMax %VArMax or %VArAval depending on value of DeptRef."},
-					{Id: ReadOnly, Offset: 53, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Boolean flag indicates if curve is read-only or can be modified."},
+					{Id: RmpTms, Offset: 50, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
+					{Id: RmpDecTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% ref_value/min", Access: "rw", Label: "RmpDecTmm", Description: "The maximum rate at which the VAR value may be reduced in response to changes in the voltage value. %refVal is %WMax %VArMax or %VArAval depending on value of DeptRef."},
+					{Id: RmpIncTmm, Offset: 52, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% ref_value/min", Access: "rw", Label: "RmpIncTmm", Description: "The maximum rate at which the VAR value may be increased in response to changes in the voltage value. %refVal is %WMax %VArMax or %VArAval depending on value of DeptRef."},
+					{Id: ReadOnly, Offset: 53, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Boolean flag indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model127/model.go
+++ b/models/model127/model.go
@@ -31,16 +31,16 @@ const (
 )
 
 type Block127 struct {
-	WGra         uint16              `sunspec:"offset=0,len=1,sf=WGra_SF,access=rw"`
-	HzStr        int16               `sunspec:"offset=1,len=1,sf=HzStrStop_SF,access=rw"`
-	HzStop       int16               `sunspec:"offset=2,len=1,sf=HzStrStop_SF,access=rw"`
-	HysEna       sunspec.Bitfield16  `sunspec:"offset=3,len=1,access=rw"`
-	ModEna       sunspec.Bitfield16  `sunspec:"offset=4,len=1,access=rw"`
-	HzStopWGra   uint16              `sunspec:"offset=5,len=1,sf=RmpIncDec_SF,access=rw"`
-	WGra_SF      sunspec.ScaleFactor `sunspec:"offset=6,len=1"`
-	HzStrStop_SF sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad          sunspec.Pad         `sunspec:"offset=9,len=1"`
+	WGra         uint16              `sunspec:"offset=0,sf=WGra_SF,access=rw"`
+	HzStr        int16               `sunspec:"offset=1,sf=HzStrStop_SF,access=rw"`
+	HzStop       int16               `sunspec:"offset=2,sf=HzStrStop_SF,access=rw"`
+	HysEna       sunspec.Bitfield16  `sunspec:"offset=3,access=rw"`
+	ModEna       sunspec.Bitfield16  `sunspec:"offset=4,access=rw"`
+	HzStopWGra   uint16              `sunspec:"offset=5,sf=RmpIncDec_SF,access=rw"`
+	WGra_SF      sunspec.ScaleFactor `sunspec:"offset=6"`
+	HzStrStop_SF sunspec.ScaleFactor `sunspec:"offset=7"`
+	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad          sunspec.Pad         `sunspec:"offset=9"`
 }
 
 func (block *Block127) GetId() sunspec.ModelId {
@@ -59,16 +59,16 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: WGra, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "WGra_SF", Units: "% PM/Hz", Access: "rw", Length: 1, Mandatory: true, Label: "WGra", Description: "The slope of the reduction in the maximum allowed watts output as a function of frequency."},
-					{Id: HzStr, Offset: 1, Type: typelabel.Int16, ScaleFactor: "HzStrStop_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "HzStr", Description: "The frequency deviation from nominal frequency (ECPNomHz) at which a snapshot of the instantaneous power output is taken to act as the CAPPED power level (PM) and above which reduction in power output occurs."},
-					{Id: HzStop, Offset: 2, Type: typelabel.Int16, ScaleFactor: "HzStrStop_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "HzStop", Description: "The frequency deviation from nominal frequency (ECPNomHz) at which curtailed power output may return to normal and the cap on the power level value is removed."},
-					{Id: HysEna, Offset: 3, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "HysEna", Description: "Enable hysteresis"},
-					{Id: ModEna, Offset: 4, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is Parameterized Frequency-Watt control active."},
-					{Id: HzStopWGra, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Length: 1, Label: "HzStopWGra", Description: "The maximum time-based rate of change at which power output returns to normal after having been capped by an over frequency event."},
-					{Id: WGra_SF, Offset: 6, Type: typelabel.ScaleFactor, Length: 1, Label: "WGra_SF", Description: "Scale factor for output gradient."},
-					{Id: HzStrStop_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Label: "HzStrStop_SF", Description: "Scale factor for frequency deviations."},
-					{Id: RmpIncDec_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: WGra, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "WGra_SF", Units: "% PM/Hz", Access: "rw", Mandatory: true, Label: "WGra", Description: "The slope of the reduction in the maximum allowed watts output as a function of frequency."},
+					{Id: HzStr, Offset: 1, Type: typelabel.Int16, ScaleFactor: "HzStrStop_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "HzStr", Description: "The frequency deviation from nominal frequency (ECPNomHz) at which a snapshot of the instantaneous power output is taken to act as the CAPPED power level (PM) and above which reduction in power output occurs."},
+					{Id: HzStop, Offset: 2, Type: typelabel.Int16, ScaleFactor: "HzStrStop_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "HzStop", Description: "The frequency deviation from nominal frequency (ECPNomHz) at which curtailed power output may return to normal and the cap on the power level value is removed."},
+					{Id: HysEna, Offset: 3, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "HysEna", Description: "Enable hysteresis"},
+					{Id: ModEna, Offset: 4, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is Parameterized Frequency-Watt control active."},
+					{Id: HzStopWGra, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Label: "HzStopWGra", Description: "The maximum time-based rate of change at which power output returns to normal after having been capped by an over frequency event."},
+					{Id: WGra_SF, Offset: 6, Type: typelabel.ScaleFactor, Label: "WGra_SF", Description: "Scale factor for output gradient."},
+					{Id: HzStrStop_SF, Offset: 7, Type: typelabel.ScaleFactor, Label: "HzStrStop_SF", Description: "Scale factor for frequency deviations."},
+					{Id: RmpIncDec_SF, Offset: 8, Type: typelabel.ScaleFactor, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model128/model.go
+++ b/models/model128/model.go
@@ -35,20 +35,20 @@ const (
 )
 
 type Block128 struct {
-	ArGraMod   sunspec.Enum16      `sunspec:"offset=0,len=1,access=rw"`
-	ArGraSag   uint16              `sunspec:"offset=1,len=1,sf=ArGra_SF,access=rw"`
-	ArGraSwell uint16              `sunspec:"offset=2,len=1,sf=ArGra_SF,access=rw"`
-	ModEna     sunspec.Bitfield16  `sunspec:"offset=3,len=1,access=rw"`
-	FilTms     uint16              `sunspec:"offset=4,len=1,access=rw"`
-	DbVMin     uint16              `sunspec:"offset=5,len=1,sf=VRefPct_SF,access=rw"`
-	DbVMax     uint16              `sunspec:"offset=6,len=1,sf=VRefPct_SF,access=rw"`
-	BlkZnV     uint16              `sunspec:"offset=7,len=1,sf=VRefPct_SF,access=rw"`
-	HysBlkZnV  uint16              `sunspec:"offset=8,len=1,sf=VRefPct_SF,access=rw"`
-	BlkZnTmms  uint16              `sunspec:"offset=9,len=1,access=rw"`
-	HoldTmms   uint16              `sunspec:"offset=10,len=1,access=rw"`
-	ArGra_SF   sunspec.ScaleFactor `sunspec:"offset=11,len=1"`
-	VRefPct_SF sunspec.ScaleFactor `sunspec:"offset=12,len=1"`
-	Pad        sunspec.Pad         `sunspec:"offset=13,len=1"`
+	ArGraMod   sunspec.Enum16      `sunspec:"offset=0,access=rw"`
+	ArGraSag   uint16              `sunspec:"offset=1,sf=ArGra_SF,access=rw"`
+	ArGraSwell uint16              `sunspec:"offset=2,sf=ArGra_SF,access=rw"`
+	ModEna     sunspec.Bitfield16  `sunspec:"offset=3,access=rw"`
+	FilTms     uint16              `sunspec:"offset=4,access=rw"`
+	DbVMin     uint16              `sunspec:"offset=5,sf=VRefPct_SF,access=rw"`
+	DbVMax     uint16              `sunspec:"offset=6,sf=VRefPct_SF,access=rw"`
+	BlkZnV     uint16              `sunspec:"offset=7,sf=VRefPct_SF,access=rw"`
+	HysBlkZnV  uint16              `sunspec:"offset=8,sf=VRefPct_SF,access=rw"`
+	BlkZnTmms  uint16              `sunspec:"offset=9,access=rw"`
+	HoldTmms   uint16              `sunspec:"offset=10,access=rw"`
+	ArGra_SF   sunspec.ScaleFactor `sunspec:"offset=11"`
+	VRefPct_SF sunspec.ScaleFactor `sunspec:"offset=12"`
+	Pad        sunspec.Pad         `sunspec:"offset=13"`
 }
 
 func (block *Block128) GetId() sunspec.ModelId {
@@ -67,20 +67,20 @@ func init() {
 				Length: 14,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ArGraMod, Offset: 0, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "ArGraMod", Description: "Indicates if gradients trend toward zero at the edges of the deadband or trend toward zero at the center of the deadband."},
-					{Id: ArGraSag, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "ArGra_SF", Units: "%ARtg/%dV", Access: "rw", Length: 1, Mandatory: true, Label: "ArGraSag", Description: "The gradient used to increase capacitive dynamic current. A value of 0 indicates no additional reactive current support."},
-					{Id: ArGraSwell, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "ArGra_SF", Units: "%ARtg/%dV", Access: "rw", Length: 1, Mandatory: true, Label: "ArGraSwell", Description: "The gradient used to increase inductive dynamic current.  A value of 0 indicates no additional reactive current support."},
-					{Id: ModEna, Offset: 3, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Activate dynamic reactive current model"},
-					{Id: FilTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "FilTms", Description: "The time window used to calculate the moving average voltage."},
-					{Id: DbVMin, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "DbVMin", Description: "The lower delta voltage limit for which negative voltage deviations less than this value no dynamic vars are produced."},
-					{Id: DbVMax, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "DbVMax", Description: "The upper delta voltage limit for which positive voltage deviations less than this value no dynamic current produced."},
-					{Id: BlkZnV, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "BlkZnV", Description: "Block zone voltage which defines a lower voltage boundary below which no dynamic current is produced."},
-					{Id: HysBlkZnV, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "HysBlkZnV", Description: "Hysteresis voltage used with BlkZnV."},
-					{Id: BlkZnTmms, Offset: 9, Type: typelabel.Uint16, Units: "mSecs", Access: "rw", Length: 1, Label: "BlkZnTmms", Description: "Block zone time the time before which reactive current support remains active regardless of how low the voltage drops."},
-					{Id: HoldTmms, Offset: 10, Type: typelabel.Uint16, Units: "mSecs", Access: "rw", Length: 1, Label: "HoldTmms", Description: "Hold time during which reactive current support continues after the average voltage has entered the dead zone."},
-					{Id: ArGra_SF, Offset: 11, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "ArGra_SF", Description: "Scale factor for the gradients."},
-					{Id: VRefPct_SF, Offset: 12, Type: typelabel.ScaleFactor, Length: 1, Label: "VRefPct_SF", Description: "Scale factor for the voltage zone and limit settings."},
-					{Id: Pad, Offset: 13, Type: typelabel.Pad, Length: 1},
+					{Id: ArGraMod, Offset: 0, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "ArGraMod", Description: "Indicates if gradients trend toward zero at the edges of the deadband or trend toward zero at the center of the deadband."},
+					{Id: ArGraSag, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "ArGra_SF", Units: "%ARtg/%dV", Access: "rw", Mandatory: true, Label: "ArGraSag", Description: "The gradient used to increase capacitive dynamic current. A value of 0 indicates no additional reactive current support."},
+					{Id: ArGraSwell, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "ArGra_SF", Units: "%ARtg/%dV", Access: "rw", Mandatory: true, Label: "ArGraSwell", Description: "The gradient used to increase inductive dynamic current.  A value of 0 indicates no additional reactive current support."},
+					{Id: ModEna, Offset: 3, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Activate dynamic reactive current model"},
+					{Id: FilTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "FilTms", Description: "The time window used to calculate the moving average voltage."},
+					{Id: DbVMin, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Label: "DbVMin", Description: "The lower delta voltage limit for which negative voltage deviations less than this value no dynamic vars are produced."},
+					{Id: DbVMax, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Label: "DbVMax", Description: "The upper delta voltage limit for which positive voltage deviations less than this value no dynamic current produced."},
+					{Id: BlkZnV, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Label: "BlkZnV", Description: "Block zone voltage which defines a lower voltage boundary below which no dynamic current is produced."},
+					{Id: HysBlkZnV, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "VRefPct_SF", Units: "% VRef", Access: "rw", Label: "HysBlkZnV", Description: "Hysteresis voltage used with BlkZnV."},
+					{Id: BlkZnTmms, Offset: 9, Type: typelabel.Uint16, Units: "mSecs", Access: "rw", Label: "BlkZnTmms", Description: "Block zone time the time before which reactive current support remains active regardless of how low the voltage drops."},
+					{Id: HoldTmms, Offset: 10, Type: typelabel.Uint16, Units: "mSecs", Access: "rw", Label: "HoldTmms", Description: "Hold time during which reactive current support continues after the average voltage has entered the dead zone."},
+					{Id: ArGra_SF, Offset: 11, Type: typelabel.ScaleFactor, Mandatory: true, Label: "ArGra_SF", Description: "Scale factor for the gradients."},
+					{Id: VRefPct_SF, Offset: 12, Type: typelabel.ScaleFactor, Label: "VRefPct_SF", Description: "Scale factor for the voltage zone and limit settings."},
+					{Id: Pad, Offset: 13, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model129/model.go
+++ b/models/model129/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block129Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	V1       uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	V2       uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	V3       uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	V4       uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	V5       uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	V6       uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	V7       uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	V8       uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	V9       uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	V10      uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	V11      uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	V12      uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	V13      uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	V14      uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	V15      uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	V16      uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	V17      uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	V18      uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	V19      uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	V20      uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	V1       uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	V2       uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	V3       uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	V4       uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	V5       uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	V6       uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	V7       uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	V8       uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	V9       uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	V10      uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	V11      uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	V12      uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	V13      uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	V14      uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	V15      uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	V16      uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	V17      uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	V18      uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	V19      uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	V20      uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block129 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block129Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LVRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LVRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 must disconnect voltage."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must disconnect duration."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 must disconnect voltage."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must disconnect duration."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 must disconnect voltage."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must disconnect duration."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 must disconnect voltage."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must disconnect duration."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 must disconnect voltage."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must disconnect duration."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 must disconnect voltage."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must disconnect duration."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 must disconnect voltage."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must disconnect duration."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 must disconnect voltage."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must disconnect duration."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 must disconnect voltage."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must disconnect duration."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 must disconnect voltage."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must disconnect duration."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 must disconnect voltage."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must disconnect duration."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 must disconnect voltage."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must disconnect duration."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 must disconnect voltage."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must disconnect duration."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 must disconnect voltage."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must disconnect duration."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 must disconnect voltage."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must disconnect duration."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 must disconnect voltage."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must disconnect duration."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 must disconnect voltage."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must disconnect duration."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 must disconnect voltage."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must disconnect duration."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 must disconnect voltage."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must disconnect duration."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 must disconnect voltage."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 must disconnect voltage."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must disconnect duration."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 must disconnect voltage."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must disconnect duration."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 must disconnect voltage."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must disconnect duration."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 must disconnect voltage."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must disconnect duration."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 must disconnect voltage."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must disconnect duration."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 must disconnect voltage."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must disconnect duration."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 must disconnect voltage."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must disconnect duration."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 must disconnect voltage."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must disconnect duration."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 must disconnect voltage."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must disconnect duration."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 must disconnect voltage."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must disconnect duration."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 must disconnect voltage."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must disconnect duration."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 must disconnect voltage."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must disconnect duration."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 must disconnect voltage."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must disconnect duration."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 must disconnect voltage."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must disconnect duration."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 must disconnect voltage."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must disconnect duration."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 must disconnect voltage."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must disconnect duration."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 must disconnect voltage."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must disconnect duration."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 must disconnect voltage."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must disconnect duration."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 must disconnect voltage."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must disconnect duration."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 must disconnect voltage."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model13/model.go
+++ b/models/model13/model.go
@@ -38,11 +38,11 @@ const (
 
 type Block13 struct {
 	Nam     string             `sunspec:"offset=0,len=4,access=rw"`
-	CfgSt   sunspec.Enum16     `sunspec:"offset=4,len=1"`
-	ChgSt   sunspec.Bitfield16 `sunspec:"offset=5,len=1"`
-	Cap     sunspec.Bitfield16 `sunspec:"offset=6,len=1"`
-	Cfg     sunspec.Enum16     `sunspec:"offset=7,len=1,access=rw"`
-	Ctl     sunspec.Enum16     `sunspec:"offset=8,len=1,access=rw"`
+	CfgSt   sunspec.Enum16     `sunspec:"offset=4"`
+	ChgSt   sunspec.Bitfield16 `sunspec:"offset=5"`
+	Cap     sunspec.Bitfield16 `sunspec:"offset=6"`
+	Cfg     sunspec.Enum16     `sunspec:"offset=7,access=rw"`
+	Ctl     sunspec.Enum16     `sunspec:"offset=8,access=rw"`
 	Addr    string             `sunspec:"offset=9,len=20,access=rw"`
 	CIDR    string             `sunspec:"offset=29,len=20,access=rw"`
 	Gw      string             `sunspec:"offset=49,len=20,access=rw"`
@@ -52,7 +52,7 @@ type Block13 struct {
 	NTP2    string             `sunspec:"offset=129,len=20,access=rw"`
 	DomNam  string             `sunspec:"offset=149,len=12,access=rw"`
 	HostNam string             `sunspec:"offset=161,len=12,access=rw"`
-	Pad     sunspec.Pad        `sunspec:"offset=173,len=1"`
+	Pad     sunspec.Pad        `sunspec:"offset=173"`
 }
 
 func (block *Block13) GetId() sunspec.ModelId {
@@ -72,11 +72,11 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name"},
-					{Id: CfgSt, Offset: 4, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Config Status", Description: "Enumerated value.  Configuration status"},
-					{Id: ChgSt, Offset: 5, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "Change Status", Description: "Bitmask value.  A configuration change is pending"},
-					{Id: Cap, Offset: 6, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "Config Capability", Description: "Bitmask value. Identify capable sources of configuration"},
-					{Id: Cfg, Offset: 7, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "IPv6 Config", Description: "Enumerated value.  Configuration method used."},
-					{Id: Ctl, Offset: 8, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Control", Description: "Bitmask value.  Configure use of services"},
+					{Id: CfgSt, Offset: 4, Type: typelabel.Enum16, Mandatory: true, Label: "Config Status", Description: "Enumerated value.  Configuration status"},
+					{Id: ChgSt, Offset: 5, Type: typelabel.Bitfield16, Mandatory: true, Label: "Change Status", Description: "Bitmask value.  A configuration change is pending"},
+					{Id: Cap, Offset: 6, Type: typelabel.Bitfield16, Mandatory: true, Label: "Config Capability", Description: "Bitmask value. Identify capable sources of configuration"},
+					{Id: Cfg, Offset: 7, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "IPv6 Config", Description: "Enumerated value.  Configuration method used."},
+					{Id: Ctl, Offset: 8, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Control", Description: "Bitmask value.  Configure use of services"},
 					{Id: Addr, Offset: 9, Type: typelabel.String, Access: "rw", Length: 20, Mandatory: true, Label: "IP", Description: "IPv6 numeric address as a dotted string xxxx.xxxx.xxxx.xxxx"},
 					{Id: CIDR, Offset: 29, Type: typelabel.String, Access: "rw", Length: 20, Label: "CIDR", Description: "Classless Inter-Domain Routing Number"},
 					{Id: Gw, Offset: 49, Type: typelabel.String, Access: "rw", Length: 20, Label: "Gateway", Description: "IPv6 numeric address as a dotted string xxxx.xxxx.xxxx.xxxx"},
@@ -86,7 +86,7 @@ func init() {
 					{Id: NTP2, Offset: 129, Type: typelabel.String, Access: "rw", Length: 20, Label: "NTP2", Description: "IPv6 numeric NTP address as a name or dotted string xxxx.xxxx.xxxx.xxxx"},
 					{Id: DomNam, Offset: 149, Type: typelabel.String, Access: "rw", Length: 12, Label: "Domain", Description: "Domain name (24 chars max)"},
 					{Id: HostNam, Offset: 161, Type: typelabel.String, Access: "rw", Length: 12, Label: "Host Name", Description: "Host name (24 chars max)"},
-					{Id: Pad, Offset: 173, Type: typelabel.Pad, Length: 1},
+					{Id: Pad, Offset: 173, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model130/model.go
+++ b/models/model130/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block130Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	V1       uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	V2       uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	V3       uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	V4       uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	V5       uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	V6       uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	V7       uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	V8       uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	V9       uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	V10      uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	V11      uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	V12      uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	V13      uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	V14      uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	V15      uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	V16      uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	V17      uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	V18      uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	V19      uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	V20      uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	V1       uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	V2       uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	V3       uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	V4       uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	V5       uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	V6       uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	V7       uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	V8       uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	V9       uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	V10      uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	V11      uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	V12      uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	V13      uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	V14      uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	V15      uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	V16      uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	V17      uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	V18      uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	V19      uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	V20      uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block130 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block130Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "HVRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for HVRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for HVRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "HVRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for HVRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for HVRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 must disconnect voltage."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must disconnect duration."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 must disconnect voltage."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must disconnect duration."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 must disconnect voltage."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must disconnect duration."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 must disconnect voltage."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must disconnect duration."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 must disconnect voltage."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must disconnect duration."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 must disconnect voltage."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must disconnect duration."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 must disconnect voltage."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must disconnect duration."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 must disconnect voltage."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must disconnect duration."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 must disconnect voltage."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must disconnect duration."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 must disconnect voltage."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must disconnect duration."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 must disconnect voltage."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must disconnect duration."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 must disconnect voltage."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must disconnect duration."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 must disconnect voltage."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must disconnect duration."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 must disconnect voltage."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must disconnect duration."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 must disconnect voltage."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must disconnect duration."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 must disconnect voltage."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must disconnect duration."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 must disconnect voltage."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must disconnect duration."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 must disconnect voltage."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must disconnect duration."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 must disconnect voltage."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must disconnect duration."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 must disconnect voltage."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 must disconnect voltage."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must disconnect duration."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 must disconnect voltage."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must disconnect duration."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 must disconnect voltage."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must disconnect duration."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 must disconnect voltage."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must disconnect duration."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 must disconnect voltage."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must disconnect duration."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 must disconnect voltage."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must disconnect duration."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 must disconnect voltage."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must disconnect duration."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 must disconnect voltage."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must disconnect duration."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 must disconnect voltage."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must disconnect duration."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 must disconnect voltage."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must disconnect duration."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 must disconnect voltage."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must disconnect duration."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 must disconnect voltage."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must disconnect duration."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 must disconnect voltage."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must disconnect duration."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 must disconnect voltage."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must disconnect duration."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 must disconnect voltage."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must disconnect duration."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 must disconnect voltage."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must disconnect duration."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 must disconnect voltage."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must disconnect duration."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 must disconnect voltage."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must disconnect duration."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 must disconnect voltage."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must disconnect duration."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 must disconnect voltage."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model131/model.go
+++ b/models/model131/model.go
@@ -78,66 +78,66 @@ const (
 )
 
 type Block131Repeat struct {
-	ActPt     uint16         `sunspec:"offset=0,len=1,access=rw"`
-	W1        int16          `sunspec:"offset=1,len=1,sf=W_SF,access=rw"`
-	PF1       int16          `sunspec:"offset=2,len=1,sf=PF_SF,access=rw"`
-	W2        int16          `sunspec:"offset=3,len=1,sf=W_SF,access=rw"`
-	PF2       int16          `sunspec:"offset=4,len=1,sf=PF_SF,access=rw"`
-	W3        int16          `sunspec:"offset=5,len=1,sf=W_SF,access=rw"`
-	PF3       int16          `sunspec:"offset=6,len=1,sf=PF_SF,access=rw"`
-	W4        int16          `sunspec:"offset=7,len=1,sf=W_SF,access=rw"`
-	PF4       int16          `sunspec:"offset=8,len=1,sf=PF_SF,access=rw"`
-	W5        int16          `sunspec:"offset=9,len=1,sf=W_SF,access=rw"`
-	PF5       int16          `sunspec:"offset=10,len=1,sf=PF_SF,access=rw"`
-	W6        int16          `sunspec:"offset=11,len=1,sf=W_SF,access=rw"`
-	PF6       int16          `sunspec:"offset=12,len=1,sf=PF_SF,access=rw"`
-	W7        int16          `sunspec:"offset=13,len=1,sf=W_SF,access=rw"`
-	PF7       int16          `sunspec:"offset=14,len=1,sf=PF_SF,access=rw"`
-	W8        int16          `sunspec:"offset=15,len=1,sf=W_SF,access=rw"`
-	PF8       int16          `sunspec:"offset=16,len=1,sf=PF_SF,access=rw"`
-	W9        int16          `sunspec:"offset=17,len=1,sf=W_SF,access=rw"`
-	PF9       int16          `sunspec:"offset=18,len=1,sf=PF_SF,access=rw"`
-	W10       int16          `sunspec:"offset=19,len=1,sf=W_SF,access=rw"`
-	PF10      int16          `sunspec:"offset=20,len=1,sf=PF_SF,access=rw"`
-	W11       int16          `sunspec:"offset=21,len=1,sf=W_SF,access=rw"`
-	PF11      int16          `sunspec:"offset=22,len=1,sf=PF_SF,access=rw"`
-	W12       int16          `sunspec:"offset=23,len=1,sf=W_SF,access=rw"`
-	PF12      int16          `sunspec:"offset=24,len=1,sf=PF_SF,access=rw"`
-	W13       int16          `sunspec:"offset=25,len=1,sf=W_SF,access=rw"`
-	PF13      int16          `sunspec:"offset=26,len=1,sf=PF_SF,access=rw"`
-	W14       int16          `sunspec:"offset=27,len=1,sf=W_SF,access=rw"`
-	PF14      int16          `sunspec:"offset=28,len=1,sf=PF_SF,access=rw"`
-	W15       int16          `sunspec:"offset=29,len=1,sf=W_SF,access=rw"`
-	PF15      int16          `sunspec:"offset=30,len=1,sf=PF_SF,access=rw"`
-	W16       int16          `sunspec:"offset=31,len=1,sf=W_SF,access=rw"`
-	PF16      int16          `sunspec:"offset=32,len=1,sf=PF_SF,access=rw"`
-	W17       int16          `sunspec:"offset=33,len=1,sf=W_SF,access=rw"`
-	PF17      int16          `sunspec:"offset=34,len=1,sf=PF_SF,access=rw"`
-	W18       int16          `sunspec:"offset=35,len=1,sf=W_SF,access=rw"`
-	PF18      int16          `sunspec:"offset=36,len=1,sf=PF_SF,access=rw"`
-	W19       int16          `sunspec:"offset=37,len=1,sf=W_SF,access=rw"`
-	PF19      int16          `sunspec:"offset=38,len=1,sf=PF_SF,access=rw"`
-	W20       int16          `sunspec:"offset=39,len=1,sf=W_SF,access=rw"`
-	PF20      int16          `sunspec:"offset=40,len=1,sf=PF_SF,access=rw"`
+	ActPt     uint16         `sunspec:"offset=0,access=rw"`
+	W1        int16          `sunspec:"offset=1,sf=W_SF,access=rw"`
+	PF1       int16          `sunspec:"offset=2,sf=PF_SF,access=rw"`
+	W2        int16          `sunspec:"offset=3,sf=W_SF,access=rw"`
+	PF2       int16          `sunspec:"offset=4,sf=PF_SF,access=rw"`
+	W3        int16          `sunspec:"offset=5,sf=W_SF,access=rw"`
+	PF3       int16          `sunspec:"offset=6,sf=PF_SF,access=rw"`
+	W4        int16          `sunspec:"offset=7,sf=W_SF,access=rw"`
+	PF4       int16          `sunspec:"offset=8,sf=PF_SF,access=rw"`
+	W5        int16          `sunspec:"offset=9,sf=W_SF,access=rw"`
+	PF5       int16          `sunspec:"offset=10,sf=PF_SF,access=rw"`
+	W6        int16          `sunspec:"offset=11,sf=W_SF,access=rw"`
+	PF6       int16          `sunspec:"offset=12,sf=PF_SF,access=rw"`
+	W7        int16          `sunspec:"offset=13,sf=W_SF,access=rw"`
+	PF7       int16          `sunspec:"offset=14,sf=PF_SF,access=rw"`
+	W8        int16          `sunspec:"offset=15,sf=W_SF,access=rw"`
+	PF8       int16          `sunspec:"offset=16,sf=PF_SF,access=rw"`
+	W9        int16          `sunspec:"offset=17,sf=W_SF,access=rw"`
+	PF9       int16          `sunspec:"offset=18,sf=PF_SF,access=rw"`
+	W10       int16          `sunspec:"offset=19,sf=W_SF,access=rw"`
+	PF10      int16          `sunspec:"offset=20,sf=PF_SF,access=rw"`
+	W11       int16          `sunspec:"offset=21,sf=W_SF,access=rw"`
+	PF11      int16          `sunspec:"offset=22,sf=PF_SF,access=rw"`
+	W12       int16          `sunspec:"offset=23,sf=W_SF,access=rw"`
+	PF12      int16          `sunspec:"offset=24,sf=PF_SF,access=rw"`
+	W13       int16          `sunspec:"offset=25,sf=W_SF,access=rw"`
+	PF13      int16          `sunspec:"offset=26,sf=PF_SF,access=rw"`
+	W14       int16          `sunspec:"offset=27,sf=W_SF,access=rw"`
+	PF14      int16          `sunspec:"offset=28,sf=PF_SF,access=rw"`
+	W15       int16          `sunspec:"offset=29,sf=W_SF,access=rw"`
+	PF15      int16          `sunspec:"offset=30,sf=PF_SF,access=rw"`
+	W16       int16          `sunspec:"offset=31,sf=W_SF,access=rw"`
+	PF16      int16          `sunspec:"offset=32,sf=PF_SF,access=rw"`
+	W17       int16          `sunspec:"offset=33,sf=W_SF,access=rw"`
+	PF17      int16          `sunspec:"offset=34,sf=PF_SF,access=rw"`
+	W18       int16          `sunspec:"offset=35,sf=W_SF,access=rw"`
+	PF18      int16          `sunspec:"offset=36,sf=PF_SF,access=rw"`
+	W19       int16          `sunspec:"offset=37,sf=W_SF,access=rw"`
+	PF19      int16          `sunspec:"offset=38,sf=PF_SF,access=rw"`
+	W20       int16          `sunspec:"offset=39,sf=W_SF,access=rw"`
+	PF20      int16          `sunspec:"offset=40,sf=PF_SF,access=rw"`
 	CrvNam    string         `sunspec:"offset=41,len=8,access=rw"`
-	RmpPT1Tms uint16         `sunspec:"offset=49,len=1,access=rw"`
-	RmpDecTmm uint16         `sunspec:"offset=50,len=1,sf=RmpIncDec_SF,access=rw"`
-	RmpIncTmm uint16         `sunspec:"offset=51,len=1,sf=RmpIncDec_SF,access=rw"`
-	ReadOnly  sunspec.Enum16 `sunspec:"offset=52,len=1"`
-	Pad       sunspec.Pad    `sunspec:"offset=53,len=1"`
+	RmpPT1Tms uint16         `sunspec:"offset=49,access=rw"`
+	RmpDecTmm uint16         `sunspec:"offset=50,sf=RmpIncDec_SF,access=rw"`
+	RmpIncTmm uint16         `sunspec:"offset=51,sf=RmpIncDec_SF,access=rw"`
+	ReadOnly  sunspec.Enum16 `sunspec:"offset=52"`
+	Pad       sunspec.Pad    `sunspec:"offset=53"`
 }
 
 type Block131 struct {
-	ActCrv       uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms       uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms      uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms       uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv         uint16              `sunspec:"offset=5,len=1"`
-	NPt          uint16              `sunspec:"offset=6,len=1"`
-	W_SF         sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	PF_SF        sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
+	ActCrv       uint16              `sunspec:"offset=0,access=rw"`
+	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms       uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms      uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms       uint16              `sunspec:"offset=4,access=rw"`
+	NCrv         uint16              `sunspec:"offset=5"`
+	NPt          uint16              `sunspec:"offset=6"`
+	W_SF         sunspec.ScaleFactor `sunspec:"offset=7"`
+	PF_SF        sunspec.ScaleFactor `sunspec:"offset=8"`
+	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9"`
 
 	Repeats []Block131Repeat
 }
@@ -158,69 +158,69 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is watt-PF mode active."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for watt-PF change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for watt-PF curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Max number of points in array."},
-					{Id: W_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "W_SF", Description: "Scale factor for percent WMax."},
-					{Id: PF_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "PF_SF", Description: "Scale factor for PF."},
-					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Length: 1, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is watt-PF mode active."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for watt-PF change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for watt-PF curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Max number of points in array."},
+					{Id: W_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "W_SF", Description: "Scale factor for percent WMax."},
+					{Id: PF_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "PF_SF", Description: "Scale factor for PF."},
+					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
 				},
 			},
 			{Name: "curve",
 				Length: 54,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: W1, Offset: 1, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Mandatory: true, Label: "W1", Description: "Point 1 Watts."},
-					{Id: PF1, Offset: 2, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Mandatory: true, Label: "PF1", Description: "Point 1 PF in EEI notation."},
-					{Id: W2, Offset: 3, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W2", Description: "Point 2 Watts."},
-					{Id: PF2, Offset: 4, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF2", Description: "Point 2 PF in EEI notation."},
-					{Id: W3, Offset: 5, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W3", Description: "Point 3 Watts."},
-					{Id: PF3, Offset: 6, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF3", Description: "Point 3 PF in EEI notation."},
-					{Id: W4, Offset: 7, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W4", Description: "Point 4 Watts."},
-					{Id: PF4, Offset: 8, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF4", Description: "Point 4 PF in EEI notation."},
-					{Id: W5, Offset: 9, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W5", Description: "Point 5 Watts."},
-					{Id: PF5, Offset: 10, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF5", Description: "Point 5 PF in EEI notation."},
-					{Id: W6, Offset: 11, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W6", Description: "Point 6 Watts."},
-					{Id: PF6, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF6", Description: "Point 6 PF in EEI notation."},
-					{Id: W7, Offset: 13, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W7", Description: "Point 7 Watts."},
-					{Id: PF7, Offset: 14, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF7", Description: "Point 7 PF in EEI notation."},
-					{Id: W8, Offset: 15, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W8", Description: "Point 8 Watts."},
-					{Id: PF8, Offset: 16, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF8", Description: "Point 8 PF in EEI notation."},
-					{Id: W9, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W9", Description: "Point 9 Watts."},
-					{Id: PF9, Offset: 18, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF9", Description: "Point 9 PF in EEI notation."},
-					{Id: W10, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W10", Description: "Point 10 Watts."},
-					{Id: PF10, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF10", Description: "Point 10 PF in EEI notation."},
-					{Id: W11, Offset: 21, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W11", Description: "Point 11 Watts."},
-					{Id: PF11, Offset: 22, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF11", Description: "Point 11 PF in EEI notation."},
-					{Id: W12, Offset: 23, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W12", Description: "Point 12 Watts."},
-					{Id: PF12, Offset: 24, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF12", Description: "Point 12 PF in EEI notation."},
-					{Id: W13, Offset: 25, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W13", Description: "Point 13 Watts."},
-					{Id: PF13, Offset: 26, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF13", Description: "Point 13 PF in EEI notation."},
-					{Id: W14, Offset: 27, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W14", Description: "Point 14 Watts."},
-					{Id: PF14, Offset: 28, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF14", Description: "Point 14 PF in EEI notation."},
-					{Id: W15, Offset: 29, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W15", Description: "Point 15 Watts."},
-					{Id: PF15, Offset: 30, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF15", Description: "Point 15 PF in EEI notation."},
-					{Id: W16, Offset: 31, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W16", Description: "Point 16 Watts."},
-					{Id: PF16, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF16", Description: "Point 16 PF in EEI notation."},
-					{Id: W17, Offset: 33, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W17", Description: "Point 17 Watts."},
-					{Id: PF17, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF17", Description: "Point 17 PF in EEI notation."},
-					{Id: W18, Offset: 35, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W18", Description: "Point 18 Watts."},
-					{Id: PF18, Offset: 36, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF18", Description: "Point 18 PF in EEI notation."},
-					{Id: W19, Offset: 37, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W19", Description: "Point 19 Watts."},
-					{Id: PF19, Offset: 38, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF19", Description: "Point 19 PF in EEI notation."},
-					{Id: W20, Offset: 39, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Length: 1, Label: "W20", Description: "Point 20 Watts."},
-					{Id: PF20, Offset: 40, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Length: 1, Label: "PF20", Description: "Point 20 PF in EEI notation."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: W1, Offset: 1, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Mandatory: true, Label: "W1", Description: "Point 1 Watts."},
+					{Id: PF1, Offset: 2, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Mandatory: true, Label: "PF1", Description: "Point 1 PF in EEI notation."},
+					{Id: W2, Offset: 3, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W2", Description: "Point 2 Watts."},
+					{Id: PF2, Offset: 4, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF2", Description: "Point 2 PF in EEI notation."},
+					{Id: W3, Offset: 5, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W3", Description: "Point 3 Watts."},
+					{Id: PF3, Offset: 6, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF3", Description: "Point 3 PF in EEI notation."},
+					{Id: W4, Offset: 7, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W4", Description: "Point 4 Watts."},
+					{Id: PF4, Offset: 8, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF4", Description: "Point 4 PF in EEI notation."},
+					{Id: W5, Offset: 9, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W5", Description: "Point 5 Watts."},
+					{Id: PF5, Offset: 10, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF5", Description: "Point 5 PF in EEI notation."},
+					{Id: W6, Offset: 11, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W6", Description: "Point 6 Watts."},
+					{Id: PF6, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF6", Description: "Point 6 PF in EEI notation."},
+					{Id: W7, Offset: 13, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W7", Description: "Point 7 Watts."},
+					{Id: PF7, Offset: 14, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF7", Description: "Point 7 PF in EEI notation."},
+					{Id: W8, Offset: 15, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W8", Description: "Point 8 Watts."},
+					{Id: PF8, Offset: 16, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF8", Description: "Point 8 PF in EEI notation."},
+					{Id: W9, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W9", Description: "Point 9 Watts."},
+					{Id: PF9, Offset: 18, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF9", Description: "Point 9 PF in EEI notation."},
+					{Id: W10, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W10", Description: "Point 10 Watts."},
+					{Id: PF10, Offset: 20, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF10", Description: "Point 10 PF in EEI notation."},
+					{Id: W11, Offset: 21, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W11", Description: "Point 11 Watts."},
+					{Id: PF11, Offset: 22, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF11", Description: "Point 11 PF in EEI notation."},
+					{Id: W12, Offset: 23, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W12", Description: "Point 12 Watts."},
+					{Id: PF12, Offset: 24, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF12", Description: "Point 12 PF in EEI notation."},
+					{Id: W13, Offset: 25, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W13", Description: "Point 13 Watts."},
+					{Id: PF13, Offset: 26, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF13", Description: "Point 13 PF in EEI notation."},
+					{Id: W14, Offset: 27, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W14", Description: "Point 14 Watts."},
+					{Id: PF14, Offset: 28, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF14", Description: "Point 14 PF in EEI notation."},
+					{Id: W15, Offset: 29, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W15", Description: "Point 15 Watts."},
+					{Id: PF15, Offset: 30, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF15", Description: "Point 15 PF in EEI notation."},
+					{Id: W16, Offset: 31, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W16", Description: "Point 16 Watts."},
+					{Id: PF16, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF16", Description: "Point 16 PF in EEI notation."},
+					{Id: W17, Offset: 33, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W17", Description: "Point 17 Watts."},
+					{Id: PF17, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF17", Description: "Point 17 PF in EEI notation."},
+					{Id: W18, Offset: 35, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W18", Description: "Point 18 Watts."},
+					{Id: PF18, Offset: 36, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF18", Description: "Point 18 PF in EEI notation."},
+					{Id: W19, Offset: 37, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W19", Description: "Point 19 Watts."},
+					{Id: PF19, Offset: 38, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF19", Description: "Point 19 PF in EEI notation."},
+					{Id: W20, Offset: 39, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WMax", Access: "rw", Label: "W20", Description: "Point 20 Watts."},
+					{Id: PF20, Offset: 40, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "cos()", Access: "rw", Label: "PF20", Description: "Point 20 PF in EEI notation."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: RmpPT1Tms, Offset: 49, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpPT1Tms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
-					{Id: RmpDecTmm, Offset: 50, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% PF/min", Access: "rw", Length: 1, Label: "RmpDecTmm", Description: "The maximum rate at which the power factor may be reduced in response to changes in the power value."},
-					{Id: RmpIncTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% PF/min", Access: "rw", Length: 1, Label: "RmpIncTmm", Description: "The maximum rate at which the power factor may be increased in response to changes in the power value."},
-					{Id: ReadOnly, Offset: 52, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
-					{Id: Pad, Offset: 53, Type: typelabel.Pad, Length: 1},
+					{Id: RmpPT1Tms, Offset: 49, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpPT1Tms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
+					{Id: RmpDecTmm, Offset: 50, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% PF/min", Access: "rw", Label: "RmpDecTmm", Description: "The maximum rate at which the power factor may be reduced in response to changes in the power value."},
+					{Id: RmpIncTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% PF/min", Access: "rw", Label: "RmpIncTmm", Description: "The maximum rate at which the power factor may be increased in response to changes in the power value."},
+					{Id: ReadOnly, Offset: 52, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: Pad, Offset: 53, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model132/model.go
+++ b/models/model132/model.go
@@ -78,66 +78,66 @@ const (
 )
 
 type Block132Repeat struct {
-	ActPt     uint16         `sunspec:"offset=0,len=1,access=rw"`
-	DeptRef   sunspec.Enum16 `sunspec:"offset=1,len=1,access=rw"`
-	V1        uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	W1        int16          `sunspec:"offset=3,len=1,sf=DeptRef_SF,access=rw"`
-	V2        uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	W2        int16          `sunspec:"offset=5,len=1,sf=DeptRef_SF,access=rw"`
-	V3        uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	W3        int16          `sunspec:"offset=7,len=1,sf=DeptRef_SF,access=rw"`
-	V4        uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	W4        int16          `sunspec:"offset=9,len=1,sf=DeptRef_SF,access=rw"`
-	V5        uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	W5        int16          `sunspec:"offset=11,len=1,sf=DeptRef_SF,access=rw"`
-	V6        uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	W6        int16          `sunspec:"offset=13,len=1,sf=DeptRef_SF,access=rw"`
-	V7        uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	W7        int16          `sunspec:"offset=15,len=1,sf=DeptRef_SF,access=rw"`
-	V8        uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	W8        int16          `sunspec:"offset=17,len=1,sf=DeptRef_SF,access=rw"`
-	V9        uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	W9        int16          `sunspec:"offset=19,len=1,sf=DeptRef_SF,access=rw"`
-	V10       uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	W10       int16          `sunspec:"offset=21,len=1,sf=DeptRef_SF,access=rw"`
-	V11       uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	W11       int16          `sunspec:"offset=23,len=1,sf=DeptRef_SF,access=rw"`
-	V12       uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	W12       int16          `sunspec:"offset=25,len=1,sf=DeptRef_SF,access=rw"`
-	V13       uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	W13       int16          `sunspec:"offset=27,len=1,sf=DeptRef_SF,access=rw"`
-	V14       uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	W14       int16          `sunspec:"offset=29,len=1,sf=DeptRef_SF,access=rw"`
-	V15       uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	W15       int16          `sunspec:"offset=31,len=1,sf=DeptRef_SF,access=rw"`
-	V16       uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	W16       int16          `sunspec:"offset=33,len=1,sf=DeptRef_SF,access=rw"`
-	V17       uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	W17       int16          `sunspec:"offset=35,len=1,sf=DeptRef_SF,access=rw"`
-	V18       uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	W18       int16          `sunspec:"offset=37,len=1,sf=DeptRef_SF,access=rw"`
-	V19       uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	W19       int16          `sunspec:"offset=39,len=1,sf=DeptRef_SF,access=rw"`
-	V20       uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
-	W20       int16          `sunspec:"offset=41,len=1,sf=DeptRef_SF,access=rw"`
+	ActPt     uint16         `sunspec:"offset=0,access=rw"`
+	DeptRef   sunspec.Enum16 `sunspec:"offset=1,access=rw"`
+	V1        uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	W1        int16          `sunspec:"offset=3,sf=DeptRef_SF,access=rw"`
+	V2        uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	W2        int16          `sunspec:"offset=5,sf=DeptRef_SF,access=rw"`
+	V3        uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	W3        int16          `sunspec:"offset=7,sf=DeptRef_SF,access=rw"`
+	V4        uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	W4        int16          `sunspec:"offset=9,sf=DeptRef_SF,access=rw"`
+	V5        uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	W5        int16          `sunspec:"offset=11,sf=DeptRef_SF,access=rw"`
+	V6        uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	W6        int16          `sunspec:"offset=13,sf=DeptRef_SF,access=rw"`
+	V7        uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	W7        int16          `sunspec:"offset=15,sf=DeptRef_SF,access=rw"`
+	V8        uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	W8        int16          `sunspec:"offset=17,sf=DeptRef_SF,access=rw"`
+	V9        uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	W9        int16          `sunspec:"offset=19,sf=DeptRef_SF,access=rw"`
+	V10       uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	W10       int16          `sunspec:"offset=21,sf=DeptRef_SF,access=rw"`
+	V11       uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	W11       int16          `sunspec:"offset=23,sf=DeptRef_SF,access=rw"`
+	V12       uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	W12       int16          `sunspec:"offset=25,sf=DeptRef_SF,access=rw"`
+	V13       uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	W13       int16          `sunspec:"offset=27,sf=DeptRef_SF,access=rw"`
+	V14       uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	W14       int16          `sunspec:"offset=29,sf=DeptRef_SF,access=rw"`
+	V15       uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	W15       int16          `sunspec:"offset=31,sf=DeptRef_SF,access=rw"`
+	V16       uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	W16       int16          `sunspec:"offset=33,sf=DeptRef_SF,access=rw"`
+	V17       uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	W17       int16          `sunspec:"offset=35,sf=DeptRef_SF,access=rw"`
+	V18       uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	W18       int16          `sunspec:"offset=37,sf=DeptRef_SF,access=rw"`
+	V19       uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	W19       int16          `sunspec:"offset=39,sf=DeptRef_SF,access=rw"`
+	V20       uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
+	W20       int16          `sunspec:"offset=41,sf=DeptRef_SF,access=rw"`
 	CrvNam    string         `sunspec:"offset=42,len=8,access=rw"`
-	RmpPt1Tms uint16         `sunspec:"offset=50,len=1,access=rw"`
-	RmpDecTmm uint16         `sunspec:"offset=51,len=1,sf=RmpIncDec_SF,access=rw"`
-	RmpIncTmm uint16         `sunspec:"offset=52,len=1,sf=RmpIncDec_SF,access=rw"`
-	ReadOnly  sunspec.Enum16 `sunspec:"offset=53,len=1"`
+	RmpPt1Tms uint16         `sunspec:"offset=50,access=rw"`
+	RmpDecTmm uint16         `sunspec:"offset=51,sf=RmpIncDec_SF,access=rw"`
+	RmpIncTmm uint16         `sunspec:"offset=52,sf=RmpIncDec_SF,access=rw"`
+	ReadOnly  sunspec.Enum16 `sunspec:"offset=53"`
 }
 
 type Block132 struct {
-	ActCrv       uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms       uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms      uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms       uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv         uint16              `sunspec:"offset=5,len=1"`
-	NPt          uint16              `sunspec:"offset=6,len=1"`
-	V_SF         sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	DeptRef_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
+	ActCrv       uint16              `sunspec:"offset=0,access=rw"`
+	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms       uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms      uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms       uint16              `sunspec:"offset=4,access=rw"`
+	NCrv         uint16              `sunspec:"offset=5"`
+	NPt          uint16              `sunspec:"offset=6"`
+	V_SF         sunspec.ScaleFactor `sunspec:"offset=7"`
+	DeptRef_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9"`
 
 	Repeats []Block132Repeat
 }
@@ -158,69 +158,69 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is Volt-Watt control active."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for volt-watt change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for volt-watt curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend min. 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of points in array (maximum 20)."},
-					{Id: V_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: DeptRef_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "DeptRef_SF", Description: "Scale Factor for % DeptRef"},
-					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Length: 1, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is Volt-Watt control active."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for volt-watt change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for volt-watt curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend min. 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of points in array (maximum 20)."},
+					{Id: V_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: DeptRef_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "DeptRef_SF", Description: "Scale Factor for % DeptRef"},
+					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
 				},
 			},
 			{Name: "curve",
 				Length: 54,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: DeptRef, Offset: 1, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "DeptRef", Description: "Defines the meaning of the Watts DeptRef.  1=% WMax 2=% WAvail"},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 Volts."},
-					{Id: W1, Offset: 3, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "W1", Description: "Point 1 Watts."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 Volts."},
-					{Id: W2, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W2", Description: "Point 2 Watts."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 Volts."},
-					{Id: W3, Offset: 7, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W3", Description: "Point 3 Watts."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 Volts."},
-					{Id: W4, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W4", Description: "Point 4 Watts."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 Volts."},
-					{Id: W5, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W5", Description: "Point 5 Watts."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 Volts."},
-					{Id: W6, Offset: 13, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W6", Description: "Point 6 Watts."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 Volts."},
-					{Id: W7, Offset: 15, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W7", Description: "Point 7 Watts."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 Volts."},
-					{Id: W8, Offset: 17, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W8", Description: "Point 8 Watts."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 Volts."},
-					{Id: W9, Offset: 19, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W9", Description: "Point 9 Watts."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 Volts."},
-					{Id: W10, Offset: 21, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W10", Description: "Point 10 Watts."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 Volts."},
-					{Id: W11, Offset: 23, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W11", Description: "Point 11 Watts."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 Volts."},
-					{Id: W12, Offset: 25, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W12", Description: "Point 12 Watts."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 Volts."},
-					{Id: W13, Offset: 27, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W13", Description: "Point 13 Watts."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 Volts."},
-					{Id: W14, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W14", Description: "Point 14 Watts."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 Volts."},
-					{Id: W15, Offset: 31, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W15", Description: "Point 15 Watts."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 Volts."},
-					{Id: W16, Offset: 33, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W16", Description: "Point 16 Watts."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 Volts."},
-					{Id: W17, Offset: 35, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W17", Description: "Point 17 Watts."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 Volts."},
-					{Id: W18, Offset: 37, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W18", Description: "Point 18 Watts."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 Volts."},
-					{Id: W19, Offset: 39, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W19", Description: "Point 19 Watts."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 Volts."},
-					{Id: W20, Offset: 41, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "W20", Description: "Point 20 Watts."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: DeptRef, Offset: 1, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "DeptRef", Description: "Defines the meaning of the Watts DeptRef.  1=% WMax 2=% WAvail"},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 Volts."},
+					{Id: W1, Offset: 3, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "W1", Description: "Point 1 Watts."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 Volts."},
+					{Id: W2, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W2", Description: "Point 2 Watts."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 Volts."},
+					{Id: W3, Offset: 7, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W3", Description: "Point 3 Watts."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 Volts."},
+					{Id: W4, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W4", Description: "Point 4 Watts."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 Volts."},
+					{Id: W5, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W5", Description: "Point 5 Watts."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 Volts."},
+					{Id: W6, Offset: 13, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W6", Description: "Point 6 Watts."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 Volts."},
+					{Id: W7, Offset: 15, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W7", Description: "Point 7 Watts."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 Volts."},
+					{Id: W8, Offset: 17, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W8", Description: "Point 8 Watts."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 Volts."},
+					{Id: W9, Offset: 19, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W9", Description: "Point 9 Watts."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 Volts."},
+					{Id: W10, Offset: 21, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W10", Description: "Point 10 Watts."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 Volts."},
+					{Id: W11, Offset: 23, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W11", Description: "Point 11 Watts."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 Volts."},
+					{Id: W12, Offset: 25, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W12", Description: "Point 12 Watts."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 Volts."},
+					{Id: W13, Offset: 27, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W13", Description: "Point 13 Watts."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 Volts."},
+					{Id: W14, Offset: 29, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W14", Description: "Point 14 Watts."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 Volts."},
+					{Id: W15, Offset: 31, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W15", Description: "Point 15 Watts."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 Volts."},
+					{Id: W16, Offset: 33, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W16", Description: "Point 16 Watts."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 Volts."},
+					{Id: W17, Offset: 35, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W17", Description: "Point 17 Watts."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 Volts."},
+					{Id: W18, Offset: 37, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W18", Description: "Point 18 Watts."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 Volts."},
+					{Id: W19, Offset: 39, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W19", Description: "Point 19 Watts."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 Volts."},
+					{Id: W20, Offset: 41, Type: typelabel.Int16, ScaleFactor: "DeptRef_SF", Units: "% VRef", Access: "rw", Label: "W20", Description: "Point 20 Watts."},
 					{Id: CrvNam, Offset: 42, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: RmpPt1Tms, Offset: 50, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpPt1Tms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
-					{Id: RmpDecTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Length: 1, Label: "RmpDecTmm", Description: "The maximum rate at which the watt value may be reduced in response to changes in the voltage value."},
-					{Id: RmpIncTmm, Offset: 52, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Length: 1, Label: "RmpIncTmm", Description: "The maximum rate at which the watt value may be increased in response to changes in the voltage value."},
-					{Id: ReadOnly, Offset: 53, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: RmpPt1Tms, Offset: 50, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpPt1Tms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
+					{Id: RmpDecTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Label: "RmpDecTmm", Description: "The maximum rate at which the watt value may be reduced in response to changes in the voltage value."},
+					{Id: RmpIncTmm, Offset: 52, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Label: "RmpIncTmm", Description: "The maximum rate at which the watt value may be increased in response to changes in the voltage value."},
+					{Id: ReadOnly, Offset: 53, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model133/model.go
+++ b/models/model133/model.go
@@ -58,46 +58,46 @@ const (
 )
 
 type Block133Repeat struct {
-	ActPts  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	StrTms  uint32              `sunspec:"offset=1,len=2,access=rw"`
-	RepPer  uint16              `sunspec:"offset=3,len=1,access=rw"`
-	IntvTyp sunspec.Enum16      `sunspec:"offset=4,len=1,access=rw"`
-	XTyp    sunspec.Enum16      `sunspec:"offset=5,len=1,access=rw"`
-	X_SF    sunspec.ScaleFactor `sunspec:"offset=6,len=1,access=rw"`
-	YTyp    sunspec.Enum16      `sunspec:"offset=7,len=1,access=rw"`
-	Y_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1,access=rw"`
-	X1      int32               `sunspec:"offset=9,len=2,sf=X_SF,access=rw"`
-	Y1      int32               `sunspec:"offset=11,len=2,sf=Y_SF,access=rw"`
-	X2      int32               `sunspec:"offset=13,len=2,sf=X_SF,access=rw"`
-	Y2      int32               `sunspec:"offset=15,len=2,sf=Y_SF,access=rw"`
-	X3      int32               `sunspec:"offset=17,len=2,sf=X_SF,access=rw"`
-	Y3      int32               `sunspec:"offset=19,len=2,sf=Y_SF,access=rw"`
-	X4      int32               `sunspec:"offset=21,len=2,sf=X_SF,access=rw"`
-	Y4      int32               `sunspec:"offset=23,len=2,sf=Y_SF,access=rw"`
-	X5      int32               `sunspec:"offset=25,len=2,sf=X_SF,access=rw"`
-	Y5      int32               `sunspec:"offset=27,len=2,sf=Y_SF,access=rw"`
-	X6      int32               `sunspec:"offset=29,len=2,sf=X_SF,access=rw"`
-	Y6      int32               `sunspec:"offset=31,len=2,sf=Y_SF,access=rw"`
-	X7      int32               `sunspec:"offset=33,len=2,sf=X_SF,access=rw"`
-	Y7      int32               `sunspec:"offset=35,len=2,sf=Y_SF,access=rw"`
-	X8      int32               `sunspec:"offset=37,len=2,sf=X_SF,access=rw"`
-	Y8      int32               `sunspec:"offset=39,len=2,sf=Y_SF,access=rw"`
-	X9      int32               `sunspec:"offset=41,len=2,sf=X_SF,access=rw"`
-	Y9      int32               `sunspec:"offset=43,len=2,sf=Y_SF,access=rw"`
-	X10     int32               `sunspec:"offset=45,len=2,sf=X_SF,access=rw"`
-	Y10     int32               `sunspec:"offset=47,len=2,sf=Y_SF,access=rw"`
+	ActPts  uint16              `sunspec:"offset=0,access=rw"`
+	StrTms  uint32              `sunspec:"offset=1,access=rw"`
+	RepPer  uint16              `sunspec:"offset=3,access=rw"`
+	IntvTyp sunspec.Enum16      `sunspec:"offset=4,access=rw"`
+	XTyp    sunspec.Enum16      `sunspec:"offset=5,access=rw"`
+	X_SF    sunspec.ScaleFactor `sunspec:"offset=6,access=rw"`
+	YTyp    sunspec.Enum16      `sunspec:"offset=7,access=rw"`
+	Y_SF    sunspec.ScaleFactor `sunspec:"offset=8,access=rw"`
+	X1      int32               `sunspec:"offset=9,sf=X_SF,access=rw"`
+	Y1      int32               `sunspec:"offset=11,sf=Y_SF,access=rw"`
+	X2      int32               `sunspec:"offset=13,sf=X_SF,access=rw"`
+	Y2      int32               `sunspec:"offset=15,sf=Y_SF,access=rw"`
+	X3      int32               `sunspec:"offset=17,sf=X_SF,access=rw"`
+	Y3      int32               `sunspec:"offset=19,sf=Y_SF,access=rw"`
+	X4      int32               `sunspec:"offset=21,sf=X_SF,access=rw"`
+	Y4      int32               `sunspec:"offset=23,sf=Y_SF,access=rw"`
+	X5      int32               `sunspec:"offset=25,sf=X_SF,access=rw"`
+	Y5      int32               `sunspec:"offset=27,sf=Y_SF,access=rw"`
+	X6      int32               `sunspec:"offset=29,sf=X_SF,access=rw"`
+	Y6      int32               `sunspec:"offset=31,sf=Y_SF,access=rw"`
+	X7      int32               `sunspec:"offset=33,sf=X_SF,access=rw"`
+	Y7      int32               `sunspec:"offset=35,sf=Y_SF,access=rw"`
+	X8      int32               `sunspec:"offset=37,sf=X_SF,access=rw"`
+	Y8      int32               `sunspec:"offset=39,sf=Y_SF,access=rw"`
+	X9      int32               `sunspec:"offset=41,sf=X_SF,access=rw"`
+	Y9      int32               `sunspec:"offset=43,sf=Y_SF,access=rw"`
+	X10     int32               `sunspec:"offset=45,sf=X_SF,access=rw"`
+	Y10     int32               `sunspec:"offset=47,sf=Y_SF,access=rw"`
 	Nam     string              `sunspec:"offset=49,len=8,access=rw"`
-	WinTms  uint16              `sunspec:"offset=57,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=58,len=1,access=rw"`
-	ActIndx uint16              `sunspec:"offset=59,len=1"`
+	WinTms  uint16              `sunspec:"offset=57,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=58,access=rw"`
+	ActIndx uint16              `sunspec:"offset=59"`
 }
 
 type Block133 struct {
-	ActSchd sunspec.Bitfield32 `sunspec:"offset=0,len=2,access=rw"`
-	ModEna  sunspec.Bitfield16 `sunspec:"offset=2,len=1,access=rw"`
-	NSchd   uint16             `sunspec:"offset=3,len=1"`
-	NPts    uint16             `sunspec:"offset=4,len=1"`
-	Pad     sunspec.Pad        `sunspec:"offset=5,len=1"`
+	ActSchd sunspec.Bitfield32 `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16 `sunspec:"offset=2,access=rw"`
+	NSchd   uint16             `sunspec:"offset=3"`
+	NPts    uint16             `sunspec:"offset=4"`
+	Pad     sunspec.Pad        `sunspec:"offset=5"`
 
 	Repeats []Block133Repeat
 }
@@ -118,49 +118,49 @@ func init() {
 				Length: 6,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActSchd, Offset: 0, Type: typelabel.Bitfield32, Access: "rw", Length: 2, Mandatory: true, Label: "ActSchd", Description: "Bitfield of active schedules"},
-					{Id: ModEna, Offset: 2, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is basic scheduling active."},
-					{Id: NSchd, Offset: 3, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NSchd", Description: "Number of schedules supported (recommend min. 4, max 32)"},
-					{Id: NPts, Offset: 4, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPts", Description: "Number of schedule entries supported (maximum of 10)."},
-					{Id: Pad, Offset: 5, Type: typelabel.Pad, Length: 1, Label: "Pad", Description: "Pad register."},
+					{Id: ActSchd, Offset: 0, Type: typelabel.Bitfield32, Access: "rw", Mandatory: true, Label: "ActSchd", Description: "Bitfield of active schedules"},
+					{Id: ModEna, Offset: 2, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is basic scheduling active."},
+					{Id: NSchd, Offset: 3, Type: typelabel.Uint16, Mandatory: true, Label: "NSchd", Description: "Number of schedules supported (recommend min. 4, max 32)"},
+					{Id: NPts, Offset: 4, Type: typelabel.Uint16, Mandatory: true, Label: "NPts", Description: "Number of schedule entries supported (maximum of 10)."},
+					{Id: Pad, Offset: 5, Type: typelabel.Pad, Label: "Pad", Description: "Pad register."},
 				},
 			},
 			{
 				Length: 60,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPts, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPts", Description: "Number of active entries in schedule."},
-					{Id: StrTms, Offset: 1, Type: typelabel.Uint32, Units: "Secs", Access: "rw", Length: 2, Mandatory: true, Label: "StrTms", Description: "Schedule start in seconds since 2000 JAN 01 00:00:00 UTC."},
-					{Id: RepPer, Offset: 3, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "RepPer", Description: "The repetition count for time-based schedules (0=repeat forever)"},
-					{Id: IntvTyp, Offset: 4, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "SchdTyp", Description: "The repetition frequency for time-based schedules: no repeat=0"},
-					{Id: XTyp, Offset: 5, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "XTyp", Description: "The meaning of the X-values in the array. "},
-					{Id: X_SF, Offset: 6, Type: typelabel.ScaleFactor, Access: "rw", Length: 1, Mandatory: true, Label: "X_SF", Description: "Scale factor for schedule range values."},
-					{Id: YTyp, Offset: 7, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "YTyp", Description: "The meaning of the Y-values in the array."},
-					{Id: Y_SF, Offset: 8, Type: typelabel.ScaleFactor, Access: "rw", Length: 1, Mandatory: true, Label: "Y_SF", Description: "Scale factor for schedule target values."},
-					{Id: X1, Offset: 9, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Mandatory: true, Label: "X1", Description: "Entry 1 range."},
-					{Id: Y1, Offset: 11, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Mandatory: true, Label: "Y1", Description: "Entry 1 target."},
-					{Id: X2, Offset: 13, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X2", Description: "Entry 2 range."},
-					{Id: Y2, Offset: 15, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y2", Description: "Entry 2 target."},
-					{Id: X3, Offset: 17, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X3", Description: "Entry 3 range."},
-					{Id: Y3, Offset: 19, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y3", Description: "Entry 3 target."},
-					{Id: X4, Offset: 21, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X4", Description: "Entry 4 range."},
-					{Id: Y4, Offset: 23, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y4", Description: "Entry 4 target."},
-					{Id: X5, Offset: 25, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X5", Description: "Entry 15range."},
-					{Id: Y5, Offset: 27, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y5", Description: "Entry 5 target."},
-					{Id: X6, Offset: 29, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X6", Description: "Entry 6 range."},
-					{Id: Y6, Offset: 31, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y6", Description: "Entry 6 target."},
-					{Id: X7, Offset: 33, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X7", Description: "Entry 7 range."},
-					{Id: Y7, Offset: 35, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y7", Description: "Entry 7 target."},
-					{Id: X8, Offset: 37, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X8", Description: "Entry 8 range."},
-					{Id: Y8, Offset: 39, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y8", Description: "Entry 8 target."},
-					{Id: X9, Offset: 41, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X9", Description: "Entry 9 range."},
-					{Id: Y9, Offset: 43, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y9", Description: "Entry 9 target."},
-					{Id: X10, Offset: 45, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Length: 2, Label: "X10", Description: "Entry 10 range."},
-					{Id: Y10, Offset: 47, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Length: 2, Label: "Y10", Description: "Entry 10 target."},
+					{Id: ActPts, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPts", Description: "Number of active entries in schedule."},
+					{Id: StrTms, Offset: 1, Type: typelabel.Uint32, Units: "Secs", Access: "rw", Mandatory: true, Label: "StrTms", Description: "Schedule start in seconds since 2000 JAN 01 00:00:00 UTC."},
+					{Id: RepPer, Offset: 3, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "RepPer", Description: "The repetition count for time-based schedules (0=repeat forever)"},
+					{Id: IntvTyp, Offset: 4, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "SchdTyp", Description: "The repetition frequency for time-based schedules: no repeat=0"},
+					{Id: XTyp, Offset: 5, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "XTyp", Description: "The meaning of the X-values in the array. "},
+					{Id: X_SF, Offset: 6, Type: typelabel.ScaleFactor, Access: "rw", Mandatory: true, Label: "X_SF", Description: "Scale factor for schedule range values."},
+					{Id: YTyp, Offset: 7, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "YTyp", Description: "The meaning of the Y-values in the array."},
+					{Id: Y_SF, Offset: 8, Type: typelabel.ScaleFactor, Access: "rw", Mandatory: true, Label: "Y_SF", Description: "Scale factor for schedule target values."},
+					{Id: X1, Offset: 9, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Mandatory: true, Label: "X1", Description: "Entry 1 range."},
+					{Id: Y1, Offset: 11, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Mandatory: true, Label: "Y1", Description: "Entry 1 target."},
+					{Id: X2, Offset: 13, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X2", Description: "Entry 2 range."},
+					{Id: Y2, Offset: 15, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y2", Description: "Entry 2 target."},
+					{Id: X3, Offset: 17, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X3", Description: "Entry 3 range."},
+					{Id: Y3, Offset: 19, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y3", Description: "Entry 3 target."},
+					{Id: X4, Offset: 21, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X4", Description: "Entry 4 range."},
+					{Id: Y4, Offset: 23, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y4", Description: "Entry 4 target."},
+					{Id: X5, Offset: 25, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X5", Description: "Entry 15range."},
+					{Id: Y5, Offset: 27, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y5", Description: "Entry 5 target."},
+					{Id: X6, Offset: 29, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X6", Description: "Entry 6 range."},
+					{Id: Y6, Offset: 31, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y6", Description: "Entry 6 target."},
+					{Id: X7, Offset: 33, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X7", Description: "Entry 7 range."},
+					{Id: Y7, Offset: 35, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y7", Description: "Entry 7 target."},
+					{Id: X8, Offset: 37, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X8", Description: "Entry 8 range."},
+					{Id: Y8, Offset: 39, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y8", Description: "Entry 8 target."},
+					{Id: X9, Offset: 41, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X9", Description: "Entry 9 range."},
+					{Id: Y9, Offset: 43, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y9", Description: "Entry 9 target."},
+					{Id: X10, Offset: 45, Type: typelabel.Int32, ScaleFactor: "X_SF", Access: "rw", Label: "X10", Description: "Entry 10 range."},
+					{Id: Y10, Offset: 47, Type: typelabel.Int32, ScaleFactor: "Y_SF", Access: "rw", Label: "Y10", Description: "Entry 10 target."},
 					{Id: Nam, Offset: 49, Type: typelabel.String, Access: "rw", Length: 8, Label: "Nam", Description: "Optional description for schedule."},
-					{Id: WinTms, Offset: 57, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for schedule entry change."},
-					{Id: RmpTms, Offset: 58, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current target to new target."},
-					{Id: ActIndx, Offset: 59, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "ActIndx", Description: "Index of active entry in the active schedule."},
+					{Id: WinTms, Offset: 57, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for schedule entry change."},
+					{Id: RmpTms, Offset: 58, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current target to new target."},
+					{Id: ActIndx, Offset: 59, Type: typelabel.Uint16, Mandatory: true, Label: "ActIndx", Description: "Index of active entry in the active schedule."},
 				},
 			},
 		}})

--- a/models/model134/model.go
+++ b/models/model134/model.go
@@ -82,70 +82,70 @@ const (
 )
 
 type Block134Repeat struct {
-	ActPt      uint16             `sunspec:"offset=0,len=1,access=rw"`
-	Hz1        uint16             `sunspec:"offset=1,len=1,sf=Hz_SF,access=rw"`
-	W1         int16              `sunspec:"offset=2,len=1,sf=W_SF,access=rw"`
-	Hz2        uint16             `sunspec:"offset=3,len=1,sf=Hz_SF,access=rw"`
-	W2         int16              `sunspec:"offset=4,len=1,sf=W_SF,access=rw"`
-	Hz3        uint16             `sunspec:"offset=5,len=1,sf=Hz_SF,access=rw"`
-	W3         int16              `sunspec:"offset=6,len=1,sf=W_SF,access=rw"`
-	Hz4        uint16             `sunspec:"offset=7,len=1,sf=Hz_SF,access=rw"`
-	W4         int16              `sunspec:"offset=8,len=1,sf=W_SF,access=rw"`
-	Hz5        uint16             `sunspec:"offset=9,len=1,sf=Hz_SF,access=rw"`
-	W5         int16              `sunspec:"offset=10,len=1,sf=W_SF,access=rw"`
-	Hz6        uint16             `sunspec:"offset=11,len=1,sf=Hz_SF,access=rw"`
-	W6         int16              `sunspec:"offset=12,len=1,sf=W_SF,access=rw"`
-	Hz7        uint16             `sunspec:"offset=13,len=1,sf=Hz_SF,access=rw"`
-	W7         int16              `sunspec:"offset=14,len=1,sf=W_SF,access=rw"`
-	Hz8        uint16             `sunspec:"offset=15,len=1,sf=Hz_SF,access=rw"`
-	W8         int16              `sunspec:"offset=16,len=1,sf=W_SF,access=rw"`
-	Hz9        uint16             `sunspec:"offset=17,len=1,sf=Hz_SF,access=rw"`
-	W9         int16              `sunspec:"offset=18,len=1,sf=W_SF,access=rw"`
-	Hz10       uint16             `sunspec:"offset=19,len=1,sf=Hz_SF,access=rw"`
-	W10        int16              `sunspec:"offset=20,len=1,sf=W_SF,access=rw"`
-	Hz11       uint16             `sunspec:"offset=21,len=1,sf=Hz_SF,access=rw"`
-	W11        int16              `sunspec:"offset=22,len=1,sf=W_SF,access=rw"`
-	Hz12       uint16             `sunspec:"offset=23,len=1,sf=Hz_SF,access=rw"`
-	W12        int16              `sunspec:"offset=24,len=1,sf=W_SF,access=rw"`
-	Hz13       uint16             `sunspec:"offset=25,len=1,sf=Hz_SF,access=rw"`
-	W13        int16              `sunspec:"offset=26,len=1,sf=W_SF,access=rw"`
-	Hz14       uint16             `sunspec:"offset=27,len=1,sf=Hz_SF,access=rw"`
-	W14        int16              `sunspec:"offset=28,len=1,sf=W_SF,access=rw"`
-	Hz15       uint16             `sunspec:"offset=29,len=1,sf=Hz_SF,access=rw"`
-	W15        int16              `sunspec:"offset=30,len=1,sf=W_SF,access=rw"`
-	Hz16       uint16             `sunspec:"offset=31,len=1,sf=Hz_SF,access=rw"`
-	W16        int16              `sunspec:"offset=32,len=1,sf=W_SF,access=rw"`
-	Hz17       uint16             `sunspec:"offset=33,len=1,sf=Hz_SF,access=rw"`
-	W17        int16              `sunspec:"offset=34,len=1,sf=W_SF,access=rw"`
-	Hz18       uint16             `sunspec:"offset=35,len=1,sf=Hz_SF,access=rw"`
-	W18        int16              `sunspec:"offset=36,len=1,sf=W_SF,access=rw"`
-	Hz19       uint16             `sunspec:"offset=37,len=1,sf=Hz_SF,access=rw"`
-	W19        int16              `sunspec:"offset=38,len=1,sf=W_SF,access=rw"`
-	Hz20       uint16             `sunspec:"offset=39,len=1,sf=Hz_SF,access=rw"`
-	W20        int16              `sunspec:"offset=40,len=1,sf=W_SF,access=rw"`
+	ActPt      uint16             `sunspec:"offset=0,access=rw"`
+	Hz1        uint16             `sunspec:"offset=1,sf=Hz_SF,access=rw"`
+	W1         int16              `sunspec:"offset=2,sf=W_SF,access=rw"`
+	Hz2        uint16             `sunspec:"offset=3,sf=Hz_SF,access=rw"`
+	W2         int16              `sunspec:"offset=4,sf=W_SF,access=rw"`
+	Hz3        uint16             `sunspec:"offset=5,sf=Hz_SF,access=rw"`
+	W3         int16              `sunspec:"offset=6,sf=W_SF,access=rw"`
+	Hz4        uint16             `sunspec:"offset=7,sf=Hz_SF,access=rw"`
+	W4         int16              `sunspec:"offset=8,sf=W_SF,access=rw"`
+	Hz5        uint16             `sunspec:"offset=9,sf=Hz_SF,access=rw"`
+	W5         int16              `sunspec:"offset=10,sf=W_SF,access=rw"`
+	Hz6        uint16             `sunspec:"offset=11,sf=Hz_SF,access=rw"`
+	W6         int16              `sunspec:"offset=12,sf=W_SF,access=rw"`
+	Hz7        uint16             `sunspec:"offset=13,sf=Hz_SF,access=rw"`
+	W7         int16              `sunspec:"offset=14,sf=W_SF,access=rw"`
+	Hz8        uint16             `sunspec:"offset=15,sf=Hz_SF,access=rw"`
+	W8         int16              `sunspec:"offset=16,sf=W_SF,access=rw"`
+	Hz9        uint16             `sunspec:"offset=17,sf=Hz_SF,access=rw"`
+	W9         int16              `sunspec:"offset=18,sf=W_SF,access=rw"`
+	Hz10       uint16             `sunspec:"offset=19,sf=Hz_SF,access=rw"`
+	W10        int16              `sunspec:"offset=20,sf=W_SF,access=rw"`
+	Hz11       uint16             `sunspec:"offset=21,sf=Hz_SF,access=rw"`
+	W11        int16              `sunspec:"offset=22,sf=W_SF,access=rw"`
+	Hz12       uint16             `sunspec:"offset=23,sf=Hz_SF,access=rw"`
+	W12        int16              `sunspec:"offset=24,sf=W_SF,access=rw"`
+	Hz13       uint16             `sunspec:"offset=25,sf=Hz_SF,access=rw"`
+	W13        int16              `sunspec:"offset=26,sf=W_SF,access=rw"`
+	Hz14       uint16             `sunspec:"offset=27,sf=Hz_SF,access=rw"`
+	W14        int16              `sunspec:"offset=28,sf=W_SF,access=rw"`
+	Hz15       uint16             `sunspec:"offset=29,sf=Hz_SF,access=rw"`
+	W15        int16              `sunspec:"offset=30,sf=W_SF,access=rw"`
+	Hz16       uint16             `sunspec:"offset=31,sf=Hz_SF,access=rw"`
+	W16        int16              `sunspec:"offset=32,sf=W_SF,access=rw"`
+	Hz17       uint16             `sunspec:"offset=33,sf=Hz_SF,access=rw"`
+	W17        int16              `sunspec:"offset=34,sf=W_SF,access=rw"`
+	Hz18       uint16             `sunspec:"offset=35,sf=Hz_SF,access=rw"`
+	W18        int16              `sunspec:"offset=36,sf=W_SF,access=rw"`
+	Hz19       uint16             `sunspec:"offset=37,sf=Hz_SF,access=rw"`
+	W19        int16              `sunspec:"offset=38,sf=W_SF,access=rw"`
+	Hz20       uint16             `sunspec:"offset=39,sf=Hz_SF,access=rw"`
+	W20        int16              `sunspec:"offset=40,sf=W_SF,access=rw"`
 	CrvNam     string             `sunspec:"offset=41,len=8,access=rw"`
-	RmpPT1Tms  uint16             `sunspec:"offset=49,len=1,access=rw"`
-	RmpDecTmm  uint16             `sunspec:"offset=50,len=1,sf=RmpIncDec_SF,access=rw"`
-	RmpIncTmm  uint16             `sunspec:"offset=51,len=1,sf=RmpIncDec_SF,access=rw"`
-	RmpRsUp    uint16             `sunspec:"offset=52,len=1,sf=RmpIncDec_SF,access=rw"`
-	SnptW      sunspec.Bitfield16 `sunspec:"offset=53,len=1,access=rw"`
-	WRef       uint16             `sunspec:"offset=54,len=1,sf=W_SF,access=rw"`
-	WRefStrHz  uint16             `sunspec:"offset=55,len=1,sf=Hz_SF,access=rw"`
-	WRefStopHz uint16             `sunspec:"offset=56,len=1,sf=Hz_SF,access=rw"`
-	ReadOnly   sunspec.Enum16     `sunspec:"offset=57,len=1"`
+	RmpPT1Tms  uint16             `sunspec:"offset=49,access=rw"`
+	RmpDecTmm  uint16             `sunspec:"offset=50,sf=RmpIncDec_SF,access=rw"`
+	RmpIncTmm  uint16             `sunspec:"offset=51,sf=RmpIncDec_SF,access=rw"`
+	RmpRsUp    uint16             `sunspec:"offset=52,sf=RmpIncDec_SF,access=rw"`
+	SnptW      sunspec.Bitfield16 `sunspec:"offset=53,access=rw"`
+	WRef       uint16             `sunspec:"offset=54,sf=W_SF,access=rw"`
+	WRefStrHz  uint16             `sunspec:"offset=55,sf=Hz_SF,access=rw"`
+	WRefStopHz uint16             `sunspec:"offset=56,sf=Hz_SF,access=rw"`
+	ReadOnly   sunspec.Enum16     `sunspec:"offset=57"`
 }
 
 type Block134 struct {
-	ActCrv       uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms       uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms      uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms       uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv         uint16              `sunspec:"offset=5,len=1"`
-	NPt          uint16              `sunspec:"offset=6,len=1"`
-	Hz_SF        sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	W_SF         sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
+	ActCrv       uint16              `sunspec:"offset=0,access=rw"`
+	ModEna       sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms       uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms      uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms       uint16              `sunspec:"offset=4,access=rw"`
+	NCrv         uint16              `sunspec:"offset=5"`
+	NPt          uint16              `sunspec:"offset=6"`
+	Hz_SF        sunspec.ScaleFactor `sunspec:"offset=7"`
+	W_SF         sunspec.ScaleFactor `sunspec:"offset=8"`
+	RmpIncDec_SF sunspec.ScaleFactor `sunspec:"offset=9"`
 
 	Repeats []Block134Repeat
 }
@@ -166,73 +166,73 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "Is curve-based Frequency-Watt control active."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for freq-watt change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for freq-watt curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend min. 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Hz_SF, Offset: 7, Type: typelabel.ScaleFactor, Units: "SF", Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: W_SF, Offset: 8, Type: typelabel.ScaleFactor, Units: "SF", Length: 1, Mandatory: true, Label: "W_SF", Description: "Scale factor for percent WRef."},
-					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Units: "SF", Length: 1, Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "Is curve-based Frequency-Watt control active."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for freq-watt change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for freq-watt curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend min. 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Hz_SF, Offset: 7, Type: typelabel.ScaleFactor, Units: "SF", Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: W_SF, Offset: 8, Type: typelabel.ScaleFactor, Units: "SF", Mandatory: true, Label: "W_SF", Description: "Scale factor for percent WRef."},
+					{Id: RmpIncDec_SF, Offset: 9, Type: typelabel.ScaleFactor, Units: "SF", Label: "RmpIncDec_SF", Description: "Scale factor for increment and decrement ramps."},
 				},
 			},
 			{Name: "curve",
 				Length: 58,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Hz1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 Hertz."},
-					{Id: W1, Offset: 2, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Mandatory: true, Label: "W1", Description: "Point 1 Watts."},
-					{Id: Hz2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 Hertz."},
-					{Id: W2, Offset: 4, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W2", Description: "Point 2 Watts."},
-					{Id: Hz3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 Hertz."},
-					{Id: W3, Offset: 6, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W3", Description: "Point 3 Watts."},
-					{Id: Hz4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 Hertz."},
-					{Id: W4, Offset: 8, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W4", Description: "Point 4 Watts."},
-					{Id: Hz5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 Hertz."},
-					{Id: W5, Offset: 10, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W5", Description: "Point 5 Watts."},
-					{Id: Hz6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 Hertz."},
-					{Id: W6, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W6", Description: "Point 6 Watts."},
-					{Id: Hz7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 Hertz."},
-					{Id: W7, Offset: 14, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W7", Description: "Point 7 Watts."},
-					{Id: Hz8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 Hertz."},
-					{Id: W8, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W8", Description: "Point 8 Watts."},
-					{Id: Hz9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 Hertz."},
-					{Id: W9, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W9", Description: "Point 9 Watts."},
-					{Id: Hz10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 Hertz."},
-					{Id: W10, Offset: 20, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W10", Description: "Point 10 Watts."},
-					{Id: Hz11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 Hertz."},
-					{Id: W11, Offset: 22, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W11", Description: "Point 11 Watts."},
-					{Id: Hz12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 Hertz."},
-					{Id: W12, Offset: 24, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W12", Description: "Point 12 Watts."},
-					{Id: Hz13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 Hertz."},
-					{Id: W13, Offset: 26, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W13", Description: "Point 13 Watts."},
-					{Id: Hz14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 Hertz."},
-					{Id: W14, Offset: 28, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W14", Description: "Point 14 Watts."},
-					{Id: Hz15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 Hertz."},
-					{Id: W15, Offset: 30, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W15", Description: "Point 15 Watts."},
-					{Id: Hz16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 Hertz."},
-					{Id: W16, Offset: 32, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W16", Description: "Point 16 Watts."},
-					{Id: Hz17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 Hertz."},
-					{Id: W17, Offset: 34, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W17", Description: "Point 17 Watts."},
-					{Id: Hz18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 Hertz."},
-					{Id: W18, Offset: 36, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W18", Description: "Point 18 Watts."},
-					{Id: Hz19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 Hertz."},
-					{Id: W19, Offset: 38, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W19", Description: "Point 19 Watts."},
-					{Id: Hz20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 Hertz."},
-					{Id: W20, Offset: 40, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Length: 1, Label: "W20", Description: "Point 20 Watts."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Hz1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 Hertz."},
+					{Id: W1, Offset: 2, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Mandatory: true, Label: "W1", Description: "Point 1 Watts."},
+					{Id: Hz2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 Hertz."},
+					{Id: W2, Offset: 4, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W2", Description: "Point 2 Watts."},
+					{Id: Hz3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 Hertz."},
+					{Id: W3, Offset: 6, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W3", Description: "Point 3 Watts."},
+					{Id: Hz4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 Hertz."},
+					{Id: W4, Offset: 8, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W4", Description: "Point 4 Watts."},
+					{Id: Hz5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 Hertz."},
+					{Id: W5, Offset: 10, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W5", Description: "Point 5 Watts."},
+					{Id: Hz6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 Hertz."},
+					{Id: W6, Offset: 12, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W6", Description: "Point 6 Watts."},
+					{Id: Hz7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 Hertz."},
+					{Id: W7, Offset: 14, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W7", Description: "Point 7 Watts."},
+					{Id: Hz8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 Hertz."},
+					{Id: W8, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W8", Description: "Point 8 Watts."},
+					{Id: Hz9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 Hertz."},
+					{Id: W9, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W9", Description: "Point 9 Watts."},
+					{Id: Hz10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 Hertz."},
+					{Id: W10, Offset: 20, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W10", Description: "Point 10 Watts."},
+					{Id: Hz11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 Hertz."},
+					{Id: W11, Offset: 22, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W11", Description: "Point 11 Watts."},
+					{Id: Hz12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 Hertz."},
+					{Id: W12, Offset: 24, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W12", Description: "Point 12 Watts."},
+					{Id: Hz13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 Hertz."},
+					{Id: W13, Offset: 26, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W13", Description: "Point 13 Watts."},
+					{Id: Hz14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 Hertz."},
+					{Id: W14, Offset: 28, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W14", Description: "Point 14 Watts."},
+					{Id: Hz15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 Hertz."},
+					{Id: W15, Offset: 30, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W15", Description: "Point 15 Watts."},
+					{Id: Hz16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 Hertz."},
+					{Id: W16, Offset: 32, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W16", Description: "Point 16 Watts."},
+					{Id: Hz17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 Hertz."},
+					{Id: W17, Offset: 34, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W17", Description: "Point 17 Watts."},
+					{Id: Hz18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 Hertz."},
+					{Id: W18, Offset: 36, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W18", Description: "Point 18 Watts."},
+					{Id: Hz19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 Hertz."},
+					{Id: W19, Offset: 38, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W19", Description: "Point 19 Watts."},
+					{Id: Hz20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 Hertz."},
+					{Id: W20, Offset: 40, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "% WRef", Access: "rw", Label: "W20", Description: "Point 20 Watts."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve. (Max 16 chars)"},
-					{Id: RmpPT1Tms, Offset: 49, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpPT1Tms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
-					{Id: RmpDecTmm, Offset: 50, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Length: 1, Label: "RmpDecTmm", Description: "The maximum rate at which the power value may be reduced in response to changes in the frequency value."},
-					{Id: RmpIncTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Length: 1, Label: "RmpIncTmm", Description: "The maximum rate at which the power value may be increased in response to changes in the frequency value."},
-					{Id: RmpRsUp, Offset: 52, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Length: 1, Label: "RmpRsUp", Description: "The maximum rate at which the power may be increased after releasing the frozen value of snap shot function. "},
-					{Id: SnptW, Offset: 53, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "SnptW", Description: "1=enable snapshot/capture mode"},
-					{Id: WRef, Offset: 54, Type: typelabel.Uint16, ScaleFactor: "W_SF", Units: "W", Access: "rw", Length: 1, Label: "WRef", Description: "Reference active power (default = WMax)."},
-					{Id: WRefStrHz, Offset: 55, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "WRefStrHz", Description: "Frequency deviation from nominal frequency at the time of the snapshot to start constraining power output."},
-					{Id: WRefStopHz, Offset: 56, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "WRefStopHz", Description: "Frequency deviation from nominal frequency at which to release the power output."},
-					{Id: ReadOnly, Offset: 57, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: RmpPT1Tms, Offset: 49, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpPT1Tms", Description: "The time of the PT1 in seconds (time to accomplish a change of 95%)."},
+					{Id: RmpDecTmm, Offset: 50, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Label: "RmpDecTmm", Description: "The maximum rate at which the power value may be reduced in response to changes in the frequency value."},
+					{Id: RmpIncTmm, Offset: 51, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Label: "RmpIncTmm", Description: "The maximum rate at which the power value may be increased in response to changes in the frequency value."},
+					{Id: RmpRsUp, Offset: 52, Type: typelabel.Uint16, ScaleFactor: "RmpIncDec_SF", Units: "% WMax/min", Access: "rw", Label: "RmpRsUp", Description: "The maximum rate at which the power may be increased after releasing the frozen value of snap shot function. "},
+					{Id: SnptW, Offset: 53, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "SnptW", Description: "1=enable snapshot/capture mode"},
+					{Id: WRef, Offset: 54, Type: typelabel.Uint16, ScaleFactor: "W_SF", Units: "W", Access: "rw", Label: "WRef", Description: "Reference active power (default = WMax)."},
+					{Id: WRefStrHz, Offset: 55, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "WRefStrHz", Description: "Frequency deviation from nominal frequency at the time of the snapshot to start constraining power output."},
+					{Id: WRefStopHz, Offset: 56, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "WRefStopHz", Description: "Frequency deviation from nominal frequency at which to release the power output."},
+					{Id: ReadOnly, Offset: 57, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model135/model.go
+++ b/models/model135/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block135Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	Hz1      uint16         `sunspec:"offset=2,len=1,sf=Hz_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	Hz2      uint16         `sunspec:"offset=4,len=1,sf=Hz_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	Hz3      uint16         `sunspec:"offset=6,len=1,sf=Hz_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	Hz4      uint16         `sunspec:"offset=8,len=1,sf=Hz_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	Hz5      uint16         `sunspec:"offset=10,len=1,sf=Hz_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	Hz6      uint16         `sunspec:"offset=12,len=1,sf=Hz_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	Hz7      uint16         `sunspec:"offset=14,len=1,sf=Hz_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	Hz8      uint16         `sunspec:"offset=16,len=1,sf=Hz_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	Hz9      uint16         `sunspec:"offset=18,len=1,sf=Hz_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	Hz10     uint16         `sunspec:"offset=20,len=1,sf=Hz_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	Hz11     uint16         `sunspec:"offset=22,len=1,sf=Hz_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	Hz12     uint16         `sunspec:"offset=24,len=1,sf=Hz_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	Hz13     uint16         `sunspec:"offset=26,len=1,sf=Hz_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	Hz14     uint16         `sunspec:"offset=28,len=1,sf=Hz_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	Hz15     uint16         `sunspec:"offset=30,len=1,sf=Hz_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	Hz16     uint16         `sunspec:"offset=32,len=1,sf=Hz_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	Hz17     uint16         `sunspec:"offset=34,len=1,sf=Hz_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	Hz18     uint16         `sunspec:"offset=36,len=1,sf=Hz_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	Hz19     uint16         `sunspec:"offset=38,len=1,sf=Hz_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	Hz20     uint16         `sunspec:"offset=40,len=1,sf=Hz_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	Hz1      uint16         `sunspec:"offset=2,sf=Hz_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	Hz2      uint16         `sunspec:"offset=4,sf=Hz_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	Hz3      uint16         `sunspec:"offset=6,sf=Hz_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	Hz4      uint16         `sunspec:"offset=8,sf=Hz_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	Hz5      uint16         `sunspec:"offset=10,sf=Hz_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	Hz6      uint16         `sunspec:"offset=12,sf=Hz_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	Hz7      uint16         `sunspec:"offset=14,sf=Hz_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	Hz8      uint16         `sunspec:"offset=16,sf=Hz_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	Hz9      uint16         `sunspec:"offset=18,sf=Hz_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	Hz10     uint16         `sunspec:"offset=20,sf=Hz_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	Hz11     uint16         `sunspec:"offset=22,sf=Hz_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	Hz12     uint16         `sunspec:"offset=24,sf=Hz_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	Hz13     uint16         `sunspec:"offset=26,sf=Hz_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	Hz14     uint16         `sunspec:"offset=28,sf=Hz_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	Hz15     uint16         `sunspec:"offset=30,sf=Hz_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	Hz16     uint16         `sunspec:"offset=32,sf=Hz_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	Hz17     uint16         `sunspec:"offset=34,sf=Hz_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	Hz18     uint16         `sunspec:"offset=36,sf=Hz_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	Hz19     uint16         `sunspec:"offset=38,sf=Hz_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	Hz20     uint16         `sunspec:"offset=40,sf=Hz_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block135 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block135Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LFRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LFRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
-					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 must disconnect frequency."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must disconnect duration."},
-					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 must disconnect frequency."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must disconnect duration."},
-					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 must disconnect frequency."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must disconnect duration."},
-					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 must disconnect frequency."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must disconnect duration."},
-					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 must disconnect frequency."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must disconnect duration."},
-					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 must disconnect frequency."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must disconnect duration."},
-					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 must disconnect frequency."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must disconnect duration."},
-					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 must disconnect frequency."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must disconnect duration."},
-					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 must disconnect frequency."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must disconnect duration."},
-					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 must disconnect frequency."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must disconnect duration."},
-					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 must disconnect frequency."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must disconnect duration."},
-					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 must disconnect frequency."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must disconnect duration."},
-					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 must disconnect frequency."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must disconnect duration."},
-					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 must disconnect frequency."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must disconnect duration."},
-					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 must disconnect frequency."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must disconnect duration."},
-					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 must disconnect frequency."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must disconnect duration."},
-					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 must disconnect frequency."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must disconnect duration."},
-					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 must disconnect frequency."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must disconnect duration."},
-					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 must disconnect frequency."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must disconnect duration."},
-					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 must disconnect frequency."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
+					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 must disconnect frequency."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must disconnect duration."},
+					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 must disconnect frequency."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must disconnect duration."},
+					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 must disconnect frequency."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must disconnect duration."},
+					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 must disconnect frequency."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must disconnect duration."},
+					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 must disconnect frequency."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must disconnect duration."},
+					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 must disconnect frequency."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must disconnect duration."},
+					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 must disconnect frequency."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must disconnect duration."},
+					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 must disconnect frequency."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must disconnect duration."},
+					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 must disconnect frequency."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must disconnect duration."},
+					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 must disconnect frequency."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must disconnect duration."},
+					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 must disconnect frequency."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must disconnect duration."},
+					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 must disconnect frequency."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must disconnect duration."},
+					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 must disconnect frequency."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must disconnect duration."},
+					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 must disconnect frequency."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must disconnect duration."},
+					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 must disconnect frequency."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must disconnect duration."},
+					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 must disconnect frequency."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must disconnect duration."},
+					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 must disconnect frequency."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must disconnect duration."},
+					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 must disconnect frequency."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must disconnect duration."},
+					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 must disconnect frequency."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must disconnect duration."},
+					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 must disconnect frequency."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model136/model.go
+++ b/models/model136/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block136Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	Hz1      uint16         `sunspec:"offset=2,len=1,sf=Hz_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	Hz2      uint16         `sunspec:"offset=4,len=1,sf=Hz_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	Hz3      uint16         `sunspec:"offset=6,len=1,sf=Hz_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	Hz4      uint16         `sunspec:"offset=8,len=1,sf=Hz_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	Hz5      uint16         `sunspec:"offset=10,len=1,sf=Hz_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	Hz6      uint16         `sunspec:"offset=12,len=1,sf=Hz_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	Hz7      uint16         `sunspec:"offset=14,len=1,sf=Hz_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	Hz8      uint16         `sunspec:"offset=16,len=1,sf=Hz_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	Hz9      uint16         `sunspec:"offset=18,len=1,sf=Hz_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	Hz10     uint16         `sunspec:"offset=20,len=1,sf=Hz_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	Hz11     uint16         `sunspec:"offset=22,len=1,sf=Hz_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	Hz12     uint16         `sunspec:"offset=24,len=1,sf=Hz_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	Hz13     uint16         `sunspec:"offset=26,len=1,sf=Hz_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	Hz14     uint16         `sunspec:"offset=28,len=1,sf=Hz_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	Hz15     uint16         `sunspec:"offset=30,len=1,sf=Hz_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	Hz16     uint16         `sunspec:"offset=32,len=1,sf=Hz_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	Hz17     uint16         `sunspec:"offset=34,len=1,sf=Hz_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	Hz18     uint16         `sunspec:"offset=36,len=1,sf=Hz_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	Hz19     uint16         `sunspec:"offset=38,len=1,sf=Hz_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	Hz20     uint16         `sunspec:"offset=40,len=1,sf=Hz_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	Hz1      uint16         `sunspec:"offset=2,sf=Hz_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	Hz2      uint16         `sunspec:"offset=4,sf=Hz_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	Hz3      uint16         `sunspec:"offset=6,sf=Hz_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	Hz4      uint16         `sunspec:"offset=8,sf=Hz_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	Hz5      uint16         `sunspec:"offset=10,sf=Hz_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	Hz6      uint16         `sunspec:"offset=12,sf=Hz_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	Hz7      uint16         `sunspec:"offset=14,sf=Hz_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	Hz8      uint16         `sunspec:"offset=16,sf=Hz_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	Hz9      uint16         `sunspec:"offset=18,sf=Hz_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	Hz10     uint16         `sunspec:"offset=20,sf=Hz_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	Hz11     uint16         `sunspec:"offset=22,sf=Hz_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	Hz12     uint16         `sunspec:"offset=24,sf=Hz_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	Hz13     uint16         `sunspec:"offset=26,sf=Hz_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	Hz14     uint16         `sunspec:"offset=28,sf=Hz_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	Hz15     uint16         `sunspec:"offset=30,sf=Hz_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	Hz16     uint16         `sunspec:"offset=32,sf=Hz_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	Hz17     uint16         `sunspec:"offset=34,sf=Hz_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	Hz18     uint16         `sunspec:"offset=36,sf=Hz_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	Hz19     uint16         `sunspec:"offset=38,sf=Hz_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	Hz20     uint16         `sunspec:"offset=40,sf=Hz_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block136 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block136Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "HFRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for HFRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for HFRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "HFRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for HFRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for HFRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
-					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 must disconnect frequency."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must disconnect duration."},
-					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 must disconnect frequency."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must disconnect duration."},
-					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 must disconnect frequency."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must disconnect duration."},
-					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 must disconnect frequency."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must disconnect duration."},
-					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 must disconnect frequency."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must disconnect duration."},
-					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 must disconnect frequency."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must disconnect duration."},
-					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 must disconnect frequency."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must disconnect duration."},
-					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 must disconnect frequency."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must disconnect duration."},
-					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 must disconnect frequency."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must disconnect duration."},
-					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 must disconnect frequency."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must disconnect duration."},
-					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 must disconnect frequency."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must disconnect duration."},
-					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 must disconnect frequency."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must disconnect duration."},
-					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 must disconnect frequency."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must disconnect duration."},
-					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 must disconnect frequency."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must disconnect duration."},
-					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 must disconnect frequency."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must disconnect duration."},
-					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 must disconnect frequency."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must disconnect duration."},
-					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 must disconnect frequency."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must disconnect duration."},
-					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 must disconnect frequency."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must disconnect duration."},
-					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 must disconnect frequency."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must disconnect duration."},
-					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 must disconnect frequency."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must disconnect duration."},
+					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 must disconnect frequency."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must disconnect duration."},
+					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 must disconnect frequency."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must disconnect duration."},
+					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 must disconnect frequency."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must disconnect duration."},
+					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 must disconnect frequency."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must disconnect duration."},
+					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 must disconnect frequency."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must disconnect duration."},
+					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 must disconnect frequency."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must disconnect duration."},
+					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 must disconnect frequency."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must disconnect duration."},
+					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 must disconnect frequency."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must disconnect duration."},
+					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 must disconnect frequency."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must disconnect duration."},
+					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 must disconnect frequency."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must disconnect duration."},
+					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 must disconnect frequency."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must disconnect duration."},
+					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 must disconnect frequency."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must disconnect duration."},
+					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 must disconnect frequency."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must disconnect duration."},
+					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 must disconnect frequency."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must disconnect duration."},
+					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 must disconnect frequency."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must disconnect duration."},
+					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 must disconnect frequency."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must disconnect duration."},
+					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 must disconnect frequency."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must disconnect duration."},
+					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 must disconnect frequency."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must disconnect duration."},
+					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 must disconnect frequency."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must disconnect duration."},
+					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 must disconnect frequency."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model137/model.go
+++ b/models/model137/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block137Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	V1       uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	V2       uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	V3       uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	V4       uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	V5       uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	V6       uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	V7       uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	V8       uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	V9       uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	V10      uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	V11      uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	V12      uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	V13      uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	V14      uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	V15      uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	V16      uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	V17      uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	V18      uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	V19      uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	V20      uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	V1       uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	V2       uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	V3       uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	V4       uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	V5       uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	V6       uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	V7       uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	V8       uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	V9       uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	V10      uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	V11      uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	V12      uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	V13      uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	V14      uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	V15      uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	V16      uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	V17      uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	V18      uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	V19      uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	V20      uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block137 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block137Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LVRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LVRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 must remain connected voltage."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must remain connected duration."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 must remain connected voltage."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must remain connected duration."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 must remain connected voltage."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must remain connected duration."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 must remain connected voltage."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must remain connected duration."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 must remain connected voltage."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must remain connected duration."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 must remain connected voltage."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must remain connected duration."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 must remain connected voltage."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must remain connected duration."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 must remain connected voltage."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must remain connected duration."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 must remain connected voltage."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must remain connected duration."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 must remain connected voltage."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must remain connected duration."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 must remain connected voltage."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must remain connected duration."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 must remain connected voltage."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must remain connected duration."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 must remain connected voltage."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must remain connected duration."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 must remain connected voltage."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must remain connected duration."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 must remain connected voltage."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must remain connected duration."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 must remain connected voltage."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must remain connected duration."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 must remain connected voltage."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must remain connected duration."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 must remain connected voltage."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must remain connected duration."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 must remain connected voltage."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must remain connected duration."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 must remain connected voltage."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 must remain connected voltage."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must remain connected duration."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 must remain connected voltage."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must remain connected duration."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 must remain connected voltage."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must remain connected duration."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 must remain connected voltage."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must remain connected duration."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 must remain connected voltage."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must remain connected duration."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 must remain connected voltage."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must remain connected duration."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 must remain connected voltage."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must remain connected duration."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 must remain connected voltage."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must remain connected duration."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 must remain connected voltage."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must remain connected duration."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 must remain connected voltage."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must remain connected duration."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 must remain connected voltage."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must remain connected duration."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 must remain connected voltage."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must remain connected duration."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 must remain connected voltage."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must remain connected duration."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 must remain connected voltage."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must remain connected duration."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 must remain connected voltage."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must remain connected duration."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 must remain connected voltage."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must remain connected duration."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 must remain connected voltage."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must remain connected duration."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 must remain connected voltage."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must remain connected duration."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 must remain connected voltage."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must remain connected duration."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 must remain connected voltage."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model138/model.go
+++ b/models/model138/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block138Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	V1       uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	V2       uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	V3       uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	V4       uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	V5       uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	V6       uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	V7       uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	V8       uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	V9       uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	V10      uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	V11      uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	V12      uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	V13      uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	V14      uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	V15      uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	V16      uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	V17      uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	V18      uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	V19      uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	V20      uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	V1       uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	V2       uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	V3       uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	V4       uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	V5       uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	V6       uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	V7       uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	V8       uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	V9       uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	V10      uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	V11      uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	V12      uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	V13      uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	V14      uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	V15      uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	V16      uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	V17      uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	V18      uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	V19      uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	V20      uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block138 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block138Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "HVRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for HVRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for HVRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "HVRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for HVRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for HVRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 must remain connected voltage."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must remain connected duration."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 must remain connected voltage."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must remain connected duration."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 must remain connected voltage."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must remain connected duration."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 must remain connected voltage."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must remain connected duration."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 must remain connected voltage."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must remain connected duration."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 must remain connected voltage."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must remain connected duration."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 must remain connected voltage."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must remain connected duration."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 must remain connected voltage."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must remain connected duration."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 must remain connected voltage."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must remain connected duration."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 must remain connected voltage."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must remain connected duration."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 must remain connected voltage."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must remain connected duration."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 must remain connected voltage."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must remain connected duration."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 must remain connected voltage."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must remain connected duration."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 must remain connected voltage."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must remain connected duration."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 must remain connected voltage."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must remain connected duration."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 must remain connected voltage."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must remain connected duration."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 must remain connected voltage."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must remain connected duration."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 must remain connected voltage."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must remain connected duration."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 must remain connected voltage."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must remain connected duration."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 must remain connected voltage."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 must remain connected voltage."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must remain connected duration."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 must remain connected voltage."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must remain connected duration."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 must remain connected voltage."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must remain connected duration."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 must remain connected voltage."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must remain connected duration."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 must remain connected voltage."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must remain connected duration."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 must remain connected voltage."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must remain connected duration."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 must remain connected voltage."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must remain connected duration."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 must remain connected voltage."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must remain connected duration."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 must remain connected voltage."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must remain connected duration."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 must remain connected voltage."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must remain connected duration."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 must remain connected voltage."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must remain connected duration."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 must remain connected voltage."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must remain connected duration."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 must remain connected voltage."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must remain connected duration."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 must remain connected voltage."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must remain connected duration."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 must remain connected voltage."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must remain connected duration."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 must remain connected voltage."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must remain connected duration."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 must remain connected voltage."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must remain connected duration."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 must remain connected voltage."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must remain connected duration."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 must remain connected voltage."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must remain connected duration."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 must remain connected voltage."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model139/model.go
+++ b/models/model139/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block139Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	V1       uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	V2       uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	V3       uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	V4       uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	V5       uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	V6       uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	V7       uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	V8       uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	V9       uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	V10      uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	V11      uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	V12      uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	V13      uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	V14      uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	V15      uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	V16      uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	V17      uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	V18      uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	V19      uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	V20      uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	V1       uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	V2       uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	V3       uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	V4       uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	V5       uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	V6       uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	V7       uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	V8       uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	V9       uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	V10      uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	V11      uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	V12      uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	V13      uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	V14      uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	V15      uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	V16      uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	V17      uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	V18      uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	V19      uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	V20      uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block139 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	CrvType sunspec.Enum16      `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=8"`
+	CrvType sunspec.Enum16      `sunspec:"offset=9"`
 
 	Repeats []Block139Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LVRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Length: 1, Mandatory: true},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LVRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Mandatory: true},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 voltage."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 duration."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 voltage."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 duration."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 voltage."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 duration."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 voltage."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 duration."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 voltage."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 duration."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 voltage."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 duration."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 voltage."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 duration."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 voltage."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 duration."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 voltage."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 duration."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 voltage."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 duration."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 voltage."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 duration."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 voltage."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 duration."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 voltage."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 duration."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 voltage."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 duration."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 voltage."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 duration."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 voltage."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 duration."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 voltage."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 duration."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 voltage."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 duration."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 voltage."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 duration."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 voltage."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 voltage."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 duration."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 voltage."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 duration."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 voltage."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 duration."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 voltage."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 duration."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 voltage."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 duration."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 voltage."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 duration."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 voltage."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 duration."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 voltage."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 duration."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 voltage."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 duration."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 voltage."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 duration."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 voltage."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 duration."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 voltage."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 duration."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 voltage."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 duration."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 voltage."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 duration."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 voltage."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 duration."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 voltage."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 duration."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 voltage."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 duration."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 voltage."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 duration."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 voltage."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 duration."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 voltage."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model14/model.go
+++ b/models/model14/model.go
@@ -30,11 +30,11 @@ const (
 
 type Block14 struct {
 	Nam  string             `sunspec:"offset=0,len=4,access=rw"`
-	Cap  sunspec.Bitfield16 `sunspec:"offset=4,len=1,access=rw"`
-	Cfg  sunspec.Enum16     `sunspec:"offset=5,len=1,access=rw"`
-	Typ  sunspec.Bitfield16 `sunspec:"offset=6,len=1,access=rw"`
+	Cap  sunspec.Bitfield16 `sunspec:"offset=4,access=rw"`
+	Cfg  sunspec.Enum16     `sunspec:"offset=5,access=rw"`
+	Typ  sunspec.Bitfield16 `sunspec:"offset=6,access=rw"`
 	Addr string             `sunspec:"offset=7,len=20,access=rw"`
-	Port uint16             `sunspec:"offset=27,len=1,access=rw"`
+	Port uint16             `sunspec:"offset=27,access=rw"`
 	User string             `sunspec:"offset=28,len=12,access=rw"`
 	Pw   string             `sunspec:"offset=40,len=12,access=rw"`
 }
@@ -56,11 +56,11 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "name", Description: "Interface name (8 chars)"},
-					{Id: Cap, Offset: 4, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "Capabilities", Description: "Bitmask value.  Proxy configuration capabilities"},
-					{Id: Cfg, Offset: 5, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Config", Description: "Enumerated value.  Set proxy address type"},
-					{Id: Typ, Offset: 6, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "Type", Description: "Enumerate value.  Proxy server type"},
+					{Id: Cap, Offset: 4, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "Capabilities", Description: "Bitmask value.  Proxy configuration capabilities"},
+					{Id: Cfg, Offset: 5, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Config", Description: "Enumerated value.  Set proxy address type"},
+					{Id: Typ, Offset: 6, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "Type", Description: "Enumerate value.  Proxy server type"},
 					{Id: Addr, Offset: 7, Type: typelabel.String, Access: "rw", Length: 20, Mandatory: true, Label: "Address", Description: "IPv4 or IPv6 proxy hostname or dotted address (40 chars)"},
-					{Id: Port, Offset: 27, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Port", Description: "Proxy port number"},
+					{Id: Port, Offset: 27, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Port", Description: "Proxy port number"},
 					{Id: User, Offset: 28, Type: typelabel.String, Access: "rw", Length: 12, Label: "Username", Description: "Proxy user name"},
 					{Id: Pw, Offset: 40, Type: typelabel.String, Access: "rw", Length: 12, Label: "Password", Description: "Proxy password"},
 				},

--- a/models/model140/model.go
+++ b/models/model140/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block140Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	V1       uint16         `sunspec:"offset=2,len=1,sf=V_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	V2       uint16         `sunspec:"offset=4,len=1,sf=V_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	V3       uint16         `sunspec:"offset=6,len=1,sf=V_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	V4       uint16         `sunspec:"offset=8,len=1,sf=V_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	V5       uint16         `sunspec:"offset=10,len=1,sf=V_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	V6       uint16         `sunspec:"offset=12,len=1,sf=V_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	V7       uint16         `sunspec:"offset=14,len=1,sf=V_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	V8       uint16         `sunspec:"offset=16,len=1,sf=V_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	V9       uint16         `sunspec:"offset=18,len=1,sf=V_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	V10      uint16         `sunspec:"offset=20,len=1,sf=V_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	V11      uint16         `sunspec:"offset=22,len=1,sf=V_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	V12      uint16         `sunspec:"offset=24,len=1,sf=V_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	V13      uint16         `sunspec:"offset=26,len=1,sf=V_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	V14      uint16         `sunspec:"offset=28,len=1,sf=V_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	V15      uint16         `sunspec:"offset=30,len=1,sf=V_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	V16      uint16         `sunspec:"offset=32,len=1,sf=V_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	V17      uint16         `sunspec:"offset=34,len=1,sf=V_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	V18      uint16         `sunspec:"offset=36,len=1,sf=V_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	V19      uint16         `sunspec:"offset=38,len=1,sf=V_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	V20      uint16         `sunspec:"offset=40,len=1,sf=V_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	V1       uint16         `sunspec:"offset=2,sf=V_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	V2       uint16         `sunspec:"offset=4,sf=V_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	V3       uint16         `sunspec:"offset=6,sf=V_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	V4       uint16         `sunspec:"offset=8,sf=V_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	V5       uint16         `sunspec:"offset=10,sf=V_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	V6       uint16         `sunspec:"offset=12,sf=V_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	V7       uint16         `sunspec:"offset=14,sf=V_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	V8       uint16         `sunspec:"offset=16,sf=V_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	V9       uint16         `sunspec:"offset=18,sf=V_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	V10      uint16         `sunspec:"offset=20,sf=V_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	V11      uint16         `sunspec:"offset=22,sf=V_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	V12      uint16         `sunspec:"offset=24,sf=V_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	V13      uint16         `sunspec:"offset=26,sf=V_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	V14      uint16         `sunspec:"offset=28,sf=V_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	V15      uint16         `sunspec:"offset=30,sf=V_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	V16      uint16         `sunspec:"offset=32,sf=V_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	V17      uint16         `sunspec:"offset=34,sf=V_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	V18      uint16         `sunspec:"offset=36,sf=V_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	V19      uint16         `sunspec:"offset=38,sf=V_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	V20      uint16         `sunspec:"offset=40,sf=V_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block140 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	V_SF    sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	CrvType sunspec.Enum16      `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	V_SF    sunspec.ScaleFactor `sunspec:"offset=8"`
+	CrvType sunspec.Enum16      `sunspec:"offset=9"`
 
 	Repeats []Block140Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LVRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
-					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Length: 1, Mandatory: true},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LVRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LVRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LVRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: V_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "V_SF", Description: "Scale factor for percent VRef."},
+					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Mandatory: true},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
-					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Mandatory: true, Label: "V1", Description: "Point 1 voltage."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 duration."},
-					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V2", Description: "Point 2 voltage."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 duration."},
-					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V3", Description: "Point 3 voltage."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 duration."},
-					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V4", Description: "Point 4 voltage."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 duration."},
-					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V5", Description: "Point 5 voltage."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 duration."},
-					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V6", Description: "Point 6 voltage."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 duration."},
-					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V7", Description: "Point 7 voltage."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 duration."},
-					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V8", Description: "Point 8 voltage."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 duration."},
-					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V9", Description: "Point 9 voltage."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 duration."},
-					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V10", Description: "Point 10 voltage."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 duration."},
-					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V11", Description: "Point 11 voltage."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 duration."},
-					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V12", Description: "Point 12 voltage."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 duration."},
-					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V13", Description: "Point 13 voltage."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 duration."},
-					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V14", Description: "Point 14 voltage."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 duration."},
-					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V15", Description: "Point 15 voltage."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 duration."},
-					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V16", Description: "Point 16 voltage."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 duration."},
-					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V17", Description: "Point 17 voltage."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 duration."},
-					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V18", Description: "Point 18 voltage."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 duration."},
-					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V19", Description: "Point 19 voltage."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 duration."},
-					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Length: 1, Label: "V20", Description: "Point 20 voltage."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
+					{Id: V1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Mandatory: true, Label: "V1", Description: "Point 1 voltage."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 duration."},
+					{Id: V2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V2", Description: "Point 2 voltage."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 duration."},
+					{Id: V3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V3", Description: "Point 3 voltage."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 duration."},
+					{Id: V4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V4", Description: "Point 4 voltage."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 duration."},
+					{Id: V5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V5", Description: "Point 5 voltage."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 duration."},
+					{Id: V6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V6", Description: "Point 6 voltage."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 duration."},
+					{Id: V7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V7", Description: "Point 7 voltage."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 duration."},
+					{Id: V8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V8", Description: "Point 8 voltage."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 duration."},
+					{Id: V9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V9", Description: "Point 9 voltage."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 duration."},
+					{Id: V10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V10", Description: "Point 10 voltage."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 duration."},
+					{Id: V11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V11", Description: "Point 11 voltage."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 duration."},
+					{Id: V12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V12", Description: "Point 12 voltage."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 duration."},
+					{Id: V13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V13", Description: "Point 13 voltage."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 duration."},
+					{Id: V14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V14", Description: "Point 14 voltage."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 duration."},
+					{Id: V15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V15", Description: "Point 15 voltage."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 duration."},
+					{Id: V16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V16", Description: "Point 16 voltage."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 duration."},
+					{Id: V17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V17", Description: "Point 17 voltage."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 duration."},
+					{Id: V18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V18", Description: "Point 18 voltage."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 duration."},
+					{Id: V19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V19", Description: "Point 19 voltage."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 duration."},
+					{Id: V20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "% VRef", Access: "rw", Label: "V20", Description: "Point 20 voltage."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model141/model.go
+++ b/models/model141/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block141Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	Hz1      uint16         `sunspec:"offset=2,len=1,sf=Hz_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	Hz2      uint16         `sunspec:"offset=4,len=1,sf=Hz_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	Hz3      uint16         `sunspec:"offset=6,len=1,sf=Hz_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	Hz4      uint16         `sunspec:"offset=8,len=1,sf=Hz_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	Hz5      uint16         `sunspec:"offset=10,len=1,sf=Hz_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	Hz6      uint16         `sunspec:"offset=12,len=1,sf=Hz_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	Hz7      uint16         `sunspec:"offset=14,len=1,sf=Hz_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	Hz8      uint16         `sunspec:"offset=16,len=1,sf=Hz_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	Hz9      uint16         `sunspec:"offset=18,len=1,sf=Hz_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	Hz10     uint16         `sunspec:"offset=20,len=1,sf=Hz_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	Hz11     uint16         `sunspec:"offset=22,len=1,sf=Hz_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	Hz12     uint16         `sunspec:"offset=24,len=1,sf=Hz_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	Hz13     uint16         `sunspec:"offset=26,len=1,sf=Hz_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	Hz14     uint16         `sunspec:"offset=28,len=1,sf=Hz_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	Hz15     uint16         `sunspec:"offset=30,len=1,sf=Hz_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	Hz16     uint16         `sunspec:"offset=32,len=1,sf=Hz_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	Hz17     uint16         `sunspec:"offset=34,len=1,sf=Hz_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	Hz18     uint16         `sunspec:"offset=36,len=1,sf=Hz_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	Hz19     uint16         `sunspec:"offset=38,len=1,sf=Hz_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	Hz20     uint16         `sunspec:"offset=40,len=1,sf=Hz_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	Hz1      uint16         `sunspec:"offset=2,sf=Hz_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	Hz2      uint16         `sunspec:"offset=4,sf=Hz_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	Hz3      uint16         `sunspec:"offset=6,sf=Hz_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	Hz4      uint16         `sunspec:"offset=8,sf=Hz_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	Hz5      uint16         `sunspec:"offset=10,sf=Hz_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	Hz6      uint16         `sunspec:"offset=12,sf=Hz_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	Hz7      uint16         `sunspec:"offset=14,sf=Hz_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	Hz8      uint16         `sunspec:"offset=16,sf=Hz_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	Hz9      uint16         `sunspec:"offset=18,sf=Hz_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	Hz10     uint16         `sunspec:"offset=20,sf=Hz_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	Hz11     uint16         `sunspec:"offset=22,sf=Hz_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	Hz12     uint16         `sunspec:"offset=24,sf=Hz_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	Hz13     uint16         `sunspec:"offset=26,sf=Hz_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	Hz14     uint16         `sunspec:"offset=28,sf=Hz_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	Hz15     uint16         `sunspec:"offset=30,sf=Hz_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	Hz16     uint16         `sunspec:"offset=32,sf=Hz_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	Hz17     uint16         `sunspec:"offset=34,sf=Hz_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	Hz18     uint16         `sunspec:"offset=36,sf=Hz_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	Hz19     uint16         `sunspec:"offset=38,sf=Hz_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	Hz20     uint16         `sunspec:"offset=40,sf=Hz_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block141 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block141Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LFRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LFRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
-					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 must remain connected frequency."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must remain connected duration."},
-					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 must remain connected frequency."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must remain connected duration."},
-					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 must remain connected frequency."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must remain connected duration."},
-					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 must remain connected frequency."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must remain connected duration."},
-					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 must remain connected frequency."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must remain connected duration."},
-					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 must remain connected frequency."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must remain connected duration."},
-					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 must remain connected frequency."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must remain connected duration."},
-					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 must remain connected frequency."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must remain connected duration."},
-					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 must remain connected frequency."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must remain connected duration."},
-					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 must remain connected frequency."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must remain connected duration."},
-					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 must remain connected frequency."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must remain connected duration."},
-					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 must remain connected frequency."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must remain connected duration."},
-					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 must remain connected frequency."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must remain connected duration."},
-					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 must remain connected frequency."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must remain connected duration."},
-					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 must remain connected frequency."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must remain connected duration."},
-					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 must remain connected frequency."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must remain connected duration."},
-					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 must remain connected frequency."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must remain connected duration."},
-					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 must remain connected frequency."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must remain connected duration."},
-					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 must remain connected frequency."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must remain connected duration."},
-					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 must remain connected frequency."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
+					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 must remain connected frequency."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must remain connected duration."},
+					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 must remain connected frequency."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must remain connected duration."},
+					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 must remain connected frequency."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must remain connected duration."},
+					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 must remain connected frequency."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must remain connected duration."},
+					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 must remain connected frequency."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must remain connected duration."},
+					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 must remain connected frequency."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must remain connected duration."},
+					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 must remain connected frequency."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must remain connected duration."},
+					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 must remain connected frequency."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must remain connected duration."},
+					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 must remain connected frequency."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must remain connected duration."},
+					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 must remain connected frequency."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must remain connected duration."},
+					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 must remain connected frequency."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must remain connected duration."},
+					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 must remain connected frequency."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must remain connected duration."},
+					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 must remain connected frequency."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must remain connected duration."},
+					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 must remain connected frequency."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must remain connected duration."},
+					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 must remain connected frequency."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must remain connected duration."},
+					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 must remain connected frequency."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must remain connected duration."},
+					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 must remain connected frequency."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must remain connected duration."},
+					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 must remain connected frequency."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must remain connected duration."},
+					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 must remain connected frequency."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must remain connected duration."},
+					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 must remain connected frequency."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model142/model.go
+++ b/models/model142/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block142Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	Hz1      uint16         `sunspec:"offset=2,len=1,sf=Hz_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	Hz2      uint16         `sunspec:"offset=4,len=1,sf=Hz_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	Hz3      uint16         `sunspec:"offset=6,len=1,sf=Hz_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	Hz4      uint16         `sunspec:"offset=8,len=1,sf=Hz_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	Hz5      uint16         `sunspec:"offset=10,len=1,sf=Hz_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	Hz6      uint16         `sunspec:"offset=12,len=1,sf=Hz_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	Hz7      uint16         `sunspec:"offset=14,len=1,sf=Hz_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	Hz8      uint16         `sunspec:"offset=16,len=1,sf=Hz_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	Hz9      uint16         `sunspec:"offset=18,len=1,sf=Hz_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	Hz10     uint16         `sunspec:"offset=20,len=1,sf=Hz_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	Hz11     uint16         `sunspec:"offset=22,len=1,sf=Hz_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	Hz12     uint16         `sunspec:"offset=24,len=1,sf=Hz_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	Hz13     uint16         `sunspec:"offset=26,len=1,sf=Hz_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	Hz14     uint16         `sunspec:"offset=28,len=1,sf=Hz_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	Hz15     uint16         `sunspec:"offset=30,len=1,sf=Hz_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	Hz16     uint16         `sunspec:"offset=32,len=1,sf=Hz_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	Hz17     uint16         `sunspec:"offset=34,len=1,sf=Hz_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	Hz18     uint16         `sunspec:"offset=36,len=1,sf=Hz_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	Hz19     uint16         `sunspec:"offset=38,len=1,sf=Hz_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	Hz20     uint16         `sunspec:"offset=40,len=1,sf=Hz_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	Hz1      uint16         `sunspec:"offset=2,sf=Hz_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	Hz2      uint16         `sunspec:"offset=4,sf=Hz_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	Hz3      uint16         `sunspec:"offset=6,sf=Hz_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	Hz4      uint16         `sunspec:"offset=8,sf=Hz_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	Hz5      uint16         `sunspec:"offset=10,sf=Hz_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	Hz6      uint16         `sunspec:"offset=12,sf=Hz_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	Hz7      uint16         `sunspec:"offset=14,sf=Hz_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	Hz8      uint16         `sunspec:"offset=16,sf=Hz_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	Hz9      uint16         `sunspec:"offset=18,sf=Hz_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	Hz10     uint16         `sunspec:"offset=20,sf=Hz_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	Hz11     uint16         `sunspec:"offset=22,sf=Hz_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	Hz12     uint16         `sunspec:"offset=24,sf=Hz_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	Hz13     uint16         `sunspec:"offset=26,sf=Hz_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	Hz14     uint16         `sunspec:"offset=28,sf=Hz_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	Hz15     uint16         `sunspec:"offset=30,sf=Hz_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	Hz16     uint16         `sunspec:"offset=32,sf=Hz_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	Hz17     uint16         `sunspec:"offset=34,sf=Hz_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	Hz18     uint16         `sunspec:"offset=36,sf=Hz_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	Hz19     uint16         `sunspec:"offset=38,sf=Hz_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	Hz20     uint16         `sunspec:"offset=40,sf=Hz_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block142 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	Pad     sunspec.Pad         `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	Pad     sunspec.Pad         `sunspec:"offset=9"`
 
 	Repeats []Block142Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LFRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: Pad, Offset: 9, Type: typelabel.Pad, Length: 1},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LFRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: Pad, Offset: 9, Type: typelabel.Pad},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
-					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 must remain connected frequency."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 must remain connected duration."},
-					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 must remain connected frequency."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 must remain connected duration."},
-					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 must remain connected frequency."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 must remain connected duration."},
-					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 must remain connected frequency."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 must remain connected duration."},
-					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 must remain connected frequency."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 must remain connected duration."},
-					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 must remain connected frequency."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 must remain connected duration."},
-					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 must remain connected frequency."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 must remain connected duration."},
-					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 must remain connected frequency."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 must remain connected duration."},
-					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 must remain connected frequency."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 must remain connected duration."},
-					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 must remain connected frequency."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 must remain connected duration."},
-					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 must remain connected frequency."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 must remain connected duration."},
-					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 must remain connected frequency."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 must remain connected duration."},
-					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 must remain connected frequency."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 must remain connected duration."},
-					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 must remain connected frequency."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 must remain connected duration."},
-					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 must remain connected frequency."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 must remain connected duration."},
-					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 must remain connected frequency."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 must remain connected duration."},
-					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 must remain connected frequency."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 must remain connected duration."},
-					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 must remain connected frequency."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 must remain connected duration."},
-					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 must remain connected frequency."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 must remain connected duration."},
-					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 must remain connected frequency."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 must remain connected duration."},
+					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 must remain connected frequency."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 must remain connected duration."},
+					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 must remain connected frequency."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 must remain connected duration."},
+					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 must remain connected frequency."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 must remain connected duration."},
+					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 must remain connected frequency."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 must remain connected duration."},
+					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 must remain connected frequency."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 must remain connected duration."},
+					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 must remain connected frequency."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 must remain connected duration."},
+					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 must remain connected frequency."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 must remain connected duration."},
+					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 must remain connected frequency."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 must remain connected duration."},
+					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 must remain connected frequency."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 must remain connected duration."},
+					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 must remain connected frequency."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 must remain connected duration."},
+					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 must remain connected frequency."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 must remain connected duration."},
+					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 must remain connected frequency."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 must remain connected duration."},
+					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 must remain connected frequency."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 must remain connected duration."},
+					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 must remain connected frequency."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 must remain connected duration."},
+					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 must remain connected frequency."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 must remain connected duration."},
+					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 must remain connected frequency."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 must remain connected duration."},
+					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 must remain connected frequency."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 must remain connected duration."},
+					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 must remain connected frequency."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 must remain connected duration."},
+					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 must remain connected frequency."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 must remain connected duration."},
+					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 must remain connected frequency."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model143/model.go
+++ b/models/model143/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block143Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	Hz1      uint16         `sunspec:"offset=2,len=1,sf=Hz_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	Hz2      uint16         `sunspec:"offset=4,len=1,sf=Hz_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	Hz3      uint16         `sunspec:"offset=6,len=1,sf=Hz_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	Hz4      uint16         `sunspec:"offset=8,len=1,sf=Hz_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	Hz5      uint16         `sunspec:"offset=10,len=1,sf=Hz_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	Hz6      uint16         `sunspec:"offset=12,len=1,sf=Hz_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	Hz7      uint16         `sunspec:"offset=14,len=1,sf=Hz_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	Hz8      uint16         `sunspec:"offset=16,len=1,sf=Hz_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	Hz9      uint16         `sunspec:"offset=18,len=1,sf=Hz_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	Hz10     uint16         `sunspec:"offset=20,len=1,sf=Hz_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	Hz11     uint16         `sunspec:"offset=22,len=1,sf=Hz_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	Hz12     uint16         `sunspec:"offset=24,len=1,sf=Hz_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	Hz13     uint16         `sunspec:"offset=26,len=1,sf=Hz_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	Hz14     uint16         `sunspec:"offset=28,len=1,sf=Hz_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	Hz15     uint16         `sunspec:"offset=30,len=1,sf=Hz_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	Hz16     uint16         `sunspec:"offset=32,len=1,sf=Hz_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	Hz17     uint16         `sunspec:"offset=34,len=1,sf=Hz_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	Hz18     uint16         `sunspec:"offset=36,len=1,sf=Hz_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	Hz19     uint16         `sunspec:"offset=38,len=1,sf=Hz_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	Hz20     uint16         `sunspec:"offset=40,len=1,sf=Hz_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	Hz1      uint16         `sunspec:"offset=2,sf=Hz_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	Hz2      uint16         `sunspec:"offset=4,sf=Hz_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	Hz3      uint16         `sunspec:"offset=6,sf=Hz_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	Hz4      uint16         `sunspec:"offset=8,sf=Hz_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	Hz5      uint16         `sunspec:"offset=10,sf=Hz_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	Hz6      uint16         `sunspec:"offset=12,sf=Hz_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	Hz7      uint16         `sunspec:"offset=14,sf=Hz_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	Hz8      uint16         `sunspec:"offset=16,sf=Hz_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	Hz9      uint16         `sunspec:"offset=18,sf=Hz_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	Hz10     uint16         `sunspec:"offset=20,sf=Hz_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	Hz11     uint16         `sunspec:"offset=22,sf=Hz_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	Hz12     uint16         `sunspec:"offset=24,sf=Hz_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	Hz13     uint16         `sunspec:"offset=26,sf=Hz_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	Hz14     uint16         `sunspec:"offset=28,sf=Hz_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	Hz15     uint16         `sunspec:"offset=30,sf=Hz_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	Hz16     uint16         `sunspec:"offset=32,sf=Hz_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	Hz17     uint16         `sunspec:"offset=34,sf=Hz_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	Hz18     uint16         `sunspec:"offset=36,sf=Hz_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	Hz19     uint16         `sunspec:"offset=38,sf=Hz_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	Hz20     uint16         `sunspec:"offset=40,sf=Hz_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block143 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	CrvType sunspec.Enum16      `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	CrvType sunspec.Enum16      `sunspec:"offset=9"`
 
 	Repeats []Block143Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LFRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Length: 1, Mandatory: true},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LFRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Mandatory: true},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
-					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 frequency."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 duration."},
-					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 frequency."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 duration."},
-					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 frequency."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 duration."},
-					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 frequency."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 duration."},
-					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 frequency."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 duration."},
-					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 frequency."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 duration."},
-					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 frequency."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 duration."},
-					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 frequency."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 duration."},
-					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 frequency."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 duration."},
-					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 frequency."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 duration."},
-					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 frequency."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 duration."},
-					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 frequency."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 duration."},
-					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 frequency."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 duration."},
-					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 frequency."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 duration."},
-					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 frequency."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 duration."},
-					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 frequency."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 duration."},
-					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 frequency."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 duration."},
-					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 frequency."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 duration."},
-					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 frequency."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 duration."},
-					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 frequency."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
+					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 frequency."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 duration."},
+					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 frequency."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 duration."},
+					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 frequency."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 duration."},
+					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 frequency."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 duration."},
+					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 frequency."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 duration."},
+					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 frequency."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 duration."},
+					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 frequency."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 duration."},
+					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 frequency."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 duration."},
+					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 frequency."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 duration."},
+					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 frequency."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 duration."},
+					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 frequency."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 duration."},
+					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 frequency."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 duration."},
+					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 frequency."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 duration."},
+					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 frequency."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 duration."},
+					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 frequency."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 duration."},
+					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 frequency."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 duration."},
+					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 frequency."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 duration."},
+					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 frequency."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 duration."},
+					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 frequency."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 duration."},
+					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 frequency."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model144/model.go
+++ b/models/model144/model.go
@@ -74,62 +74,62 @@ const (
 )
 
 type Block144Repeat struct {
-	ActPt    uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Tms1     uint16         `sunspec:"offset=1,len=1,sf=Tms_SF,access=rw"`
-	Hz1      uint16         `sunspec:"offset=2,len=1,sf=Hz_SF,access=rw"`
-	Tms2     uint16         `sunspec:"offset=3,len=1,sf=Tms_SF,access=rw"`
-	Hz2      uint16         `sunspec:"offset=4,len=1,sf=Hz_SF,access=rw"`
-	Tms3     uint16         `sunspec:"offset=5,len=1,sf=Tms_SF,access=rw"`
-	Hz3      uint16         `sunspec:"offset=6,len=1,sf=Hz_SF,access=rw"`
-	Tms4     uint16         `sunspec:"offset=7,len=1,sf=Tms_SF,access=rw"`
-	Hz4      uint16         `sunspec:"offset=8,len=1,sf=Hz_SF,access=rw"`
-	Tms5     uint16         `sunspec:"offset=9,len=1,sf=Tms_SF,access=rw"`
-	Hz5      uint16         `sunspec:"offset=10,len=1,sf=Hz_SF,access=rw"`
-	Tms6     uint16         `sunspec:"offset=11,len=1,sf=Tms_SF,access=rw"`
-	Hz6      uint16         `sunspec:"offset=12,len=1,sf=Hz_SF,access=rw"`
-	Tms7     uint16         `sunspec:"offset=13,len=1,sf=Tms_SF,access=rw"`
-	Hz7      uint16         `sunspec:"offset=14,len=1,sf=Hz_SF,access=rw"`
-	Tms8     uint16         `sunspec:"offset=15,len=1,sf=Tms_SF,access=rw"`
-	Hz8      uint16         `sunspec:"offset=16,len=1,sf=Hz_SF,access=rw"`
-	Tms9     uint16         `sunspec:"offset=17,len=1,sf=Tms_SF,access=rw"`
-	Hz9      uint16         `sunspec:"offset=18,len=1,sf=Hz_SF,access=rw"`
-	Tms10    uint16         `sunspec:"offset=19,len=1,sf=Tms_SF,access=rw"`
-	Hz10     uint16         `sunspec:"offset=20,len=1,sf=Hz_SF,access=rw"`
-	Tms11    uint16         `sunspec:"offset=21,len=1,sf=Tms_SF,access=rw"`
-	Hz11     uint16         `sunspec:"offset=22,len=1,sf=Hz_SF,access=rw"`
-	Tms12    uint16         `sunspec:"offset=23,len=1,sf=Tms_SF,access=rw"`
-	Hz12     uint16         `sunspec:"offset=24,len=1,sf=Hz_SF,access=rw"`
-	Tms13    uint16         `sunspec:"offset=25,len=1,sf=Tms_SF,access=rw"`
-	Hz13     uint16         `sunspec:"offset=26,len=1,sf=Hz_SF,access=rw"`
-	Tms14    uint16         `sunspec:"offset=27,len=1,sf=Tms_SF,access=rw"`
-	Hz14     uint16         `sunspec:"offset=28,len=1,sf=Hz_SF,access=rw"`
-	Tms15    uint16         `sunspec:"offset=29,len=1,sf=Tms_SF,access=rw"`
-	Hz15     uint16         `sunspec:"offset=30,len=1,sf=Hz_SF,access=rw"`
-	Tms16    uint16         `sunspec:"offset=31,len=1,sf=Tms_SF,access=rw"`
-	Hz16     uint16         `sunspec:"offset=32,len=1,sf=Hz_SF,access=rw"`
-	Tms17    uint16         `sunspec:"offset=33,len=1,sf=Tms_SF,access=rw"`
-	Hz17     uint16         `sunspec:"offset=34,len=1,sf=Hz_SF,access=rw"`
-	Tms18    uint16         `sunspec:"offset=35,len=1,sf=Tms_SF,access=rw"`
-	Hz18     uint16         `sunspec:"offset=36,len=1,sf=Hz_SF,access=rw"`
-	Tms19    uint16         `sunspec:"offset=37,len=1,sf=Tms_SF,access=rw"`
-	Hz19     uint16         `sunspec:"offset=38,len=1,sf=Hz_SF,access=rw"`
-	Tms20    uint16         `sunspec:"offset=39,len=1,sf=Tms_SF,access=rw"`
-	Hz20     uint16         `sunspec:"offset=40,len=1,sf=Hz_SF,access=rw"`
+	ActPt    uint16         `sunspec:"offset=0,access=rw"`
+	Tms1     uint16         `sunspec:"offset=1,sf=Tms_SF,access=rw"`
+	Hz1      uint16         `sunspec:"offset=2,sf=Hz_SF,access=rw"`
+	Tms2     uint16         `sunspec:"offset=3,sf=Tms_SF,access=rw"`
+	Hz2      uint16         `sunspec:"offset=4,sf=Hz_SF,access=rw"`
+	Tms3     uint16         `sunspec:"offset=5,sf=Tms_SF,access=rw"`
+	Hz3      uint16         `sunspec:"offset=6,sf=Hz_SF,access=rw"`
+	Tms4     uint16         `sunspec:"offset=7,sf=Tms_SF,access=rw"`
+	Hz4      uint16         `sunspec:"offset=8,sf=Hz_SF,access=rw"`
+	Tms5     uint16         `sunspec:"offset=9,sf=Tms_SF,access=rw"`
+	Hz5      uint16         `sunspec:"offset=10,sf=Hz_SF,access=rw"`
+	Tms6     uint16         `sunspec:"offset=11,sf=Tms_SF,access=rw"`
+	Hz6      uint16         `sunspec:"offset=12,sf=Hz_SF,access=rw"`
+	Tms7     uint16         `sunspec:"offset=13,sf=Tms_SF,access=rw"`
+	Hz7      uint16         `sunspec:"offset=14,sf=Hz_SF,access=rw"`
+	Tms8     uint16         `sunspec:"offset=15,sf=Tms_SF,access=rw"`
+	Hz8      uint16         `sunspec:"offset=16,sf=Hz_SF,access=rw"`
+	Tms9     uint16         `sunspec:"offset=17,sf=Tms_SF,access=rw"`
+	Hz9      uint16         `sunspec:"offset=18,sf=Hz_SF,access=rw"`
+	Tms10    uint16         `sunspec:"offset=19,sf=Tms_SF,access=rw"`
+	Hz10     uint16         `sunspec:"offset=20,sf=Hz_SF,access=rw"`
+	Tms11    uint16         `sunspec:"offset=21,sf=Tms_SF,access=rw"`
+	Hz11     uint16         `sunspec:"offset=22,sf=Hz_SF,access=rw"`
+	Tms12    uint16         `sunspec:"offset=23,sf=Tms_SF,access=rw"`
+	Hz12     uint16         `sunspec:"offset=24,sf=Hz_SF,access=rw"`
+	Tms13    uint16         `sunspec:"offset=25,sf=Tms_SF,access=rw"`
+	Hz13     uint16         `sunspec:"offset=26,sf=Hz_SF,access=rw"`
+	Tms14    uint16         `sunspec:"offset=27,sf=Tms_SF,access=rw"`
+	Hz14     uint16         `sunspec:"offset=28,sf=Hz_SF,access=rw"`
+	Tms15    uint16         `sunspec:"offset=29,sf=Tms_SF,access=rw"`
+	Hz15     uint16         `sunspec:"offset=30,sf=Hz_SF,access=rw"`
+	Tms16    uint16         `sunspec:"offset=31,sf=Tms_SF,access=rw"`
+	Hz16     uint16         `sunspec:"offset=32,sf=Hz_SF,access=rw"`
+	Tms17    uint16         `sunspec:"offset=33,sf=Tms_SF,access=rw"`
+	Hz17     uint16         `sunspec:"offset=34,sf=Hz_SF,access=rw"`
+	Tms18    uint16         `sunspec:"offset=35,sf=Tms_SF,access=rw"`
+	Hz18     uint16         `sunspec:"offset=36,sf=Hz_SF,access=rw"`
+	Tms19    uint16         `sunspec:"offset=37,sf=Tms_SF,access=rw"`
+	Hz19     uint16         `sunspec:"offset=38,sf=Hz_SF,access=rw"`
+	Tms20    uint16         `sunspec:"offset=39,sf=Tms_SF,access=rw"`
+	Hz20     uint16         `sunspec:"offset=40,sf=Hz_SF,access=rw"`
 	CrvNam   string         `sunspec:"offset=41,len=8,access=rw"`
-	ReadOnly sunspec.Enum16 `sunspec:"offset=49,len=1"`
+	ReadOnly sunspec.Enum16 `sunspec:"offset=49"`
 }
 
 type Block144 struct {
-	ActCrv  uint16              `sunspec:"offset=0,len=1,access=rw"`
-	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,len=1,access=rw"`
-	WinTms  uint16              `sunspec:"offset=2,len=1,access=rw"`
-	RvrtTms uint16              `sunspec:"offset=3,len=1,access=rw"`
-	RmpTms  uint16              `sunspec:"offset=4,len=1,access=rw"`
-	NCrv    uint16              `sunspec:"offset=5,len=1"`
-	NPt     uint16              `sunspec:"offset=6,len=1"`
-	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	CrvType sunspec.Enum16      `sunspec:"offset=9,len=1"`
+	ActCrv  uint16              `sunspec:"offset=0,access=rw"`
+	ModEna  sunspec.Bitfield16  `sunspec:"offset=1,access=rw"`
+	WinTms  uint16              `sunspec:"offset=2,access=rw"`
+	RvrtTms uint16              `sunspec:"offset=3,access=rw"`
+	RmpTms  uint16              `sunspec:"offset=4,access=rw"`
+	NCrv    uint16              `sunspec:"offset=5"`
+	NPt     uint16              `sunspec:"offset=6"`
+	Tms_SF  sunspec.ScaleFactor `sunspec:"offset=7"`
+	Hz_SF   sunspec.ScaleFactor `sunspec:"offset=8"`
+	CrvType sunspec.Enum16      `sunspec:"offset=9"`
 
 	Repeats []Block144Repeat
 }
@@ -150,65 +150,65 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
-					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
-					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "WinTms", Description: "Time window for LFRT change."},
-					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
-					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Length: 1, Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
-					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
-					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
-					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
-					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
-					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Length: 1, Mandatory: true},
+					{Id: ActCrv, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActCrv", Description: "Index of active curve. 0=no active curve."},
+					{Id: ModEna, Offset: 1, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "ModEna", Description: "LHzRT control mode. Enable active curve.  Bitfield value."},
+					{Id: WinTms, Offset: 2, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "WinTms", Description: "Time window for LFRT change."},
+					{Id: RvrtTms, Offset: 3, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RvrtTms", Description: "Timeout period for LFRT curve selection."},
+					{Id: RmpTms, Offset: 4, Type: typelabel.Uint16, Units: "Secs", Access: "rw", Label: "RmpTms", Description: "Ramp time for moving from current mode to new mode."},
+					{Id: NCrv, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "NCrv", Description: "Number of curves supported (recommend 4)."},
+					{Id: NPt, Offset: 6, Type: typelabel.Uint16, Mandatory: true, Label: "NPt", Description: "Number of curve points supported (maximum of 20)."},
+					{Id: Tms_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Tms_SF", Description: "Scale factor for duration."},
+					{Id: Hz_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Hz_SF", Description: "Scale factor for frequency."},
+					{Id: CrvType, Offset: 9, Type: typelabel.Enum16, Mandatory: true},
 				},
 			},
 			{Name: "curve",
 				Length: 50,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
-					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
-					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Mandatory: true, Label: "Hz1", Description: "Point 1 frequency."},
-					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms2", Description: "Point 2 duration."},
-					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz2", Description: "Point 2 frequency."},
-					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms3", Description: "Point 3 duration."},
-					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz3", Description: "Point 3 frequency."},
-					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms4", Description: "Point 4 duration."},
-					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz4", Description: "Point 4 frequency."},
-					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms5", Description: "Point 5 duration."},
-					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz5", Description: "Point 5 frequency."},
-					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms6", Description: "Point 6 duration."},
-					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz6", Description: "Point 6 frequency."},
-					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms7", Description: "Point 7 duration."},
-					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz7", Description: "Point 7 frequency."},
-					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms8", Description: "Point 8 duration."},
-					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz8", Description: "Point 8 frequency."},
-					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms9", Description: "Point 9 duration."},
-					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz9", Description: "Point 9 frequency."},
-					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms10", Description: "Point 10 duration."},
-					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz10", Description: "Point 10 frequency."},
-					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms11", Description: "Point 11 duration."},
-					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz11", Description: "Point 11 frequency."},
-					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms12", Description: "Point 12 duration."},
-					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz12", Description: "Point 12 frequency."},
-					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms13", Description: "Point 13 duration."},
-					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz13", Description: "Point 13 frequency."},
-					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms14", Description: "Point 14 duration."},
-					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz14", Description: "Point 14 frequency."},
-					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms15", Description: "Point 15 duration."},
-					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz15", Description: "Point 15 frequency."},
-					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms16", Description: "Point 16 duration."},
-					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz16", Description: "Point 16 frequency."},
-					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms17", Description: "Point 17 duration."},
-					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz17", Description: "Point 17 frequency."},
-					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms18", Description: "Point 18 duration."},
-					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz18", Description: "Point 18 frequency."},
-					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms19", Description: "Point 19 duration."},
-					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz19", Description: "Point 19 frequency."},
-					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Length: 1, Label: "Tms20", Description: "Point 20 duration."},
-					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Length: 1, Label: "Hz20", Description: "Point 20 frequency."},
+					{Id: ActPt, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "ActPt", Description: "Number of active points in array."},
+					{Id: Tms1, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Mandatory: true, Label: "Tms1", Description: "Point 1 duration."},
+					{Id: Hz1, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Mandatory: true, Label: "Hz1", Description: "Point 1 frequency."},
+					{Id: Tms2, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms2", Description: "Point 2 duration."},
+					{Id: Hz2, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz2", Description: "Point 2 frequency."},
+					{Id: Tms3, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms3", Description: "Point 3 duration."},
+					{Id: Hz3, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz3", Description: "Point 3 frequency."},
+					{Id: Tms4, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms4", Description: "Point 4 duration."},
+					{Id: Hz4, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz4", Description: "Point 4 frequency."},
+					{Id: Tms5, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms5", Description: "Point 5 duration."},
+					{Id: Hz5, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz5", Description: "Point 5 frequency."},
+					{Id: Tms6, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms6", Description: "Point 6 duration."},
+					{Id: Hz6, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz6", Description: "Point 6 frequency."},
+					{Id: Tms7, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms7", Description: "Point 7 duration."},
+					{Id: Hz7, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz7", Description: "Point 7 frequency."},
+					{Id: Tms8, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms8", Description: "Point 8 duration."},
+					{Id: Hz8, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz8", Description: "Point 8 frequency."},
+					{Id: Tms9, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms9", Description: "Point 9 duration."},
+					{Id: Hz9, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz9", Description: "Point 9 frequency."},
+					{Id: Tms10, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms10", Description: "Point 10 duration."},
+					{Id: Hz10, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz10", Description: "Point 10 frequency."},
+					{Id: Tms11, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms11", Description: "Point 11 duration."},
+					{Id: Hz11, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz11", Description: "Point 11 frequency."},
+					{Id: Tms12, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms12", Description: "Point 12 duration."},
+					{Id: Hz12, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz12", Description: "Point 12 frequency."},
+					{Id: Tms13, Offset: 25, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms13", Description: "Point 13 duration."},
+					{Id: Hz13, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz13", Description: "Point 13 frequency."},
+					{Id: Tms14, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms14", Description: "Point 14 duration."},
+					{Id: Hz14, Offset: 28, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz14", Description: "Point 14 frequency."},
+					{Id: Tms15, Offset: 29, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms15", Description: "Point 15 duration."},
+					{Id: Hz15, Offset: 30, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz15", Description: "Point 15 frequency."},
+					{Id: Tms16, Offset: 31, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms16", Description: "Point 16 duration."},
+					{Id: Hz16, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz16", Description: "Point 16 frequency."},
+					{Id: Tms17, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms17", Description: "Point 17 duration."},
+					{Id: Hz17, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz17", Description: "Point 17 frequency."},
+					{Id: Tms18, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms18", Description: "Point 18 duration."},
+					{Id: Hz18, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz18", Description: "Point 18 frequency."},
+					{Id: Tms19, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms19", Description: "Point 19 duration."},
+					{Id: Hz19, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz19", Description: "Point 19 frequency."},
+					{Id: Tms20, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "Tms_SF", Units: "Secs", Access: "rw", Label: "Tms20", Description: "Point 20 duration."},
+					{Id: Hz20, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "Hz_SF", Units: "Hz", Access: "rw", Label: "Hz20", Description: "Point 20 frequency."},
 					{Id: CrvNam, Offset: 41, Type: typelabel.String, Access: "rw", Length: 8, Label: "CrvNam", Description: "Optional description for curve."},
-					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
+					{Id: ReadOnly, Offset: 49, Type: typelabel.Enum16, Mandatory: true, Label: "ReadOnly", Description: "Enumerated value indicates if curve is read-only or can be modified."},
 				},
 			},
 		}})

--- a/models/model145/model.go
+++ b/models/model145/model.go
@@ -29,14 +29,14 @@ const (
 )
 
 type Block145 struct {
-	NomRmpUpRte  uint16              `sunspec:"offset=0,len=1,sf=Rmp_SF,access=rw"`
-	NomRmpDnRte  uint16              `sunspec:"offset=1,len=1,sf=Rmp_SF,access=rw"`
-	EmgRmpUpRte  uint16              `sunspec:"offset=2,len=1,sf=Rmp_SF,access=rw"`
-	EmgRmpDnRte  uint16              `sunspec:"offset=3,len=1,sf=Rmp_SF,access=rw"`
-	ConnRmpUpRte uint16              `sunspec:"offset=4,len=1,sf=Rmp_SF,access=rw"`
-	ConnRmpDnRte uint16              `sunspec:"offset=5,len=1,sf=Rmp_SF,access=rw"`
-	AGra         uint16              `sunspec:"offset=6,len=1,sf=Rmp_SF,access=rw"`
-	Rmp_SF       sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
+	NomRmpUpRte  uint16              `sunspec:"offset=0,sf=Rmp_SF,access=rw"`
+	NomRmpDnRte  uint16              `sunspec:"offset=1,sf=Rmp_SF,access=rw"`
+	EmgRmpUpRte  uint16              `sunspec:"offset=2,sf=Rmp_SF,access=rw"`
+	EmgRmpDnRte  uint16              `sunspec:"offset=3,sf=Rmp_SF,access=rw"`
+	ConnRmpUpRte uint16              `sunspec:"offset=4,sf=Rmp_SF,access=rw"`
+	ConnRmpDnRte uint16              `sunspec:"offset=5,sf=Rmp_SF,access=rw"`
+	AGra         uint16              `sunspec:"offset=6,sf=Rmp_SF,access=rw"`
+	Rmp_SF       sunspec.ScaleFactor `sunspec:"offset=7"`
 }
 
 func (block *Block145) GetId() sunspec.ModelId {
@@ -55,14 +55,14 @@ func init() {
 				Length: 8,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: NomRmpUpRte, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "Ramp Up Rate", Description: "Ramp up rate as a percentage of max current."},
-					{Id: NomRmpDnRte, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "NomRmpDnRte", Description: "Ramp down rate as a percentage of max current."},
-					{Id: EmgRmpUpRte, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "Emergency Ramp Up Rate", Description: "Emergency ramp up rate as a percentage of max current."},
-					{Id: EmgRmpDnRte, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "Emergency Ramp Down Rate", Description: "Emergency ramp down rate as a percentage of max current."},
-					{Id: ConnRmpUpRte, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "Connect Ramp Up Rate", Description: "Connect ramp up rate as a percentage of max current."},
-					{Id: ConnRmpDnRte, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "Connect Ramp Down Rate", Description: "Connect ramp down rate as a percentage of max current."},
-					{Id: AGra, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Length: 1, Label: "Default Ramp Rate", Description: "Ramp rate specified in percent of max current."},
-					{Id: Rmp_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Label: "Ramp Rate Scale Factor", Description: "Ramp Rate Scale Factor"},
+					{Id: NomRmpUpRte, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "Ramp Up Rate", Description: "Ramp up rate as a percentage of max current."},
+					{Id: NomRmpDnRte, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "NomRmpDnRte", Description: "Ramp down rate as a percentage of max current."},
+					{Id: EmgRmpUpRte, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "Emergency Ramp Up Rate", Description: "Emergency ramp up rate as a percentage of max current."},
+					{Id: EmgRmpDnRte, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "Emergency Ramp Down Rate", Description: "Emergency ramp down rate as a percentage of max current."},
+					{Id: ConnRmpUpRte, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "Connect Ramp Up Rate", Description: "Connect ramp up rate as a percentage of max current."},
+					{Id: ConnRmpDnRte, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "Connect Ramp Down Rate", Description: "Connect ramp down rate as a percentage of max current."},
+					{Id: AGra, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "Rmp_SF", Units: "Pct", Access: "rw", Label: "Default Ramp Rate", Description: "Ramp rate specified in percent of max current."},
+					{Id: Rmp_SF, Offset: 7, Type: typelabel.ScaleFactor, Label: "Ramp Rate Scale Factor", Description: "Ramp Rate Scale Factor"},
 				},
 			},
 		}})

--- a/models/model15/model.go
+++ b/models/model15/model.go
@@ -34,19 +34,19 @@ const (
 )
 
 type Block15 struct {
-	Clr       uint16        `sunspec:"offset=0,len=1,access=rw"`
-	InCnt     sunspec.Acc32 `sunspec:"offset=1,len=2"`
-	InUcCnt   sunspec.Acc32 `sunspec:"offset=3,len=2"`
-	InNUcCnt  sunspec.Acc32 `sunspec:"offset=5,len=2"`
-	InDscCnt  sunspec.Acc32 `sunspec:"offset=7,len=2"`
-	InErrCnt  sunspec.Acc32 `sunspec:"offset=9,len=2"`
-	InUnkCnt  sunspec.Acc32 `sunspec:"offset=11,len=2"`
-	OutCnt    sunspec.Acc32 `sunspec:"offset=13,len=2"`
-	OutUcCnt  sunspec.Acc32 `sunspec:"offset=15,len=2"`
-	OutNUcCnt sunspec.Acc32 `sunspec:"offset=17,len=2"`
-	OutDscCnt sunspec.Acc32 `sunspec:"offset=19,len=2"`
-	OutErrCnt sunspec.Acc32 `sunspec:"offset=21,len=2"`
-	Pad       sunspec.Pad   `sunspec:"offset=23,len=1"`
+	Clr       uint16        `sunspec:"offset=0,access=rw"`
+	InCnt     sunspec.Acc32 `sunspec:"offset=1"`
+	InUcCnt   sunspec.Acc32 `sunspec:"offset=3"`
+	InNUcCnt  sunspec.Acc32 `sunspec:"offset=5"`
+	InDscCnt  sunspec.Acc32 `sunspec:"offset=7"`
+	InErrCnt  sunspec.Acc32 `sunspec:"offset=9"`
+	InUnkCnt  sunspec.Acc32 `sunspec:"offset=11"`
+	OutCnt    sunspec.Acc32 `sunspec:"offset=13"`
+	OutUcCnt  sunspec.Acc32 `sunspec:"offset=15"`
+	OutNUcCnt sunspec.Acc32 `sunspec:"offset=17"`
+	OutDscCnt sunspec.Acc32 `sunspec:"offset=19"`
+	OutErrCnt sunspec.Acc32 `sunspec:"offset=21"`
+	Pad       sunspec.Pad   `sunspec:"offset=23"`
 }
 
 func (block *Block15) GetId() sunspec.ModelId {
@@ -65,19 +65,19 @@ func init() {
 				Length: 24,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Clr, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Label: "Clear", Description: "Write a 1 to clear all counters"},
-					{Id: InCnt, Offset: 1, Type: typelabel.Acc32, Length: 2, Label: "Input Count", Description: "Number of bytes received"},
-					{Id: InUcCnt, Offset: 3, Type: typelabel.Acc32, Length: 2, Label: "Input Unicast Count", Description: "Number of Unicast packets received"},
-					{Id: InNUcCnt, Offset: 5, Type: typelabel.Acc32, Length: 2, Label: "Input Non-Unicast Count", Description: "Number of non-Unicast packets received"},
-					{Id: InDscCnt, Offset: 7, Type: typelabel.Acc32, Length: 2, Label: "Input Discarded Count", Description: "Number of inbound packets received on the interface but discarded"},
-					{Id: InErrCnt, Offset: 9, Type: typelabel.Acc32, Length: 2, Label: "Input Error Count", Description: "Number of inbound packets that contain errors (excluding discards)"},
-					{Id: InUnkCnt, Offset: 11, Type: typelabel.Acc32, Length: 2, Label: "Input Unknown Count", Description: "Number of inbound packets with unknown protocol"},
-					{Id: OutCnt, Offset: 13, Type: typelabel.Acc32, Length: 2, Label: "Output Count", Description: "Total number of bytes transmitted on this interface"},
-					{Id: OutUcCnt, Offset: 15, Type: typelabel.Acc32, Length: 2, Label: "Output Unicast Count", Description: "Number of Unicast packets transmitted"},
-					{Id: OutNUcCnt, Offset: 17, Type: typelabel.Acc32, Length: 2, Label: "Output Non-Unicast Count", Description: "Number of Non-Unicast packets transmitted"},
-					{Id: OutDscCnt, Offset: 19, Type: typelabel.Acc32, Length: 2, Label: "Output Discarded Count", Description: "Number of Discarded output packets"},
-					{Id: OutErrCnt, Offset: 21, Type: typelabel.Acc32, Length: 2, Label: "Output Error Count", Description: "Number of outbound error packets"},
-					{Id: Pad, Offset: 23, Type: typelabel.Pad, Length: 1},
+					{Id: Clr, Offset: 0, Type: typelabel.Uint16, Access: "rw", Label: "Clear", Description: "Write a 1 to clear all counters"},
+					{Id: InCnt, Offset: 1, Type: typelabel.Acc32, Label: "Input Count", Description: "Number of bytes received"},
+					{Id: InUcCnt, Offset: 3, Type: typelabel.Acc32, Label: "Input Unicast Count", Description: "Number of Unicast packets received"},
+					{Id: InNUcCnt, Offset: 5, Type: typelabel.Acc32, Label: "Input Non-Unicast Count", Description: "Number of non-Unicast packets received"},
+					{Id: InDscCnt, Offset: 7, Type: typelabel.Acc32, Label: "Input Discarded Count", Description: "Number of inbound packets received on the interface but discarded"},
+					{Id: InErrCnt, Offset: 9, Type: typelabel.Acc32, Label: "Input Error Count", Description: "Number of inbound packets that contain errors (excluding discards)"},
+					{Id: InUnkCnt, Offset: 11, Type: typelabel.Acc32, Label: "Input Unknown Count", Description: "Number of inbound packets with unknown protocol"},
+					{Id: OutCnt, Offset: 13, Type: typelabel.Acc32, Label: "Output Count", Description: "Total number of bytes transmitted on this interface"},
+					{Id: OutUcCnt, Offset: 15, Type: typelabel.Acc32, Label: "Output Unicast Count", Description: "Number of Unicast packets transmitted"},
+					{Id: OutNUcCnt, Offset: 17, Type: typelabel.Acc32, Label: "Output Non-Unicast Count", Description: "Number of Non-Unicast packets transmitted"},
+					{Id: OutDscCnt, Offset: 19, Type: typelabel.Acc32, Label: "Output Discarded Count", Description: "Number of Discarded output packets"},
+					{Id: OutErrCnt, Offset: 21, Type: typelabel.Acc32, Label: "Output Error Count", Description: "Number of outbound error packets"},
+					{Id: Pad, Offset: 23, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model16/model.go
+++ b/models/model16/model.go
@@ -33,16 +33,16 @@ const (
 
 type Block16 struct {
 	Nam    string             `sunspec:"offset=0,len=4,access=rw"`
-	Cfg    sunspec.Enum16     `sunspec:"offset=4,len=1"`
-	Ctl    sunspec.Bitfield16 `sunspec:"offset=5,len=1,access=rw"`
+	Cfg    sunspec.Enum16     `sunspec:"offset=4"`
+	Ctl    sunspec.Bitfield16 `sunspec:"offset=5,access=rw"`
 	Addr   string             `sunspec:"offset=6,len=8,access=rw"`
 	Msk    string             `sunspec:"offset=14,len=8,access=rw"`
 	Gw     string             `sunspec:"offset=22,len=8,access=rw"`
 	DNS1   string             `sunspec:"offset=30,len=8,access=rw"`
 	DNS2   string             `sunspec:"offset=38,len=8,access=rw"`
-	MAC    sunspec.Eui48      `sunspec:"offset=46,len=4"`
-	LnkCtl sunspec.Bitfield16 `sunspec:"offset=50,len=1,access=rw"`
-	Pad    sunspec.Pad        `sunspec:"offset=51,len=1"`
+	MAC    sunspec.Eui48      `sunspec:"offset=46"`
+	LnkCtl sunspec.Bitfield16 `sunspec:"offset=50,access=rw"`
+	Pad    sunspec.Pad        `sunspec:"offset=51"`
 }
 
 func (block *Block16) GetId() sunspec.ModelId {
@@ -62,16 +62,16 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name.  (8 chars)"},
-					{Id: Cfg, Offset: 4, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Config", Description: "Enumerated value.  Force IPv4 configuration method"},
-					{Id: Ctl, Offset: 5, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Mandatory: true, Label: "Control", Description: "Bitmask value Configure use of services"},
+					{Id: Cfg, Offset: 4, Type: typelabel.Enum16, Mandatory: true, Label: "Config", Description: "Enumerated value.  Force IPv4 configuration method"},
+					{Id: Ctl, Offset: 5, Type: typelabel.Bitfield16, Access: "rw", Mandatory: true, Label: "Control", Description: "Bitmask value Configure use of services"},
 					{Id: Addr, Offset: 6, Type: typelabel.String, Access: "rw", Length: 8, Mandatory: true, Label: "Address", Description: "IP address"},
 					{Id: Msk, Offset: 14, Type: typelabel.String, Access: "rw", Length: 8, Mandatory: true, Label: "Netmask", Description: "Netmask"},
 					{Id: Gw, Offset: 22, Type: typelabel.String, Access: "rw", Length: 8, Label: "Gateway", Description: "Gateway IP address"},
 					{Id: DNS1, Offset: 30, Type: typelabel.String, Access: "rw", Length: 8, Label: "DNS1", Description: "32 bit IP address of DNS server"},
 					{Id: DNS2, Offset: 38, Type: typelabel.String, Access: "rw", Length: 8, Label: "DNS2", Description: "32 bit IP address of DNS server"},
-					{Id: MAC, Offset: 46, Type: typelabel.Eui48, Length: 4, Label: "MAC", Description: "IEEE MAC address of this interface"},
-					{Id: LnkCtl, Offset: 50, Type: typelabel.Bitfield16, Access: "rw", Length: 1, Label: "Link Control", Description: "Bitmask value.  Link control flags"},
-					{Id: Pad, Offset: 51, Type: typelabel.Pad, Length: 1},
+					{Id: MAC, Offset: 46, Type: typelabel.Eui48, Label: "MAC", Description: "IEEE MAC address of this interface"},
+					{Id: LnkCtl, Offset: 50, Type: typelabel.Bitfield16, Access: "rw", Label: "Link Control", Description: "Bitmask value.  Link control flags"},
+					{Id: Pad, Offset: 51, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model160/model.go
+++ b/models/model160/model.go
@@ -38,26 +38,26 @@ const (
 )
 
 type Block160Repeat struct {
-	ID    uint16             `sunspec:"offset=0,len=1"`
+	ID    uint16             `sunspec:"offset=0"`
 	IDStr string             `sunspec:"offset=1,len=8"`
-	DCA   uint16             `sunspec:"offset=9,len=1,sf=DCA_SF"`
-	DCV   uint16             `sunspec:"offset=10,len=1,sf=DCV_SF"`
-	DCW   uint16             `sunspec:"offset=11,len=1,sf=DCW_SF"`
-	DCWH  sunspec.Acc32      `sunspec:"offset=12,len=2,sf=DCWH_SF"`
-	Tms   uint32             `sunspec:"offset=14,len=2"`
-	Tmp   int16              `sunspec:"offset=16,len=1"`
-	DCSt  sunspec.Enum16     `sunspec:"offset=17,len=1"`
-	DCEvt sunspec.Bitfield32 `sunspec:"offset=18,len=2"`
+	DCA   uint16             `sunspec:"offset=9,sf=DCA_SF"`
+	DCV   uint16             `sunspec:"offset=10,sf=DCV_SF"`
+	DCW   uint16             `sunspec:"offset=11,sf=DCW_SF"`
+	DCWH  sunspec.Acc32      `sunspec:"offset=12,sf=DCWH_SF"`
+	Tms   uint32             `sunspec:"offset=14"`
+	Tmp   int16              `sunspec:"offset=16"`
+	DCSt  sunspec.Enum16     `sunspec:"offset=17"`
+	DCEvt sunspec.Bitfield32 `sunspec:"offset=18"`
 }
 
 type Block160 struct {
-	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	DCWH_SF sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	Evt     sunspec.Bitfield32  `sunspec:"offset=4,len=2"`
-	N       sunspec.Count       `sunspec:"offset=6,len=1"`
-	TmsPer  uint16              `sunspec:"offset=7,len=1"`
+	DCA_SF  sunspec.ScaleFactor `sunspec:"offset=0"`
+	DCV_SF  sunspec.ScaleFactor `sunspec:"offset=1"`
+	DCW_SF  sunspec.ScaleFactor `sunspec:"offset=2"`
+	DCWH_SF sunspec.ScaleFactor `sunspec:"offset=3"`
+	Evt     sunspec.Bitfield32  `sunspec:"offset=4"`
+	N       sunspec.Count       `sunspec:"offset=6"`
+	TmsPer  uint16              `sunspec:"offset=7"`
 
 	Repeats []Block160Repeat
 }
@@ -78,29 +78,29 @@ func init() {
 				Length: 8,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Length: 1, Label: "Current Scale Factor", Description: ""},
-					{Id: DCV_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1, Label: "Voltage Scale Factor", Description: ""},
-					{Id: DCW_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1, Label: "Power Scale Factor", Description: ""},
-					{Id: DCWH_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1, Label: "Energy Scale Factor", Description: ""},
-					{Id: Evt, Offset: 4, Type: typelabel.Bitfield32, Length: 2, Label: "Global Events", Description: ""},
-					{Id: N, Offset: 6, Type: typelabel.Count, Length: 1, Label: "Number of Modules", Description: ""},
-					{Id: TmsPer, Offset: 7, Type: typelabel.Uint16, Length: 1, Label: "Timestamp Period", Description: ""},
+					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Label: "Current Scale Factor", Description: ""},
+					{Id: DCV_SF, Offset: 1, Type: typelabel.ScaleFactor, Label: "Voltage Scale Factor", Description: ""},
+					{Id: DCW_SF, Offset: 2, Type: typelabel.ScaleFactor, Label: "Power Scale Factor", Description: ""},
+					{Id: DCWH_SF, Offset: 3, Type: typelabel.ScaleFactor, Label: "Energy Scale Factor", Description: ""},
+					{Id: Evt, Offset: 4, Type: typelabel.Bitfield32, Label: "Global Events", Description: ""},
+					{Id: N, Offset: 6, Type: typelabel.Count, Label: "Number of Modules", Description: ""},
+					{Id: TmsPer, Offset: 7, Type: typelabel.Uint16, Label: "Timestamp Period", Description: ""},
 				},
 			},
 			{Name: "module",
 				Length: 20,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ID, Offset: 0, Type: typelabel.Uint16, Length: 1, Label: "Input ID", Description: ""},
+					{Id: ID, Offset: 0, Type: typelabel.Uint16, Label: "Input ID", Description: ""},
 					{Id: IDStr, Offset: 1, Type: typelabel.String, Length: 8, Label: "Input ID String", Description: ""},
-					{Id: DCA, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Label: "DC Current", Description: ""},
-					{Id: DCV, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "DC Voltage", Description: ""},
-					{Id: DCW, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "DCW_SF", Units: "W", Length: 1, Label: "DC Power", Description: ""},
-					{Id: DCWH, Offset: 12, Type: typelabel.Acc32, ScaleFactor: "DCWH_SF", Units: "Wh", Length: 2, Label: "Lifetime Energy", Description: ""},
-					{Id: Tms, Offset: 14, Type: typelabel.Uint32, Units: "Secs", Length: 2, Label: "Timestamp", Description: ""},
-					{Id: Tmp, Offset: 16, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Temperature", Description: ""},
-					{Id: DCSt, Offset: 17, Type: typelabel.Enum16, Length: 1, Label: "Operating State", Description: ""},
-					{Id: DCEvt, Offset: 18, Type: typelabel.Bitfield32, Length: 2, Label: "Module Events", Description: ""},
+					{Id: DCA, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Label: "DC Current", Description: ""},
+					{Id: DCV, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "DC Voltage", Description: ""},
+					{Id: DCW, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "DCW_SF", Units: "W", Label: "DC Power", Description: ""},
+					{Id: DCWH, Offset: 12, Type: typelabel.Acc32, ScaleFactor: "DCWH_SF", Units: "Wh", Label: "Lifetime Energy", Description: ""},
+					{Id: Tms, Offset: 14, Type: typelabel.Uint32, Units: "Secs", Label: "Timestamp", Description: ""},
+					{Id: Tmp, Offset: 16, Type: typelabel.Int16, Units: "C", Label: "Temperature", Description: ""},
+					{Id: DCSt, Offset: 17, Type: typelabel.Enum16, Label: "Operating State", Description: ""},
+					{Id: DCEvt, Offset: 18, Type: typelabel.Bitfield32, Label: "Module Events", Description: ""},
 				},
 			},
 		}})

--- a/models/model17/model.go
+++ b/models/model17/model.go
@@ -30,13 +30,13 @@ const (
 
 type Block17 struct {
 	Nam  string         `sunspec:"offset=0,len=4,access=rw"`
-	Rte  uint32         `sunspec:"offset=4,len=2,access=rw"`
-	Bits uint16         `sunspec:"offset=6,len=1,access=rw"`
-	Pty  sunspec.Enum16 `sunspec:"offset=7,len=1,access=rw"`
-	Dup  sunspec.Enum16 `sunspec:"offset=8,len=1,access=rw"`
-	Flw  sunspec.Enum16 `sunspec:"offset=9,len=1,access=rw"`
-	Typ  sunspec.Enum16 `sunspec:"offset=10,len=1"`
-	Pcol sunspec.Enum16 `sunspec:"offset=11,len=1"`
+	Rte  uint32         `sunspec:"offset=4,access=rw"`
+	Bits uint16         `sunspec:"offset=6,access=rw"`
+	Pty  sunspec.Enum16 `sunspec:"offset=7,access=rw"`
+	Dup  sunspec.Enum16 `sunspec:"offset=8,access=rw"`
+	Flw  sunspec.Enum16 `sunspec:"offset=9,access=rw"`
+	Typ  sunspec.Enum16 `sunspec:"offset=10"`
+	Pcol sunspec.Enum16 `sunspec:"offset=11"`
 }
 
 func (block *Block17) GetId() sunspec.ModelId {
@@ -56,13 +56,13 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name (8 chars)"},
-					{Id: Rte, Offset: 4, Type: typelabel.Uint32, Units: "bps", Access: "rw", Length: 2, Mandatory: true, Label: "Rate", Description: "Interface baud rate in bits per second"},
-					{Id: Bits, Offset: 6, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Bits", Description: "Number of data bits per character"},
-					{Id: Pty, Offset: 7, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Parity", Description: "Bitmask value.  Parity setting"},
-					{Id: Dup, Offset: 8, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Duplex", Description: "Enumerated value.  Duplex mode"},
-					{Id: Flw, Offset: 9, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Flow Control", Description: "Flow Control Method"},
-					{Id: Typ, Offset: 10, Type: typelabel.Enum16, Length: 1, Label: "Interface Type", Description: "Enumerated value.  Interface type"},
-					{Id: Pcol, Offset: 11, Type: typelabel.Enum16, Length: 1, Label: "Protocol", Description: "Enumerated value. Serial protocol selection"},
+					{Id: Rte, Offset: 4, Type: typelabel.Uint32, Units: "bps", Access: "rw", Mandatory: true, Label: "Rate", Description: "Interface baud rate in bits per second"},
+					{Id: Bits, Offset: 6, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Bits", Description: "Number of data bits per character"},
+					{Id: Pty, Offset: 7, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Parity", Description: "Bitmask value.  Parity setting"},
+					{Id: Dup, Offset: 8, Type: typelabel.Enum16, Access: "rw", Label: "Duplex", Description: "Enumerated value.  Duplex mode"},
+					{Id: Flw, Offset: 9, Type: typelabel.Enum16, Access: "rw", Label: "Flow Control", Description: "Flow Control Method"},
+					{Id: Typ, Offset: 10, Type: typelabel.Enum16, Label: "Interface Type", Description: "Enumerated value.  Interface type"},
+					{Id: Pcol, Offset: 11, Type: typelabel.Enum16, Label: "Protocol", Description: "Enumerated value. Serial protocol selection"},
 				},
 			},
 		}})

--- a/models/model18/model.go
+++ b/models/model18/model.go
@@ -27,7 +27,7 @@ const (
 
 type Block18 struct {
 	Nam  string `sunspec:"offset=0,len=4,access=rw"`
-	IMEI uint32 `sunspec:"offset=4,len=2,access=rw"`
+	IMEI uint32 `sunspec:"offset=4,access=rw"`
 	APN  string `sunspec:"offset=6,len=4,access=rw"`
 	Num  string `sunspec:"offset=10,len=6,access=rw"`
 	Pin  string `sunspec:"offset=16,len=6,access=rw"`
@@ -50,7 +50,7 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name"},
-					{Id: IMEI, Offset: 4, Type: typelabel.Uint32, Access: "rw", Length: 2, Label: "IMEI", Description: "International Mobile Equipment Identifier for the interface"},
+					{Id: IMEI, Offset: 4, Type: typelabel.Uint32, Access: "rw", Label: "IMEI", Description: "International Mobile Equipment Identifier for the interface"},
 					{Id: APN, Offset: 6, Type: typelabel.String, Access: "rw", Length: 4, Label: "APN", Description: "Access Point Name for the interface"},
 					{Id: Num, Offset: 10, Type: typelabel.String, Access: "rw", Length: 6, Label: "Number", Description: "Phone number for the interface"},
 					{Id: Pin, Offset: 16, Type: typelabel.String, Access: "rw", Length: 6, Label: "PIN", Description: "Personal Identification Number for the interface"},

--- a/models/model19/model.go
+++ b/models/model19/model.go
@@ -32,15 +32,15 @@ const (
 
 type Block19 struct {
 	Nam    string         `sunspec:"offset=0,len=4,access=rw"`
-	Rte    uint32         `sunspec:"offset=4,len=2,access=rw"`
-	Bits   uint16         `sunspec:"offset=6,len=1,access=rw"`
-	Pty    sunspec.Enum16 `sunspec:"offset=7,len=1,access=rw"`
-	Dup    sunspec.Enum16 `sunspec:"offset=8,len=1,access=rw"`
-	Flw    sunspec.Enum16 `sunspec:"offset=9,len=1,access=rw"`
-	Auth   sunspec.Enum16 `sunspec:"offset=10,len=1"`
+	Rte    uint32         `sunspec:"offset=4,access=rw"`
+	Bits   uint16         `sunspec:"offset=6,access=rw"`
+	Pty    sunspec.Enum16 `sunspec:"offset=7,access=rw"`
+	Dup    sunspec.Enum16 `sunspec:"offset=8,access=rw"`
+	Flw    sunspec.Enum16 `sunspec:"offset=9,access=rw"`
+	Auth   sunspec.Enum16 `sunspec:"offset=10"`
 	UsrNam string         `sunspec:"offset=11,len=12"`
 	Pw     string         `sunspec:"offset=23,len=6"`
-	Pad    sunspec.Pad    `sunspec:"offset=29,len=1"`
+	Pad    sunspec.Pad    `sunspec:"offset=29"`
 }
 
 func (block *Block19) GetId() sunspec.ModelId {
@@ -60,15 +60,15 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Access: "rw", Length: 4, Label: "Name", Description: "Interface name"},
-					{Id: Rte, Offset: 4, Type: typelabel.Uint32, Units: "bps", Access: "rw", Length: 2, Mandatory: true, Label: "Rate", Description: "Interface baud rate in bits per second"},
-					{Id: Bits, Offset: 6, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Bits", Description: "Number of data bits per character"},
-					{Id: Pty, Offset: 7, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Parity", Description: "Bitmask value.  Parity setting"},
-					{Id: Dup, Offset: 8, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Duplex", Description: "Enumerated value.  Duplex mode"},
-					{Id: Flw, Offset: 9, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Flow Control", Description: "Flow Control Method"},
-					{Id: Auth, Offset: 10, Type: typelabel.Enum16, Length: 1, Label: "Authentication", Description: "Enumerated value.  Authentication method"},
+					{Id: Rte, Offset: 4, Type: typelabel.Uint32, Units: "bps", Access: "rw", Mandatory: true, Label: "Rate", Description: "Interface baud rate in bits per second"},
+					{Id: Bits, Offset: 6, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Bits", Description: "Number of data bits per character"},
+					{Id: Pty, Offset: 7, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Parity", Description: "Bitmask value.  Parity setting"},
+					{Id: Dup, Offset: 8, Type: typelabel.Enum16, Access: "rw", Label: "Duplex", Description: "Enumerated value.  Duplex mode"},
+					{Id: Flw, Offset: 9, Type: typelabel.Enum16, Access: "rw", Label: "Flow Control", Description: "Flow Control Method"},
+					{Id: Auth, Offset: 10, Type: typelabel.Enum16, Label: "Authentication", Description: "Enumerated value.  Authentication method"},
 					{Id: UsrNam, Offset: 11, Type: typelabel.String, Length: 12, Label: "Username", Description: "Username for authentication"},
 					{Id: Pw, Offset: 23, Type: typelabel.String, Length: 6, Label: "Password", Description: "Password for authentication"},
-					{Id: Pad, Offset: 29, Type: typelabel.Pad, Length: 1},
+					{Id: Pad, Offset: 29, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model2/model.go
+++ b/models/model2/model.go
@@ -31,16 +31,16 @@ const (
 )
 
 type Block2 struct {
-	AID    uint16             `sunspec:"offset=0,len=1"`
-	N      uint16             `sunspec:"offset=1,len=1"`
-	UN     uint16             `sunspec:"offset=2,len=1"`
-	St     sunspec.Enum16     `sunspec:"offset=3,len=1"`
-	StVnd  sunspec.Enum16     `sunspec:"offset=4,len=1"`
-	Evt    sunspec.Bitfield32 `sunspec:"offset=5,len=2"`
-	EvtVnd sunspec.Bitfield32 `sunspec:"offset=7,len=2"`
-	Ctl    sunspec.Enum16     `sunspec:"offset=9,len=1"`
-	CtlVnd sunspec.Enum32     `sunspec:"offset=10,len=2"`
-	CtlVl  sunspec.Enum32     `sunspec:"offset=12,len=2"`
+	AID    uint16             `sunspec:"offset=0"`
+	N      uint16             `sunspec:"offset=1"`
+	UN     uint16             `sunspec:"offset=2"`
+	St     sunspec.Enum16     `sunspec:"offset=3"`
+	StVnd  sunspec.Enum16     `sunspec:"offset=4"`
+	Evt    sunspec.Bitfield32 `sunspec:"offset=5"`
+	EvtVnd sunspec.Bitfield32 `sunspec:"offset=7"`
+	Ctl    sunspec.Enum16     `sunspec:"offset=9"`
+	CtlVnd sunspec.Enum32     `sunspec:"offset=10"`
+	CtlVl  sunspec.Enum32     `sunspec:"offset=12"`
 }
 
 func (block *Block2) GetId() sunspec.ModelId {
@@ -59,16 +59,16 @@ func init() {
 				Length: 14,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: AID, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "AID", Description: "Aggregated model id"},
-					{Id: N, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "N", Description: "Number of aggregated models"},
-					{Id: UN, Offset: 2, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "UN", Description: "Update Number.  Incrementing number each time the mapping is changed.  If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes"},
-					{Id: St, Offset: 3, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Status", Description: "Enumerated status code"},
-					{Id: StVnd, Offset: 4, Type: typelabel.Enum16, Length: 1, Label: "Vendor Status", Description: "Vendor specific status code"},
-					{Id: Evt, Offset: 5, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event Code", Description: "Bitmask event code"},
-					{Id: EvtVnd, Offset: 7, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Code", Description: "Vendor specific event code"},
-					{Id: Ctl, Offset: 9, Type: typelabel.Enum16, Length: 1, Label: "Control", Description: "Control register for all aggregated devices"},
-					{Id: CtlVnd, Offset: 10, Type: typelabel.Enum32, Length: 2, Label: "Vendor Control", Description: "Vendor control register for all aggregated devices"},
-					{Id: CtlVl, Offset: 12, Type: typelabel.Enum32, Length: 2, Label: "Control Value", Description: "Numerical value used as a parameter to the control"},
+					{Id: AID, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "AID", Description: "Aggregated model id"},
+					{Id: N, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "N", Description: "Number of aggregated models"},
+					{Id: UN, Offset: 2, Type: typelabel.Uint16, Mandatory: true, Label: "UN", Description: "Update Number.  Incrementing number each time the mapping is changed.  If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes"},
+					{Id: St, Offset: 3, Type: typelabel.Enum16, Mandatory: true, Label: "Status", Description: "Enumerated status code"},
+					{Id: StVnd, Offset: 4, Type: typelabel.Enum16, Label: "Vendor Status", Description: "Vendor specific status code"},
+					{Id: Evt, Offset: 5, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event Code", Description: "Bitmask event code"},
+					{Id: EvtVnd, Offset: 7, Type: typelabel.Bitfield32, Label: "Vendor Event Code", Description: "Vendor specific event code"},
+					{Id: Ctl, Offset: 9, Type: typelabel.Enum16, Label: "Control", Description: "Control register for all aggregated devices"},
+					{Id: CtlVnd, Offset: 10, Type: typelabel.Enum32, Label: "Vendor Control", Description: "Vendor control register for all aggregated devices"},
+					{Id: CtlVl, Offset: 12, Type: typelabel.Enum32, Label: "Control Value", Description: "Numerical value used as a parameter to the control"},
 				},
 			},
 		}})

--- a/models/model201/model.go
+++ b/models/model201/model.go
@@ -93,78 +93,78 @@ const (
 )
 
 type Block201 struct {
-	A               int16               `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA            int16               `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB            int16               `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC            int16               `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF            sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PhV             int16               `sunspec:"offset=5,len=1,sf=V_SF"`
-	PhVphA          int16               `sunspec:"offset=6,len=1,sf=V_SF"`
-	PhVphB          int16               `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphC          int16               `sunspec:"offset=8,len=1,sf=V_SF"`
-	PPV             int16               `sunspec:"offset=9,len=1,sf=V_SF"`
-	PPVphAB         int16               `sunspec:"offset=10,len=1,sf=V_SF"`
-	PPVphBC         int16               `sunspec:"offset=11,len=1,sf=V_SF"`
-	PPVphCA         int16               `sunspec:"offset=12,len=1,sf=V_SF"`
-	V_SF            sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz              int16               `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	W               int16               `sunspec:"offset=16,len=1,sf=W_SF"`
-	WphA            int16               `sunspec:"offset=17,len=1,sf=W_SF"`
-	WphB            int16               `sunspec:"offset=18,len=1,sf=W_SF"`
-	WphC            int16               `sunspec:"offset=19,len=1,sf=W_SF"`
-	W_SF            sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	VA              int16               `sunspec:"offset=21,len=1,sf=VA_SF"`
-	VAphA           int16               `sunspec:"offset=22,len=1,sf=VA_SF"`
-	VAphB           int16               `sunspec:"offset=23,len=1,sf=VA_SF"`
-	VAphC           int16               `sunspec:"offset=24,len=1,sf=VA_SF"`
-	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25,len=1"`
-	VAR             int16               `sunspec:"offset=26,len=1,sf=VAR_SF"`
-	VARphA          int16               `sunspec:"offset=27,len=1,sf=VAR_SF"`
-	VARphB          int16               `sunspec:"offset=28,len=1,sf=VAR_SF"`
-	VARphC          int16               `sunspec:"offset=29,len=1,sf=VAR_SF"`
-	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	PF              int16               `sunspec:"offset=31,len=1,sf=PF_SF"`
-	PFphA           int16               `sunspec:"offset=32,len=1,sf=PF_SF"`
-	PFphB           int16               `sunspec:"offset=33,len=1,sf=PF_SF"`
-	PFphC           int16               `sunspec:"offset=34,len=1,sf=PF_SF"`
-	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,len=2,sf=TotWh_SF"`
-	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,len=2,sf=TotWh_SF"`
-	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,len=2,sf=TotWh_SF"`
-	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,len=2,sf=TotWh_SF"`
-	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,len=2,sf=TotWh_SF"`
-	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,len=2,sf=TotWh_SF"`
-	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,len=2,sf=TotWh_SF"`
-	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,len=2,sf=TotWh_SF"`
-	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52,len=1"`
-	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,len=2,sf=TotVAh_SF"`
-	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,len=2,sf=TotVAh_SF"`
-	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69,len=1"`
-	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,len=2,sf=TotVArh_SF"`
-	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102,len=1"`
-	Evt             sunspec.Bitfield32  `sunspec:"offset=103,len=2"`
+	A               int16               `sunspec:"offset=0,sf=A_SF"`
+	AphA            int16               `sunspec:"offset=1,sf=A_SF"`
+	AphB            int16               `sunspec:"offset=2,sf=A_SF"`
+	AphC            int16               `sunspec:"offset=3,sf=A_SF"`
+	A_SF            sunspec.ScaleFactor `sunspec:"offset=4"`
+	PhV             int16               `sunspec:"offset=5,sf=V_SF"`
+	PhVphA          int16               `sunspec:"offset=6,sf=V_SF"`
+	PhVphB          int16               `sunspec:"offset=7,sf=V_SF"`
+	PhVphC          int16               `sunspec:"offset=8,sf=V_SF"`
+	PPV             int16               `sunspec:"offset=9,sf=V_SF"`
+	PPVphAB         int16               `sunspec:"offset=10,sf=V_SF"`
+	PPVphBC         int16               `sunspec:"offset=11,sf=V_SF"`
+	PPVphCA         int16               `sunspec:"offset=12,sf=V_SF"`
+	V_SF            sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz              int16               `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15"`
+	W               int16               `sunspec:"offset=16,sf=W_SF"`
+	WphA            int16               `sunspec:"offset=17,sf=W_SF"`
+	WphB            int16               `sunspec:"offset=18,sf=W_SF"`
+	WphC            int16               `sunspec:"offset=19,sf=W_SF"`
+	W_SF            sunspec.ScaleFactor `sunspec:"offset=20"`
+	VA              int16               `sunspec:"offset=21,sf=VA_SF"`
+	VAphA           int16               `sunspec:"offset=22,sf=VA_SF"`
+	VAphB           int16               `sunspec:"offset=23,sf=VA_SF"`
+	VAphC           int16               `sunspec:"offset=24,sf=VA_SF"`
+	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25"`
+	VAR             int16               `sunspec:"offset=26,sf=VAR_SF"`
+	VARphA          int16               `sunspec:"offset=27,sf=VAR_SF"`
+	VARphB          int16               `sunspec:"offset=28,sf=VAR_SF"`
+	VARphC          int16               `sunspec:"offset=29,sf=VAR_SF"`
+	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30"`
+	PF              int16               `sunspec:"offset=31,sf=PF_SF"`
+	PFphA           int16               `sunspec:"offset=32,sf=PF_SF"`
+	PFphB           int16               `sunspec:"offset=33,sf=PF_SF"`
+	PFphC           int16               `sunspec:"offset=34,sf=PF_SF"`
+	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35"`
+	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,sf=TotWh_SF"`
+	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,sf=TotWh_SF"`
+	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,sf=TotWh_SF"`
+	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,sf=TotWh_SF"`
+	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,sf=TotWh_SF"`
+	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,sf=TotWh_SF"`
+	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,sf=TotWh_SF"`
+	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,sf=TotWh_SF"`
+	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52"`
+	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,sf=TotVAh_SF"`
+	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,sf=TotVAh_SF"`
+	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,sf=TotVAh_SF"`
+	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,sf=TotVAh_SF"`
+	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,sf=TotVAh_SF"`
+	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,sf=TotVAh_SF"`
+	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,sf=TotVAh_SF"`
+	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,sf=TotVAh_SF"`
+	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69"`
+	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,sf=TotVArh_SF"`
+	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,sf=TotVArh_SF"`
+	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,sf=TotVArh_SF"`
+	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,sf=TotVArh_SF"`
+	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,sf=TotVArh_SF"`
+	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,sf=TotVArh_SF"`
+	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,sf=TotVArh_SF"`
+	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,sf=TotVArh_SF"`
+	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,sf=TotVArh_SF"`
+	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,sf=TotVArh_SF"`
+	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,sf=TotVArh_SF"`
+	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,sf=TotVArh_SF"`
+	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,sf=TotVArh_SF"`
+	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,sf=TotVArh_SF"`
+	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,sf=TotVArh_SF"`
+	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,sf=TotVArh_SF"`
+	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102"`
+	Evt             sunspec.Bitfield32  `sunspec:"offset=103"`
 }
 
 func (block *Block201) GetId() sunspec.ModelId {
@@ -183,78 +183,78 @@ func init() {
 				Length: 105,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PPVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase C", Description: ""},
-					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase C", Description: ""},
-					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase C", Description: ""},
-					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase C", Description: ""},
-					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PPVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor},
+					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor},
+					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase C", Description: ""},
+					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor},
+					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor},
+					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor},
+					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model202/model.go
+++ b/models/model202/model.go
@@ -93,78 +93,78 @@ const (
 )
 
 type Block202 struct {
-	A               int16               `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA            int16               `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB            int16               `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC            int16               `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF            sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PhV             int16               `sunspec:"offset=5,len=1,sf=V_SF"`
-	PhVphA          int16               `sunspec:"offset=6,len=1,sf=V_SF"`
-	PhVphB          int16               `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphC          int16               `sunspec:"offset=8,len=1,sf=V_SF"`
-	PPV             int16               `sunspec:"offset=9,len=1,sf=V_SF"`
-	PhVphAB         int16               `sunspec:"offset=10,len=1,sf=V_SF"`
-	PhVphBC         int16               `sunspec:"offset=11,len=1,sf=V_SF"`
-	PhVphCA         int16               `sunspec:"offset=12,len=1,sf=V_SF"`
-	V_SF            sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz              int16               `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	W               int16               `sunspec:"offset=16,len=1,sf=W_SF"`
-	WphA            int16               `sunspec:"offset=17,len=1,sf=W_SF"`
-	WphB            int16               `sunspec:"offset=18,len=1,sf=W_SF"`
-	WphC            int16               `sunspec:"offset=19,len=1,sf=W_SF"`
-	W_SF            sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	VA              int16               `sunspec:"offset=21,len=1,sf=VA_SF"`
-	VAphA           int16               `sunspec:"offset=22,len=1,sf=VA_SF"`
-	VAphB           int16               `sunspec:"offset=23,len=1,sf=VA_SF"`
-	VAphC           int16               `sunspec:"offset=24,len=1,sf=VA_SF"`
-	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25,len=1"`
-	VAR             int16               `sunspec:"offset=26,len=1,sf=VAR_SF"`
-	VARphA          int16               `sunspec:"offset=27,len=1,sf=VAR_SF"`
-	VARphB          int16               `sunspec:"offset=28,len=1,sf=VAR_SF"`
-	VARphC          int16               `sunspec:"offset=29,len=1,sf=VAR_SF"`
-	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	PF              int16               `sunspec:"offset=31,len=1,sf=PF_SF"`
-	PFphA           int16               `sunspec:"offset=32,len=1,sf=PF_SF"`
-	PFphB           int16               `sunspec:"offset=33,len=1,sf=PF_SF"`
-	PFphC           int16               `sunspec:"offset=34,len=1,sf=PF_SF"`
-	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,len=2,sf=TotWh_SF"`
-	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,len=2,sf=TotWh_SF"`
-	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,len=2,sf=TotWh_SF"`
-	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,len=2,sf=TotWh_SF"`
-	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,len=2,sf=TotWh_SF"`
-	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,len=2,sf=TotWh_SF"`
-	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,len=2,sf=TotWh_SF"`
-	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,len=2,sf=TotWh_SF"`
-	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52,len=1"`
-	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,len=2,sf=TotVAh_SF"`
-	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,len=2,sf=TotVAh_SF"`
-	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69,len=1"`
-	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,len=2,sf=TotVArh_SF"`
-	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102,len=1"`
-	Evt             sunspec.Bitfield32  `sunspec:"offset=103,len=2"`
+	A               int16               `sunspec:"offset=0,sf=A_SF"`
+	AphA            int16               `sunspec:"offset=1,sf=A_SF"`
+	AphB            int16               `sunspec:"offset=2,sf=A_SF"`
+	AphC            int16               `sunspec:"offset=3,sf=A_SF"`
+	A_SF            sunspec.ScaleFactor `sunspec:"offset=4"`
+	PhV             int16               `sunspec:"offset=5,sf=V_SF"`
+	PhVphA          int16               `sunspec:"offset=6,sf=V_SF"`
+	PhVphB          int16               `sunspec:"offset=7,sf=V_SF"`
+	PhVphC          int16               `sunspec:"offset=8,sf=V_SF"`
+	PPV             int16               `sunspec:"offset=9,sf=V_SF"`
+	PhVphAB         int16               `sunspec:"offset=10,sf=V_SF"`
+	PhVphBC         int16               `sunspec:"offset=11,sf=V_SF"`
+	PhVphCA         int16               `sunspec:"offset=12,sf=V_SF"`
+	V_SF            sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz              int16               `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15"`
+	W               int16               `sunspec:"offset=16,sf=W_SF"`
+	WphA            int16               `sunspec:"offset=17,sf=W_SF"`
+	WphB            int16               `sunspec:"offset=18,sf=W_SF"`
+	WphC            int16               `sunspec:"offset=19,sf=W_SF"`
+	W_SF            sunspec.ScaleFactor `sunspec:"offset=20"`
+	VA              int16               `sunspec:"offset=21,sf=VA_SF"`
+	VAphA           int16               `sunspec:"offset=22,sf=VA_SF"`
+	VAphB           int16               `sunspec:"offset=23,sf=VA_SF"`
+	VAphC           int16               `sunspec:"offset=24,sf=VA_SF"`
+	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25"`
+	VAR             int16               `sunspec:"offset=26,sf=VAR_SF"`
+	VARphA          int16               `sunspec:"offset=27,sf=VAR_SF"`
+	VARphB          int16               `sunspec:"offset=28,sf=VAR_SF"`
+	VARphC          int16               `sunspec:"offset=29,sf=VAR_SF"`
+	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30"`
+	PF              int16               `sunspec:"offset=31,sf=PF_SF"`
+	PFphA           int16               `sunspec:"offset=32,sf=PF_SF"`
+	PFphB           int16               `sunspec:"offset=33,sf=PF_SF"`
+	PFphC           int16               `sunspec:"offset=34,sf=PF_SF"`
+	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35"`
+	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,sf=TotWh_SF"`
+	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,sf=TotWh_SF"`
+	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,sf=TotWh_SF"`
+	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,sf=TotWh_SF"`
+	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,sf=TotWh_SF"`
+	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,sf=TotWh_SF"`
+	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,sf=TotWh_SF"`
+	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,sf=TotWh_SF"`
+	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52"`
+	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,sf=TotVAh_SF"`
+	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,sf=TotVAh_SF"`
+	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,sf=TotVAh_SF"`
+	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,sf=TotVAh_SF"`
+	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,sf=TotVAh_SF"`
+	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,sf=TotVAh_SF"`
+	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,sf=TotVAh_SF"`
+	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,sf=TotVAh_SF"`
+	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69"`
+	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,sf=TotVArh_SF"`
+	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,sf=TotVArh_SF"`
+	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,sf=TotVArh_SF"`
+	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,sf=TotVArh_SF"`
+	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,sf=TotVArh_SF"`
+	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,sf=TotVArh_SF"`
+	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,sf=TotVArh_SF"`
+	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,sf=TotVArh_SF"`
+	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,sf=TotVArh_SF"`
+	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,sf=TotVArh_SF"`
+	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,sf=TotVArh_SF"`
+	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,sf=TotVArh_SF"`
+	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,sf=TotVArh_SF"`
+	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,sf=TotVArh_SF"`
+	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,sf=TotVArh_SF"`
+	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,sf=TotVArh_SF"`
+	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102"`
+	Evt             sunspec.Bitfield32  `sunspec:"offset=103"`
 }
 
 func (block *Block202) GetId() sunspec.ModelId {
@@ -183,78 +183,78 @@ func init() {
 				Length: 105,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PhVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PhVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PhVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase C", Description: ""},
-					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase C", Description: ""},
-					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase C", Description: ""},
-					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase C", Description: ""},
-					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PhVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PhVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PhVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor},
+					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor},
+					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase C", Description: ""},
+					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor},
+					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor},
+					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor},
+					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model203/model.go
+++ b/models/model203/model.go
@@ -93,78 +93,78 @@ const (
 )
 
 type Block203 struct {
-	A               int16               `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA            int16               `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB            int16               `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC            int16               `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF            sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PhV             int16               `sunspec:"offset=5,len=1,sf=V_SF"`
-	PhVphA          int16               `sunspec:"offset=6,len=1,sf=V_SF"`
-	PhVphB          int16               `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphC          int16               `sunspec:"offset=8,len=1,sf=V_SF"`
-	PPV             int16               `sunspec:"offset=9,len=1,sf=V_SF"`
-	PhVphAB         int16               `sunspec:"offset=10,len=1,sf=V_SF"`
-	PhVphBC         int16               `sunspec:"offset=11,len=1,sf=V_SF"`
-	PhVphCA         int16               `sunspec:"offset=12,len=1,sf=V_SF"`
-	V_SF            sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz              int16               `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	W               int16               `sunspec:"offset=16,len=1,sf=W_SF"`
-	WphA            int16               `sunspec:"offset=17,len=1,sf=W_SF"`
-	WphB            int16               `sunspec:"offset=18,len=1,sf=W_SF"`
-	WphC            int16               `sunspec:"offset=19,len=1,sf=W_SF"`
-	W_SF            sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	VA              int16               `sunspec:"offset=21,len=1,sf=VA_SF"`
-	VAphA           int16               `sunspec:"offset=22,len=1,sf=VA_SF"`
-	VAphB           int16               `sunspec:"offset=23,len=1,sf=VA_SF"`
-	VAphC           int16               `sunspec:"offset=24,len=1,sf=VA_SF"`
-	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25,len=1"`
-	VAR             int16               `sunspec:"offset=26,len=1,sf=VAR_SF"`
-	VARphA          int16               `sunspec:"offset=27,len=1,sf=VAR_SF"`
-	VARphB          int16               `sunspec:"offset=28,len=1,sf=VAR_SF"`
-	VARphC          int16               `sunspec:"offset=29,len=1,sf=VAR_SF"`
-	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	PF              int16               `sunspec:"offset=31,len=1,sf=PF_SF"`
-	PFphA           int16               `sunspec:"offset=32,len=1,sf=PF_SF"`
-	PFphB           int16               `sunspec:"offset=33,len=1,sf=PF_SF"`
-	PFphC           int16               `sunspec:"offset=34,len=1,sf=PF_SF"`
-	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,len=2,sf=TotWh_SF"`
-	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,len=2,sf=TotWh_SF"`
-	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,len=2,sf=TotWh_SF"`
-	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,len=2,sf=TotWh_SF"`
-	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,len=2,sf=TotWh_SF"`
-	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,len=2,sf=TotWh_SF"`
-	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,len=2,sf=TotWh_SF"`
-	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,len=2,sf=TotWh_SF"`
-	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52,len=1"`
-	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,len=2,sf=TotVAh_SF"`
-	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,len=2,sf=TotVAh_SF"`
-	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69,len=1"`
-	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,len=2,sf=TotVArh_SF"`
-	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102,len=1"`
-	Evt             sunspec.Bitfield32  `sunspec:"offset=103,len=2"`
+	A               int16               `sunspec:"offset=0,sf=A_SF"`
+	AphA            int16               `sunspec:"offset=1,sf=A_SF"`
+	AphB            int16               `sunspec:"offset=2,sf=A_SF"`
+	AphC            int16               `sunspec:"offset=3,sf=A_SF"`
+	A_SF            sunspec.ScaleFactor `sunspec:"offset=4"`
+	PhV             int16               `sunspec:"offset=5,sf=V_SF"`
+	PhVphA          int16               `sunspec:"offset=6,sf=V_SF"`
+	PhVphB          int16               `sunspec:"offset=7,sf=V_SF"`
+	PhVphC          int16               `sunspec:"offset=8,sf=V_SF"`
+	PPV             int16               `sunspec:"offset=9,sf=V_SF"`
+	PhVphAB         int16               `sunspec:"offset=10,sf=V_SF"`
+	PhVphBC         int16               `sunspec:"offset=11,sf=V_SF"`
+	PhVphCA         int16               `sunspec:"offset=12,sf=V_SF"`
+	V_SF            sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz              int16               `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15"`
+	W               int16               `sunspec:"offset=16,sf=W_SF"`
+	WphA            int16               `sunspec:"offset=17,sf=W_SF"`
+	WphB            int16               `sunspec:"offset=18,sf=W_SF"`
+	WphC            int16               `sunspec:"offset=19,sf=W_SF"`
+	W_SF            sunspec.ScaleFactor `sunspec:"offset=20"`
+	VA              int16               `sunspec:"offset=21,sf=VA_SF"`
+	VAphA           int16               `sunspec:"offset=22,sf=VA_SF"`
+	VAphB           int16               `sunspec:"offset=23,sf=VA_SF"`
+	VAphC           int16               `sunspec:"offset=24,sf=VA_SF"`
+	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25"`
+	VAR             int16               `sunspec:"offset=26,sf=VAR_SF"`
+	VARphA          int16               `sunspec:"offset=27,sf=VAR_SF"`
+	VARphB          int16               `sunspec:"offset=28,sf=VAR_SF"`
+	VARphC          int16               `sunspec:"offset=29,sf=VAR_SF"`
+	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30"`
+	PF              int16               `sunspec:"offset=31,sf=PF_SF"`
+	PFphA           int16               `sunspec:"offset=32,sf=PF_SF"`
+	PFphB           int16               `sunspec:"offset=33,sf=PF_SF"`
+	PFphC           int16               `sunspec:"offset=34,sf=PF_SF"`
+	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35"`
+	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,sf=TotWh_SF"`
+	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,sf=TotWh_SF"`
+	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,sf=TotWh_SF"`
+	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,sf=TotWh_SF"`
+	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,sf=TotWh_SF"`
+	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,sf=TotWh_SF"`
+	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,sf=TotWh_SF"`
+	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,sf=TotWh_SF"`
+	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52"`
+	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,sf=TotVAh_SF"`
+	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,sf=TotVAh_SF"`
+	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,sf=TotVAh_SF"`
+	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,sf=TotVAh_SF"`
+	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,sf=TotVAh_SF"`
+	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,sf=TotVAh_SF"`
+	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,sf=TotVAh_SF"`
+	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,sf=TotVAh_SF"`
+	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69"`
+	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,sf=TotVArh_SF"`
+	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,sf=TotVArh_SF"`
+	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,sf=TotVArh_SF"`
+	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,sf=TotVArh_SF"`
+	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,sf=TotVArh_SF"`
+	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,sf=TotVArh_SF"`
+	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,sf=TotVArh_SF"`
+	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,sf=TotVArh_SF"`
+	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,sf=TotVArh_SF"`
+	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,sf=TotVArh_SF"`
+	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,sf=TotVArh_SF"`
+	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,sf=TotVArh_SF"`
+	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,sf=TotVArh_SF"`
+	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,sf=TotVArh_SF"`
+	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,sf=TotVArh_SF"`
+	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,sf=TotVArh_SF"`
+	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102"`
+	Evt             sunspec.Bitfield32  `sunspec:"offset=103"`
 }
 
 func (block *Block203) GetId() sunspec.ModelId {
@@ -183,78 +183,78 @@ func init() {
 				Length: 105,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PhVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PhVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PhVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase C", Description: ""},
-					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase C", Description: ""},
-					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase C", Description: ""},
-					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase C", Description: ""},
-					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PhVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PhVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PhVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor},
+					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor},
+					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase C", Description: ""},
+					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor},
+					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor},
+					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor},
+					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model204/model.go
+++ b/models/model204/model.go
@@ -93,78 +93,78 @@ const (
 )
 
 type Block204 struct {
-	A               int16               `sunspec:"offset=0,len=1,sf=A_SF"`
-	AphA            int16               `sunspec:"offset=1,len=1,sf=A_SF"`
-	AphB            int16               `sunspec:"offset=2,len=1,sf=A_SF"`
-	AphC            int16               `sunspec:"offset=3,len=1,sf=A_SF"`
-	A_SF            sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	PhV             int16               `sunspec:"offset=5,len=1,sf=V_SF"`
-	PhVphA          int16               `sunspec:"offset=6,len=1,sf=V_SF"`
-	PhVphB          int16               `sunspec:"offset=7,len=1,sf=V_SF"`
-	PhVphC          int16               `sunspec:"offset=8,len=1,sf=V_SF"`
-	PPV             int16               `sunspec:"offset=9,len=1,sf=V_SF"`
-	PhVphAB         int16               `sunspec:"offset=10,len=1,sf=V_SF"`
-	PhVphBC         int16               `sunspec:"offset=11,len=1,sf=V_SF"`
-	PhVphCA         int16               `sunspec:"offset=12,len=1,sf=V_SF"`
-	V_SF            sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	Hz              int16               `sunspec:"offset=14,len=1,sf=Hz_SF"`
-	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
-	W               int16               `sunspec:"offset=16,len=1,sf=W_SF"`
-	WphA            int16               `sunspec:"offset=17,len=1,sf=W_SF"`
-	WphB            int16               `sunspec:"offset=18,len=1,sf=W_SF"`
-	WphC            int16               `sunspec:"offset=19,len=1,sf=W_SF"`
-	W_SF            sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	VA              int16               `sunspec:"offset=21,len=1,sf=VA_SF"`
-	VAphA           int16               `sunspec:"offset=22,len=1,sf=VA_SF"`
-	VAphB           int16               `sunspec:"offset=23,len=1,sf=VA_SF"`
-	VAphC           int16               `sunspec:"offset=24,len=1,sf=VA_SF"`
-	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25,len=1"`
-	VAR             int16               `sunspec:"offset=26,len=1,sf=VAR_SF"`
-	VARphA          int16               `sunspec:"offset=27,len=1,sf=VAR_SF"`
-	VARphB          int16               `sunspec:"offset=28,len=1,sf=VAR_SF"`
-	VARphC          int16               `sunspec:"offset=29,len=1,sf=VAR_SF"`
-	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	PF              int16               `sunspec:"offset=31,len=1,sf=PF_SF"`
-	PFphA           int16               `sunspec:"offset=32,len=1,sf=PF_SF"`
-	PFphB           int16               `sunspec:"offset=33,len=1,sf=PF_SF"`
-	PFphC           int16               `sunspec:"offset=34,len=1,sf=PF_SF"`
-	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35,len=1"`
-	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,len=2,sf=TotWh_SF"`
-	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,len=2,sf=TotWh_SF"`
-	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,len=2,sf=TotWh_SF"`
-	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,len=2,sf=TotWh_SF"`
-	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,len=2,sf=TotWh_SF"`
-	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,len=2,sf=TotWh_SF"`
-	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,len=2,sf=TotWh_SF"`
-	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,len=2,sf=TotWh_SF"`
-	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52,len=1"`
-	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,len=2,sf=TotVAh_SF"`
-	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,len=2,sf=TotVAh_SF"`
-	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,len=2,sf=TotVAh_SF"`
-	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,len=2,sf=TotVAh_SF"`
-	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69,len=1"`
-	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,len=2,sf=TotVArh_SF"`
-	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102,len=1"`
-	Evt             sunspec.Bitfield32  `sunspec:"offset=103,len=2"`
+	A               int16               `sunspec:"offset=0,sf=A_SF"`
+	AphA            int16               `sunspec:"offset=1,sf=A_SF"`
+	AphB            int16               `sunspec:"offset=2,sf=A_SF"`
+	AphC            int16               `sunspec:"offset=3,sf=A_SF"`
+	A_SF            sunspec.ScaleFactor `sunspec:"offset=4"`
+	PhV             int16               `sunspec:"offset=5,sf=V_SF"`
+	PhVphA          int16               `sunspec:"offset=6,sf=V_SF"`
+	PhVphB          int16               `sunspec:"offset=7,sf=V_SF"`
+	PhVphC          int16               `sunspec:"offset=8,sf=V_SF"`
+	PPV             int16               `sunspec:"offset=9,sf=V_SF"`
+	PhVphAB         int16               `sunspec:"offset=10,sf=V_SF"`
+	PhVphBC         int16               `sunspec:"offset=11,sf=V_SF"`
+	PhVphCA         int16               `sunspec:"offset=12,sf=V_SF"`
+	V_SF            sunspec.ScaleFactor `sunspec:"offset=13"`
+	Hz              int16               `sunspec:"offset=14,sf=Hz_SF"`
+	Hz_SF           sunspec.ScaleFactor `sunspec:"offset=15"`
+	W               int16               `sunspec:"offset=16,sf=W_SF"`
+	WphA            int16               `sunspec:"offset=17,sf=W_SF"`
+	WphB            int16               `sunspec:"offset=18,sf=W_SF"`
+	WphC            int16               `sunspec:"offset=19,sf=W_SF"`
+	W_SF            sunspec.ScaleFactor `sunspec:"offset=20"`
+	VA              int16               `sunspec:"offset=21,sf=VA_SF"`
+	VAphA           int16               `sunspec:"offset=22,sf=VA_SF"`
+	VAphB           int16               `sunspec:"offset=23,sf=VA_SF"`
+	VAphC           int16               `sunspec:"offset=24,sf=VA_SF"`
+	VA_SF           sunspec.ScaleFactor `sunspec:"offset=25"`
+	VAR             int16               `sunspec:"offset=26,sf=VAR_SF"`
+	VARphA          int16               `sunspec:"offset=27,sf=VAR_SF"`
+	VARphB          int16               `sunspec:"offset=28,sf=VAR_SF"`
+	VARphC          int16               `sunspec:"offset=29,sf=VAR_SF"`
+	VAR_SF          sunspec.ScaleFactor `sunspec:"offset=30"`
+	PF              int16               `sunspec:"offset=31,sf=PF_SF"`
+	PFphA           int16               `sunspec:"offset=32,sf=PF_SF"`
+	PFphB           int16               `sunspec:"offset=33,sf=PF_SF"`
+	PFphC           int16               `sunspec:"offset=34,sf=PF_SF"`
+	PF_SF           sunspec.ScaleFactor `sunspec:"offset=35"`
+	TotWhExp        sunspec.Acc32       `sunspec:"offset=36,sf=TotWh_SF"`
+	TotWhExpPhA     sunspec.Acc32       `sunspec:"offset=38,sf=TotWh_SF"`
+	TotWhExpPhB     sunspec.Acc32       `sunspec:"offset=40,sf=TotWh_SF"`
+	TotWhExpPhC     sunspec.Acc32       `sunspec:"offset=42,sf=TotWh_SF"`
+	TotWhImp        sunspec.Acc32       `sunspec:"offset=44,sf=TotWh_SF"`
+	TotWhImpPhA     sunspec.Acc32       `sunspec:"offset=46,sf=TotWh_SF"`
+	TotWhImpPhB     sunspec.Acc32       `sunspec:"offset=48,sf=TotWh_SF"`
+	TotWhImpPhC     sunspec.Acc32       `sunspec:"offset=50,sf=TotWh_SF"`
+	TotWh_SF        sunspec.ScaleFactor `sunspec:"offset=52"`
+	TotVAhExp       sunspec.Acc32       `sunspec:"offset=53,sf=TotVAh_SF"`
+	TotVAhExpPhA    sunspec.Acc32       `sunspec:"offset=55,sf=TotVAh_SF"`
+	TotVAhExpPhB    sunspec.Acc32       `sunspec:"offset=57,sf=TotVAh_SF"`
+	TotVAhExpPhC    sunspec.Acc32       `sunspec:"offset=59,sf=TotVAh_SF"`
+	TotVAhImp       sunspec.Acc32       `sunspec:"offset=61,sf=TotVAh_SF"`
+	TotVAhImpPhA    sunspec.Acc32       `sunspec:"offset=63,sf=TotVAh_SF"`
+	TotVAhImpPhB    sunspec.Acc32       `sunspec:"offset=65,sf=TotVAh_SF"`
+	TotVAhImpPhC    sunspec.Acc32       `sunspec:"offset=67,sf=TotVAh_SF"`
+	TotVAh_SF       sunspec.ScaleFactor `sunspec:"offset=69"`
+	TotVArhImpQ1    sunspec.Acc32       `sunspec:"offset=70,sf=TotVArh_SF"`
+	TotVArhImpQ1PhA sunspec.Acc32       `sunspec:"offset=72,sf=TotVArh_SF"`
+	TotVArhImpQ1PhB sunspec.Acc32       `sunspec:"offset=74,sf=TotVArh_SF"`
+	TotVArhImpQ1PhC sunspec.Acc32       `sunspec:"offset=76,sf=TotVArh_SF"`
+	TotVArhImpQ2    sunspec.Acc32       `sunspec:"offset=78,sf=TotVArh_SF"`
+	TotVArhImpQ2PhA sunspec.Acc32       `sunspec:"offset=80,sf=TotVArh_SF"`
+	TotVArhImpQ2PhB sunspec.Acc32       `sunspec:"offset=82,sf=TotVArh_SF"`
+	TotVArhImpQ2PhC sunspec.Acc32       `sunspec:"offset=84,sf=TotVArh_SF"`
+	TotVArhExpQ3    sunspec.Acc32       `sunspec:"offset=86,sf=TotVArh_SF"`
+	TotVArhExpQ3PhA sunspec.Acc32       `sunspec:"offset=88,sf=TotVArh_SF"`
+	TotVArhExpQ3PhB sunspec.Acc32       `sunspec:"offset=90,sf=TotVArh_SF"`
+	TotVArhExpQ3PhC sunspec.Acc32       `sunspec:"offset=92,sf=TotVArh_SF"`
+	TotVArhExpQ4    sunspec.Acc32       `sunspec:"offset=94,sf=TotVArh_SF"`
+	TotVArhExpQ4PhA sunspec.Acc32       `sunspec:"offset=96,sf=TotVArh_SF"`
+	TotVArhExpQ4PhB sunspec.Acc32       `sunspec:"offset=98,sf=TotVArh_SF"`
+	TotVArhExpQ4PhC sunspec.Acc32       `sunspec:"offset=100,sf=TotVArh_SF"`
+	TotVArh_SF      sunspec.ScaleFactor `sunspec:"offset=102"`
+	Evt             sunspec.Bitfield32  `sunspec:"offset=103"`
 }
 
 func (block *Block204) GetId() sunspec.ModelId {
@@ -183,78 +183,78 @@ func init() {
 				Length: 105,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PhVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PhVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PhVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Watts phase C", Description: ""},
-					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA phase C", Description: ""},
-					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR phase C", Description: ""},
-					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF phase C", Description: ""},
-					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 1, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 2, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 3, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: A_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PhV, Offset: 5, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 7, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 8, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 9, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PhVphAB, Offset: 10, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PhVphBC, Offset: 11, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PhVphCA, Offset: 12, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: V_SF, Offset: 13, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: Hz_SF, Offset: 15, Type: typelabel.ScaleFactor},
+					{Id: W, Offset: 16, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 18, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 19, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: W_SF, Offset: 20, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 21, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 22, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 23, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 24, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VA_SF, Offset: 25, Type: typelabel.ScaleFactor},
+					{Id: VAR, Offset: 26, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 27, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 28, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 29, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: VAR_SF, Offset: 30, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 31, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 32, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 33, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 34, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF phase C", Description: ""},
+					{Id: PF_SF, Offset: 35, Type: typelabel.ScaleFactor},
+					{Id: TotWhExp, Offset: 36, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 38, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 40, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 42, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 44, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 46, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 48, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 50, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotWh_SF, Offset: 52, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: TotVAhExp, Offset: 53, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 55, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 57, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 59, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 61, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 63, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 65, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 67, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVAh_SF, Offset: 69, Type: typelabel.ScaleFactor},
+					{Id: TotVArhImpQ1, Offset: 70, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1PhA, Offset: 72, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1PhB, Offset: 74, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1PhC, Offset: 76, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 78, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2PhA, Offset: 80, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2PhB, Offset: 82, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2PhC, Offset: 84, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 86, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3PhA, Offset: 88, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3PhB, Offset: 90, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3PhC, Offset: 92, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 94, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4PhA, Offset: 96, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4PhB, Offset: 98, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4PhC, Offset: 100, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: TotVArh_SF, Offset: 102, Type: typelabel.ScaleFactor},
+					{Id: Evt, Offset: 103, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model211/model.go
+++ b/models/model211/model.go
@@ -83,68 +83,68 @@ const (
 )
 
 type Block211 struct {
-	A               float32            `sunspec:"offset=0,len=2"`
-	AphA            float32            `sunspec:"offset=2,len=2"`
-	AphB            float32            `sunspec:"offset=4,len=2"`
-	AphC            float32            `sunspec:"offset=6,len=2"`
-	PhV             float32            `sunspec:"offset=8,len=2"`
-	PhVphA          float32            `sunspec:"offset=10,len=2"`
-	PhVphB          float32            `sunspec:"offset=12,len=2"`
-	PhVphC          float32            `sunspec:"offset=14,len=2"`
-	PPV             float32            `sunspec:"offset=16,len=2"`
-	PPVphAB         float32            `sunspec:"offset=18,len=2"`
-	PPVphBC         float32            `sunspec:"offset=20,len=2"`
-	PPVphCA         float32            `sunspec:"offset=22,len=2"`
-	Hz              float32            `sunspec:"offset=24,len=2"`
-	W               float32            `sunspec:"offset=26,len=2"`
-	WphA            float32            `sunspec:"offset=28,len=2"`
-	WphB            float32            `sunspec:"offset=30,len=2"`
-	WphC            float32            `sunspec:"offset=32,len=2"`
-	VA              float32            `sunspec:"offset=34,len=2"`
-	VAphA           float32            `sunspec:"offset=36,len=2"`
-	VAphB           float32            `sunspec:"offset=38,len=2"`
-	VAphC           float32            `sunspec:"offset=40,len=2"`
-	VAR             float32            `sunspec:"offset=42,len=2"`
-	VARphA          float32            `sunspec:"offset=44,len=2"`
-	VARphB          float32            `sunspec:"offset=46,len=2"`
-	VARphC          float32            `sunspec:"offset=48,len=2"`
-	PF              float32            `sunspec:"offset=50,len=2"`
-	PFphA           float32            `sunspec:"offset=52,len=2"`
-	PFphB           float32            `sunspec:"offset=54,len=2"`
-	PFphC           float32            `sunspec:"offset=56,len=2"`
-	TotWhExp        float32            `sunspec:"offset=58,len=2"`
-	TotWhExpPhA     float32            `sunspec:"offset=60,len=2"`
-	TotWhExpPhB     float32            `sunspec:"offset=62,len=2"`
-	TotWhExpPhC     float32            `sunspec:"offset=64,len=2"`
-	TotWhImp        float32            `sunspec:"offset=66,len=2"`
-	TotWhImpPhA     float32            `sunspec:"offset=68,len=2"`
-	TotWhImpPhB     float32            `sunspec:"offset=70,len=2"`
-	TotWhImpPhC     float32            `sunspec:"offset=72,len=2"`
-	TotVAhExp       float32            `sunspec:"offset=74,len=2"`
-	TotVAhExpPhA    float32            `sunspec:"offset=76,len=2"`
-	TotVAhExpPhB    float32            `sunspec:"offset=78,len=2"`
-	TotVAhExpPhC    float32            `sunspec:"offset=80,len=2"`
-	TotVAhImp       float32            `sunspec:"offset=82,len=2"`
-	TotVAhImpPhA    float32            `sunspec:"offset=84,len=2"`
-	TotVAhImpPhB    float32            `sunspec:"offset=86,len=2"`
-	TotVAhImpPhC    float32            `sunspec:"offset=88,len=2"`
-	TotVArhImpQ1    float32            `sunspec:"offset=90,len=2"`
-	TotVArhImpQ1phA float32            `sunspec:"offset=92,len=2"`
-	TotVArhImpQ1phB float32            `sunspec:"offset=94,len=2"`
-	TotVArhImpQ1phC float32            `sunspec:"offset=96,len=2"`
-	TotVArhImpQ2    float32            `sunspec:"offset=98,len=2"`
-	TotVArhImpQ2phA float32            `sunspec:"offset=100,len=2"`
-	TotVArhImpQ2phB float32            `sunspec:"offset=102,len=2"`
-	TotVArhImpQ2phC float32            `sunspec:"offset=104,len=2"`
-	TotVArhExpQ3    float32            `sunspec:"offset=106,len=2"`
-	TotVArhExpQ3phA float32            `sunspec:"offset=108,len=2"`
-	TotVArhExpQ3phB float32            `sunspec:"offset=110,len=2"`
-	TotVArhExpQ3phC float32            `sunspec:"offset=112,len=2"`
-	TotVArhExpQ4    float32            `sunspec:"offset=114,len=2"`
-	TotVArhExpQ4phA float32            `sunspec:"offset=116,len=2"`
-	TotVArhExpQ4phB float32            `sunspec:"offset=118,len=2"`
-	TotVArhExpQ4phC float32            `sunspec:"offset=120,len=2"`
-	Evt             sunspec.Bitfield32 `sunspec:"offset=122,len=2"`
+	A               float32            `sunspec:"offset=0"`
+	AphA            float32            `sunspec:"offset=2"`
+	AphB            float32            `sunspec:"offset=4"`
+	AphC            float32            `sunspec:"offset=6"`
+	PhV             float32            `sunspec:"offset=8"`
+	PhVphA          float32            `sunspec:"offset=10"`
+	PhVphB          float32            `sunspec:"offset=12"`
+	PhVphC          float32            `sunspec:"offset=14"`
+	PPV             float32            `sunspec:"offset=16"`
+	PPVphAB         float32            `sunspec:"offset=18"`
+	PPVphBC         float32            `sunspec:"offset=20"`
+	PPVphCA         float32            `sunspec:"offset=22"`
+	Hz              float32            `sunspec:"offset=24"`
+	W               float32            `sunspec:"offset=26"`
+	WphA            float32            `sunspec:"offset=28"`
+	WphB            float32            `sunspec:"offset=30"`
+	WphC            float32            `sunspec:"offset=32"`
+	VA              float32            `sunspec:"offset=34"`
+	VAphA           float32            `sunspec:"offset=36"`
+	VAphB           float32            `sunspec:"offset=38"`
+	VAphC           float32            `sunspec:"offset=40"`
+	VAR             float32            `sunspec:"offset=42"`
+	VARphA          float32            `sunspec:"offset=44"`
+	VARphB          float32            `sunspec:"offset=46"`
+	VARphC          float32            `sunspec:"offset=48"`
+	PF              float32            `sunspec:"offset=50"`
+	PFphA           float32            `sunspec:"offset=52"`
+	PFphB           float32            `sunspec:"offset=54"`
+	PFphC           float32            `sunspec:"offset=56"`
+	TotWhExp        float32            `sunspec:"offset=58"`
+	TotWhExpPhA     float32            `sunspec:"offset=60"`
+	TotWhExpPhB     float32            `sunspec:"offset=62"`
+	TotWhExpPhC     float32            `sunspec:"offset=64"`
+	TotWhImp        float32            `sunspec:"offset=66"`
+	TotWhImpPhA     float32            `sunspec:"offset=68"`
+	TotWhImpPhB     float32            `sunspec:"offset=70"`
+	TotWhImpPhC     float32            `sunspec:"offset=72"`
+	TotVAhExp       float32            `sunspec:"offset=74"`
+	TotVAhExpPhA    float32            `sunspec:"offset=76"`
+	TotVAhExpPhB    float32            `sunspec:"offset=78"`
+	TotVAhExpPhC    float32            `sunspec:"offset=80"`
+	TotVAhImp       float32            `sunspec:"offset=82"`
+	TotVAhImpPhA    float32            `sunspec:"offset=84"`
+	TotVAhImpPhB    float32            `sunspec:"offset=86"`
+	TotVAhImpPhC    float32            `sunspec:"offset=88"`
+	TotVArhImpQ1    float32            `sunspec:"offset=90"`
+	TotVArhImpQ1phA float32            `sunspec:"offset=92"`
+	TotVArhImpQ1phB float32            `sunspec:"offset=94"`
+	TotVArhImpQ1phC float32            `sunspec:"offset=96"`
+	TotVArhImpQ2    float32            `sunspec:"offset=98"`
+	TotVArhImpQ2phA float32            `sunspec:"offset=100"`
+	TotVArhImpQ2phB float32            `sunspec:"offset=102"`
+	TotVArhImpQ2phC float32            `sunspec:"offset=104"`
+	TotVArhExpQ3    float32            `sunspec:"offset=106"`
+	TotVArhExpQ3phA float32            `sunspec:"offset=108"`
+	TotVArhExpQ3phB float32            `sunspec:"offset=110"`
+	TotVArhExpQ3phC float32            `sunspec:"offset=112"`
+	TotVArhExpQ4    float32            `sunspec:"offset=114"`
+	TotVArhExpQ4phA float32            `sunspec:"offset=116"`
+	TotVArhExpQ4phB float32            `sunspec:"offset=118"`
+	TotVArhExpQ4phC float32            `sunspec:"offset=120"`
+	Evt             sunspec.Bitfield32 `sunspec:"offset=122"`
 }
 
 func (block *Block211) GetId() sunspec.ModelId {
@@ -163,68 +163,68 @@ func init() {
 				Length: 124,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase C", Description: ""},
-					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase C", Description: ""},
-					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase C", Description: ""},
-					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase C", Description: ""},
-					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Label: "PF phase C", Description: ""},
+					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model212/model.go
+++ b/models/model212/model.go
@@ -83,68 +83,68 @@ const (
 )
 
 type Block212 struct {
-	A               float32            `sunspec:"offset=0,len=2"`
-	AphA            float32            `sunspec:"offset=2,len=2"`
-	AphB            float32            `sunspec:"offset=4,len=2"`
-	AphC            float32            `sunspec:"offset=6,len=2"`
-	PhV             float32            `sunspec:"offset=8,len=2"`
-	PhVphA          float32            `sunspec:"offset=10,len=2"`
-	PhVphB          float32            `sunspec:"offset=12,len=2"`
-	PhVphC          float32            `sunspec:"offset=14,len=2"`
-	PPV             float32            `sunspec:"offset=16,len=2"`
-	PPVphAB         float32            `sunspec:"offset=18,len=2"`
-	PPVphBC         float32            `sunspec:"offset=20,len=2"`
-	PPVphCA         float32            `sunspec:"offset=22,len=2"`
-	Hz              float32            `sunspec:"offset=24,len=2"`
-	W               float32            `sunspec:"offset=26,len=2"`
-	WphA            float32            `sunspec:"offset=28,len=2"`
-	WphB            float32            `sunspec:"offset=30,len=2"`
-	WphC            float32            `sunspec:"offset=32,len=2"`
-	VA              float32            `sunspec:"offset=34,len=2"`
-	VAphA           float32            `sunspec:"offset=36,len=2"`
-	VAphB           float32            `sunspec:"offset=38,len=2"`
-	VAphC           float32            `sunspec:"offset=40,len=2"`
-	VAR             float32            `sunspec:"offset=42,len=2"`
-	VARphA          float32            `sunspec:"offset=44,len=2"`
-	VARphB          float32            `sunspec:"offset=46,len=2"`
-	VARphC          float32            `sunspec:"offset=48,len=2"`
-	PF              float32            `sunspec:"offset=50,len=2"`
-	PFphA           float32            `sunspec:"offset=52,len=2"`
-	PFphB           float32            `sunspec:"offset=54,len=2"`
-	PFphC           float32            `sunspec:"offset=56,len=2"`
-	TotWhExp        float32            `sunspec:"offset=58,len=2"`
-	TotWhExpPhA     float32            `sunspec:"offset=60,len=2"`
-	TotWhExpPhB     float32            `sunspec:"offset=62,len=2"`
-	TotWhExpPhC     float32            `sunspec:"offset=64,len=2"`
-	TotWhImp        float32            `sunspec:"offset=66,len=2"`
-	TotWhImpPhA     float32            `sunspec:"offset=68,len=2"`
-	TotWhImpPhB     float32            `sunspec:"offset=70,len=2"`
-	TotWhImpPhC     float32            `sunspec:"offset=72,len=2"`
-	TotVAhExp       float32            `sunspec:"offset=74,len=2"`
-	TotVAhExpPhA    float32            `sunspec:"offset=76,len=2"`
-	TotVAhExpPhB    float32            `sunspec:"offset=78,len=2"`
-	TotVAhExpPhC    float32            `sunspec:"offset=80,len=2"`
-	TotVAhImp       float32            `sunspec:"offset=82,len=2"`
-	TotVAhImpPhA    float32            `sunspec:"offset=84,len=2"`
-	TotVAhImpPhB    float32            `sunspec:"offset=86,len=2"`
-	TotVAhImpPhC    float32            `sunspec:"offset=88,len=2"`
-	TotVArhImpQ1    float32            `sunspec:"offset=90,len=2"`
-	TotVArhImpQ1phA float32            `sunspec:"offset=92,len=2"`
-	TotVArhImpQ1phB float32            `sunspec:"offset=94,len=2"`
-	TotVArhImpQ1phC float32            `sunspec:"offset=96,len=2"`
-	TotVArhImpQ2    float32            `sunspec:"offset=98,len=2"`
-	TotVArhImpQ2phA float32            `sunspec:"offset=100,len=2"`
-	TotVArhImpQ2phB float32            `sunspec:"offset=102,len=2"`
-	TotVArhImpQ2phC float32            `sunspec:"offset=104,len=2"`
-	TotVArhExpQ3    float32            `sunspec:"offset=106,len=2"`
-	TotVArhExpQ3phA float32            `sunspec:"offset=108,len=2"`
-	TotVArhExpQ3phB float32            `sunspec:"offset=110,len=2"`
-	TotVArhExpQ3phC float32            `sunspec:"offset=112,len=2"`
-	TotVArhExpQ4    float32            `sunspec:"offset=114,len=2"`
-	TotVArhExpQ4phA float32            `sunspec:"offset=116,len=2"`
-	TotVArhExpQ4phB float32            `sunspec:"offset=118,len=2"`
-	TotVArhExpQ4phC float32            `sunspec:"offset=120,len=2"`
-	Evt             sunspec.Bitfield32 `sunspec:"offset=122,len=2"`
+	A               float32            `sunspec:"offset=0"`
+	AphA            float32            `sunspec:"offset=2"`
+	AphB            float32            `sunspec:"offset=4"`
+	AphC            float32            `sunspec:"offset=6"`
+	PhV             float32            `sunspec:"offset=8"`
+	PhVphA          float32            `sunspec:"offset=10"`
+	PhVphB          float32            `sunspec:"offset=12"`
+	PhVphC          float32            `sunspec:"offset=14"`
+	PPV             float32            `sunspec:"offset=16"`
+	PPVphAB         float32            `sunspec:"offset=18"`
+	PPVphBC         float32            `sunspec:"offset=20"`
+	PPVphCA         float32            `sunspec:"offset=22"`
+	Hz              float32            `sunspec:"offset=24"`
+	W               float32            `sunspec:"offset=26"`
+	WphA            float32            `sunspec:"offset=28"`
+	WphB            float32            `sunspec:"offset=30"`
+	WphC            float32            `sunspec:"offset=32"`
+	VA              float32            `sunspec:"offset=34"`
+	VAphA           float32            `sunspec:"offset=36"`
+	VAphB           float32            `sunspec:"offset=38"`
+	VAphC           float32            `sunspec:"offset=40"`
+	VAR             float32            `sunspec:"offset=42"`
+	VARphA          float32            `sunspec:"offset=44"`
+	VARphB          float32            `sunspec:"offset=46"`
+	VARphC          float32            `sunspec:"offset=48"`
+	PF              float32            `sunspec:"offset=50"`
+	PFphA           float32            `sunspec:"offset=52"`
+	PFphB           float32            `sunspec:"offset=54"`
+	PFphC           float32            `sunspec:"offset=56"`
+	TotWhExp        float32            `sunspec:"offset=58"`
+	TotWhExpPhA     float32            `sunspec:"offset=60"`
+	TotWhExpPhB     float32            `sunspec:"offset=62"`
+	TotWhExpPhC     float32            `sunspec:"offset=64"`
+	TotWhImp        float32            `sunspec:"offset=66"`
+	TotWhImpPhA     float32            `sunspec:"offset=68"`
+	TotWhImpPhB     float32            `sunspec:"offset=70"`
+	TotWhImpPhC     float32            `sunspec:"offset=72"`
+	TotVAhExp       float32            `sunspec:"offset=74"`
+	TotVAhExpPhA    float32            `sunspec:"offset=76"`
+	TotVAhExpPhB    float32            `sunspec:"offset=78"`
+	TotVAhExpPhC    float32            `sunspec:"offset=80"`
+	TotVAhImp       float32            `sunspec:"offset=82"`
+	TotVAhImpPhA    float32            `sunspec:"offset=84"`
+	TotVAhImpPhB    float32            `sunspec:"offset=86"`
+	TotVAhImpPhC    float32            `sunspec:"offset=88"`
+	TotVArhImpQ1    float32            `sunspec:"offset=90"`
+	TotVArhImpQ1phA float32            `sunspec:"offset=92"`
+	TotVArhImpQ1phB float32            `sunspec:"offset=94"`
+	TotVArhImpQ1phC float32            `sunspec:"offset=96"`
+	TotVArhImpQ2    float32            `sunspec:"offset=98"`
+	TotVArhImpQ2phA float32            `sunspec:"offset=100"`
+	TotVArhImpQ2phB float32            `sunspec:"offset=102"`
+	TotVArhImpQ2phC float32            `sunspec:"offset=104"`
+	TotVArhExpQ3    float32            `sunspec:"offset=106"`
+	TotVArhExpQ3phA float32            `sunspec:"offset=108"`
+	TotVArhExpQ3phB float32            `sunspec:"offset=110"`
+	TotVArhExpQ3phC float32            `sunspec:"offset=112"`
+	TotVArhExpQ4    float32            `sunspec:"offset=114"`
+	TotVArhExpQ4phA float32            `sunspec:"offset=116"`
+	TotVArhExpQ4phB float32            `sunspec:"offset=118"`
+	TotVArhExpQ4phC float32            `sunspec:"offset=120"`
+	Evt             sunspec.Bitfield32 `sunspec:"offset=122"`
 }
 
 func (block *Block212) GetId() sunspec.ModelId {
@@ -163,68 +163,68 @@ func init() {
 				Length: 124,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase C", Description: ""},
-					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase C", Description: ""},
-					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase C", Description: ""},
-					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase C", Description: ""},
-					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Label: "PF phase C", Description: ""},
+					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model213/model.go
+++ b/models/model213/model.go
@@ -83,68 +83,68 @@ const (
 )
 
 type Block213 struct {
-	A               float32            `sunspec:"offset=0,len=2"`
-	AphA            float32            `sunspec:"offset=2,len=2"`
-	AphB            float32            `sunspec:"offset=4,len=2"`
-	AphC            float32            `sunspec:"offset=6,len=2"`
-	PhV             float32            `sunspec:"offset=8,len=2"`
-	PhVphA          float32            `sunspec:"offset=10,len=2"`
-	PhVphB          float32            `sunspec:"offset=12,len=2"`
-	PhVphC          float32            `sunspec:"offset=14,len=2"`
-	PPV             float32            `sunspec:"offset=16,len=2"`
-	PPVphAB         float32            `sunspec:"offset=18,len=2"`
-	PPVphBC         float32            `sunspec:"offset=20,len=2"`
-	PPVphCA         float32            `sunspec:"offset=22,len=2"`
-	Hz              float32            `sunspec:"offset=24,len=2"`
-	W               float32            `sunspec:"offset=26,len=2"`
-	WphA            float32            `sunspec:"offset=28,len=2"`
-	WphB            float32            `sunspec:"offset=30,len=2"`
-	WphC            float32            `sunspec:"offset=32,len=2"`
-	VA              float32            `sunspec:"offset=34,len=2"`
-	VAphA           float32            `sunspec:"offset=36,len=2"`
-	VAphB           float32            `sunspec:"offset=38,len=2"`
-	VAphC           float32            `sunspec:"offset=40,len=2"`
-	VAR             float32            `sunspec:"offset=42,len=2"`
-	VARphA          float32            `sunspec:"offset=44,len=2"`
-	VARphB          float32            `sunspec:"offset=46,len=2"`
-	VARphC          float32            `sunspec:"offset=48,len=2"`
-	PF              float32            `sunspec:"offset=50,len=2"`
-	PFphA           float32            `sunspec:"offset=52,len=2"`
-	PFphB           float32            `sunspec:"offset=54,len=2"`
-	PFphC           float32            `sunspec:"offset=56,len=2"`
-	TotWhExp        float32            `sunspec:"offset=58,len=2"`
-	TotWhExpPhA     float32            `sunspec:"offset=60,len=2"`
-	TotWhExpPhB     float32            `sunspec:"offset=62,len=2"`
-	TotWhExpPhC     float32            `sunspec:"offset=64,len=2"`
-	TotWhImp        float32            `sunspec:"offset=66,len=2"`
-	TotWhImpPhA     float32            `sunspec:"offset=68,len=2"`
-	TotWhImpPhB     float32            `sunspec:"offset=70,len=2"`
-	TotWhImpPhC     float32            `sunspec:"offset=72,len=2"`
-	TotVAhExp       float32            `sunspec:"offset=74,len=2"`
-	TotVAhExpPhA    float32            `sunspec:"offset=76,len=2"`
-	TotVAhExpPhB    float32            `sunspec:"offset=78,len=2"`
-	TotVAhExpPhC    float32            `sunspec:"offset=80,len=2"`
-	TotVAhImp       float32            `sunspec:"offset=82,len=2"`
-	TotVAhImpPhA    float32            `sunspec:"offset=84,len=2"`
-	TotVAhImpPhB    float32            `sunspec:"offset=86,len=2"`
-	TotVAhImpPhC    float32            `sunspec:"offset=88,len=2"`
-	TotVArhImpQ1    float32            `sunspec:"offset=90,len=2"`
-	TotVArhImpQ1phA float32            `sunspec:"offset=92,len=2"`
-	TotVArhImpQ1phB float32            `sunspec:"offset=94,len=2"`
-	TotVArhImpQ1phC float32            `sunspec:"offset=96,len=2"`
-	TotVArhImpQ2    float32            `sunspec:"offset=98,len=2"`
-	TotVArhImpQ2phA float32            `sunspec:"offset=100,len=2"`
-	TotVArhImpQ2phB float32            `sunspec:"offset=102,len=2"`
-	TotVArhImpQ2phC float32            `sunspec:"offset=104,len=2"`
-	TotVArhExpQ3    float32            `sunspec:"offset=106,len=2"`
-	TotVArhExpQ3phA float32            `sunspec:"offset=108,len=2"`
-	TotVArhExpQ3phB float32            `sunspec:"offset=110,len=2"`
-	TotVArhExpQ3phC float32            `sunspec:"offset=112,len=2"`
-	TotVArhExpQ4    float32            `sunspec:"offset=114,len=2"`
-	TotVArhExpQ4phA float32            `sunspec:"offset=116,len=2"`
-	TotVArhExpQ4phB float32            `sunspec:"offset=118,len=2"`
-	TotVArhExpQ4phC float32            `sunspec:"offset=120,len=2"`
-	Evt             sunspec.Bitfield32 `sunspec:"offset=122,len=2"`
+	A               float32            `sunspec:"offset=0"`
+	AphA            float32            `sunspec:"offset=2"`
+	AphB            float32            `sunspec:"offset=4"`
+	AphC            float32            `sunspec:"offset=6"`
+	PhV             float32            `sunspec:"offset=8"`
+	PhVphA          float32            `sunspec:"offset=10"`
+	PhVphB          float32            `sunspec:"offset=12"`
+	PhVphC          float32            `sunspec:"offset=14"`
+	PPV             float32            `sunspec:"offset=16"`
+	PPVphAB         float32            `sunspec:"offset=18"`
+	PPVphBC         float32            `sunspec:"offset=20"`
+	PPVphCA         float32            `sunspec:"offset=22"`
+	Hz              float32            `sunspec:"offset=24"`
+	W               float32            `sunspec:"offset=26"`
+	WphA            float32            `sunspec:"offset=28"`
+	WphB            float32            `sunspec:"offset=30"`
+	WphC            float32            `sunspec:"offset=32"`
+	VA              float32            `sunspec:"offset=34"`
+	VAphA           float32            `sunspec:"offset=36"`
+	VAphB           float32            `sunspec:"offset=38"`
+	VAphC           float32            `sunspec:"offset=40"`
+	VAR             float32            `sunspec:"offset=42"`
+	VARphA          float32            `sunspec:"offset=44"`
+	VARphB          float32            `sunspec:"offset=46"`
+	VARphC          float32            `sunspec:"offset=48"`
+	PF              float32            `sunspec:"offset=50"`
+	PFphA           float32            `sunspec:"offset=52"`
+	PFphB           float32            `sunspec:"offset=54"`
+	PFphC           float32            `sunspec:"offset=56"`
+	TotWhExp        float32            `sunspec:"offset=58"`
+	TotWhExpPhA     float32            `sunspec:"offset=60"`
+	TotWhExpPhB     float32            `sunspec:"offset=62"`
+	TotWhExpPhC     float32            `sunspec:"offset=64"`
+	TotWhImp        float32            `sunspec:"offset=66"`
+	TotWhImpPhA     float32            `sunspec:"offset=68"`
+	TotWhImpPhB     float32            `sunspec:"offset=70"`
+	TotWhImpPhC     float32            `sunspec:"offset=72"`
+	TotVAhExp       float32            `sunspec:"offset=74"`
+	TotVAhExpPhA    float32            `sunspec:"offset=76"`
+	TotVAhExpPhB    float32            `sunspec:"offset=78"`
+	TotVAhExpPhC    float32            `sunspec:"offset=80"`
+	TotVAhImp       float32            `sunspec:"offset=82"`
+	TotVAhImpPhA    float32            `sunspec:"offset=84"`
+	TotVAhImpPhB    float32            `sunspec:"offset=86"`
+	TotVAhImpPhC    float32            `sunspec:"offset=88"`
+	TotVArhImpQ1    float32            `sunspec:"offset=90"`
+	TotVArhImpQ1phA float32            `sunspec:"offset=92"`
+	TotVArhImpQ1phB float32            `sunspec:"offset=94"`
+	TotVArhImpQ1phC float32            `sunspec:"offset=96"`
+	TotVArhImpQ2    float32            `sunspec:"offset=98"`
+	TotVArhImpQ2phA float32            `sunspec:"offset=100"`
+	TotVArhImpQ2phB float32            `sunspec:"offset=102"`
+	TotVArhImpQ2phC float32            `sunspec:"offset=104"`
+	TotVArhExpQ3    float32            `sunspec:"offset=106"`
+	TotVArhExpQ3phA float32            `sunspec:"offset=108"`
+	TotVArhExpQ3phB float32            `sunspec:"offset=110"`
+	TotVArhExpQ3phC float32            `sunspec:"offset=112"`
+	TotVArhExpQ4    float32            `sunspec:"offset=114"`
+	TotVArhExpQ4phA float32            `sunspec:"offset=116"`
+	TotVArhExpQ4phB float32            `sunspec:"offset=118"`
+	TotVArhExpQ4phC float32            `sunspec:"offset=120"`
+	Evt             sunspec.Bitfield32 `sunspec:"offset=122"`
 }
 
 func (block *Block213) GetId() sunspec.ModelId {
@@ -163,68 +163,68 @@ func init() {
 				Length: 124,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase C", Description: ""},
-					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase C", Description: ""},
-					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase C", Description: ""},
-					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase C", Description: ""},
-					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Label: "PF phase C", Description: ""},
+					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model214/model.go
+++ b/models/model214/model.go
@@ -83,68 +83,68 @@ const (
 )
 
 type Block214 struct {
-	A               float32            `sunspec:"offset=0,len=2"`
-	AphA            float32            `sunspec:"offset=2,len=2"`
-	AphB            float32            `sunspec:"offset=4,len=2"`
-	AphC            float32            `sunspec:"offset=6,len=2"`
-	PhV             float32            `sunspec:"offset=8,len=2"`
-	PhVphA          float32            `sunspec:"offset=10,len=2"`
-	PhVphB          float32            `sunspec:"offset=12,len=2"`
-	PhVphC          float32            `sunspec:"offset=14,len=2"`
-	PPV             float32            `sunspec:"offset=16,len=2"`
-	PPVphAB         float32            `sunspec:"offset=18,len=2"`
-	PPVphBC         float32            `sunspec:"offset=20,len=2"`
-	PPVphCA         float32            `sunspec:"offset=22,len=2"`
-	Hz              float32            `sunspec:"offset=24,len=2"`
-	W               float32            `sunspec:"offset=26,len=2"`
-	WphA            float32            `sunspec:"offset=28,len=2"`
-	WphB            float32            `sunspec:"offset=30,len=2"`
-	WphC            float32            `sunspec:"offset=32,len=2"`
-	VA              float32            `sunspec:"offset=34,len=2"`
-	VAphA           float32            `sunspec:"offset=36,len=2"`
-	VAphB           float32            `sunspec:"offset=38,len=2"`
-	VAphC           float32            `sunspec:"offset=40,len=2"`
-	VAR             float32            `sunspec:"offset=42,len=2"`
-	VARphA          float32            `sunspec:"offset=44,len=2"`
-	VARphB          float32            `sunspec:"offset=46,len=2"`
-	VARphC          float32            `sunspec:"offset=48,len=2"`
-	PF              float32            `sunspec:"offset=50,len=2"`
-	PFphA           float32            `sunspec:"offset=52,len=2"`
-	PFphB           float32            `sunspec:"offset=54,len=2"`
-	PFphC           float32            `sunspec:"offset=56,len=2"`
-	TotWhExp        float32            `sunspec:"offset=58,len=2"`
-	TotWhExpPhA     float32            `sunspec:"offset=60,len=2"`
-	TotWhExpPhB     float32            `sunspec:"offset=62,len=2"`
-	TotWhExpPhC     float32            `sunspec:"offset=64,len=2"`
-	TotWhImp        float32            `sunspec:"offset=66,len=2"`
-	TotWhImpPhA     float32            `sunspec:"offset=68,len=2"`
-	TotWhImpPhB     float32            `sunspec:"offset=70,len=2"`
-	TotWhImpPhC     float32            `sunspec:"offset=72,len=2"`
-	TotVAhExp       float32            `sunspec:"offset=74,len=2"`
-	TotVAhExpPhA    float32            `sunspec:"offset=76,len=2"`
-	TotVAhExpPhB    float32            `sunspec:"offset=78,len=2"`
-	TotVAhExpPhC    float32            `sunspec:"offset=80,len=2"`
-	TotVAhImp       float32            `sunspec:"offset=82,len=2"`
-	TotVAhImpPhA    float32            `sunspec:"offset=84,len=2"`
-	TotVAhImpPhB    float32            `sunspec:"offset=86,len=2"`
-	TotVAhImpPhC    float32            `sunspec:"offset=88,len=2"`
-	TotVArhImpQ1    float32            `sunspec:"offset=90,len=2"`
-	TotVArhImpQ1phA float32            `sunspec:"offset=92,len=2"`
-	TotVArhImpQ1phB float32            `sunspec:"offset=94,len=2"`
-	TotVArhImpQ1phC float32            `sunspec:"offset=96,len=2"`
-	TotVArhImpQ2    float32            `sunspec:"offset=98,len=2"`
-	TotVArhImpQ2phA float32            `sunspec:"offset=100,len=2"`
-	TotVArhImpQ2phB float32            `sunspec:"offset=102,len=2"`
-	TotVArhImpQ2phC float32            `sunspec:"offset=104,len=2"`
-	TotVArhExpQ3    float32            `sunspec:"offset=106,len=2"`
-	TotVArhExpQ3phA float32            `sunspec:"offset=108,len=2"`
-	TotVArhExpQ3phB float32            `sunspec:"offset=110,len=2"`
-	TotVArhExpQ3phC float32            `sunspec:"offset=112,len=2"`
-	TotVArhExpQ4    float32            `sunspec:"offset=114,len=2"`
-	TotVArhExpQ4phA float32            `sunspec:"offset=116,len=2"`
-	TotVArhExpQ4phB float32            `sunspec:"offset=118,len=2"`
-	TotVArhExpQ4phC float32            `sunspec:"offset=120,len=2"`
-	Evt             sunspec.Bitfield32 `sunspec:"offset=122,len=2"`
+	A               float32            `sunspec:"offset=0"`
+	AphA            float32            `sunspec:"offset=2"`
+	AphB            float32            `sunspec:"offset=4"`
+	AphC            float32            `sunspec:"offset=6"`
+	PhV             float32            `sunspec:"offset=8"`
+	PhVphA          float32            `sunspec:"offset=10"`
+	PhVphB          float32            `sunspec:"offset=12"`
+	PhVphC          float32            `sunspec:"offset=14"`
+	PPV             float32            `sunspec:"offset=16"`
+	PPVphAB         float32            `sunspec:"offset=18"`
+	PPVphBC         float32            `sunspec:"offset=20"`
+	PPVphCA         float32            `sunspec:"offset=22"`
+	Hz              float32            `sunspec:"offset=24"`
+	W               float32            `sunspec:"offset=26"`
+	WphA            float32            `sunspec:"offset=28"`
+	WphB            float32            `sunspec:"offset=30"`
+	WphC            float32            `sunspec:"offset=32"`
+	VA              float32            `sunspec:"offset=34"`
+	VAphA           float32            `sunspec:"offset=36"`
+	VAphB           float32            `sunspec:"offset=38"`
+	VAphC           float32            `sunspec:"offset=40"`
+	VAR             float32            `sunspec:"offset=42"`
+	VARphA          float32            `sunspec:"offset=44"`
+	VARphB          float32            `sunspec:"offset=46"`
+	VARphC          float32            `sunspec:"offset=48"`
+	PF              float32            `sunspec:"offset=50"`
+	PFphA           float32            `sunspec:"offset=52"`
+	PFphB           float32            `sunspec:"offset=54"`
+	PFphC           float32            `sunspec:"offset=56"`
+	TotWhExp        float32            `sunspec:"offset=58"`
+	TotWhExpPhA     float32            `sunspec:"offset=60"`
+	TotWhExpPhB     float32            `sunspec:"offset=62"`
+	TotWhExpPhC     float32            `sunspec:"offset=64"`
+	TotWhImp        float32            `sunspec:"offset=66"`
+	TotWhImpPhA     float32            `sunspec:"offset=68"`
+	TotWhImpPhB     float32            `sunspec:"offset=70"`
+	TotWhImpPhC     float32            `sunspec:"offset=72"`
+	TotVAhExp       float32            `sunspec:"offset=74"`
+	TotVAhExpPhA    float32            `sunspec:"offset=76"`
+	TotVAhExpPhB    float32            `sunspec:"offset=78"`
+	TotVAhExpPhC    float32            `sunspec:"offset=80"`
+	TotVAhImp       float32            `sunspec:"offset=82"`
+	TotVAhImpPhA    float32            `sunspec:"offset=84"`
+	TotVAhImpPhB    float32            `sunspec:"offset=86"`
+	TotVAhImpPhC    float32            `sunspec:"offset=88"`
+	TotVArhImpQ1    float32            `sunspec:"offset=90"`
+	TotVArhImpQ1phA float32            `sunspec:"offset=92"`
+	TotVArhImpQ1phB float32            `sunspec:"offset=94"`
+	TotVArhImpQ1phC float32            `sunspec:"offset=96"`
+	TotVArhImpQ2    float32            `sunspec:"offset=98"`
+	TotVArhImpQ2phA float32            `sunspec:"offset=100"`
+	TotVArhImpQ2phB float32            `sunspec:"offset=102"`
+	TotVArhImpQ2phC float32            `sunspec:"offset=104"`
+	TotVArhExpQ3    float32            `sunspec:"offset=106"`
+	TotVArhExpQ3phA float32            `sunspec:"offset=108"`
+	TotVArhExpQ3phB float32            `sunspec:"offset=110"`
+	TotVArhExpQ3phC float32            `sunspec:"offset=112"`
+	TotVArhExpQ4    float32            `sunspec:"offset=114"`
+	TotVArhExpQ4phA float32            `sunspec:"offset=116"`
+	TotVArhExpQ4phB float32            `sunspec:"offset=118"`
+	TotVArhExpQ4phC float32            `sunspec:"offset=120"`
+	Evt             sunspec.Bitfield32 `sunspec:"offset=122"`
 }
 
 func (block *Block214) GetId() sunspec.ModelId {
@@ -163,68 +163,68 @@ func init() {
 				Length: 124,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
-					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
-					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Length: 2, Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
-					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
-					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
-					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
-					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
-					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
-					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
-					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
-					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Length: 2, Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
-					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Length: 2, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Length: 2, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase A", Description: ""},
-					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase B", Description: ""},
-					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Watts phase C", Description: ""},
-					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase A", Description: ""},
-					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase B", Description: ""},
-					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Length: 2, Label: "VA phase C", Description: ""},
-					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR", Description: "Reactive Power"},
-					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase A", Description: ""},
-					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase B", Description: ""},
-					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Length: 2, Label: "VAR phase C", Description: ""},
-					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF", Description: "Power Factor"},
-					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase A", Description: ""},
-					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase B", Description: ""},
-					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Length: 2, Label: "PF phase C", Description: ""},
-					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase A", Description: ""},
-					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase B", Description: ""},
-					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Exported phase C", Description: ""},
-					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase A", Description: ""},
-					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase B", Description: ""},
-					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Total Watt-hours Imported phase C", Description: ""},
-					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase A", Description: ""},
-					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase B", Description: ""},
-					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Exported phase C", Description: ""},
-					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase A", Description: ""},
-					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase B", Description: ""},
-					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Length: 2, Label: "Total VA-hours Imported phase C", Description: ""},
-					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
-					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
-					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
-					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
-					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
-					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
-					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
-					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
-					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
-					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
-					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
-					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
-					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: A, Offset: 0, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: AphA, Offset: 2, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseA", Description: "Phase A Current"},
+					{Id: AphB, Offset: 4, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseB", Description: "Phase B Current"},
+					{Id: AphC, Offset: 6, Type: typelabel.Float32, Units: "A", Mandatory: true, Label: "Amps PhaseC", Description: "Phase C Current"},
+					{Id: PhV, Offset: 8, Type: typelabel.Float32, Units: "V", Label: "Voltage LN", Description: "Line to Neutral AC Voltage (average of active phases)"},
+					{Id: PhVphA, Offset: 10, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage AN", Description: "Phase Voltage AN"},
+					{Id: PhVphB, Offset: 12, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage BN", Description: "Phase Voltage BN"},
+					{Id: PhVphC, Offset: 14, Type: typelabel.Float32, Units: "V", Label: "Phase Voltage CN", Description: "Phase Voltage CN"},
+					{Id: PPV, Offset: 16, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Voltage LL", Description: "Line to Line AC Voltage (average of active phases)"},
+					{Id: PPVphAB, Offset: 18, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage AB", Description: "Phase Voltage AB"},
+					{Id: PPVphBC, Offset: 20, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage BC", Description: "Phase Voltage BC"},
+					{Id: PPVphCA, Offset: 22, Type: typelabel.Float32, Units: "V", Mandatory: true, Label: "Phase Voltage CA", Description: "Phase Voltage CA"},
+					{Id: Hz, Offset: 24, Type: typelabel.Float32, Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: W, Offset: 26, Type: typelabel.Float32, Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: WphA, Offset: 28, Type: typelabel.Float32, Units: "W", Label: "Watts phase A", Description: ""},
+					{Id: WphB, Offset: 30, Type: typelabel.Float32, Units: "W", Label: "Watts phase B", Description: ""},
+					{Id: WphC, Offset: 32, Type: typelabel.Float32, Units: "W", Label: "Watts phase C", Description: ""},
+					{Id: VA, Offset: 34, Type: typelabel.Float32, Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VAphA, Offset: 36, Type: typelabel.Float32, Units: "VA", Label: "VA phase A", Description: ""},
+					{Id: VAphB, Offset: 38, Type: typelabel.Float32, Units: "VA", Label: "VA phase B", Description: ""},
+					{Id: VAphC, Offset: 40, Type: typelabel.Float32, Units: "VA", Label: "VA phase C", Description: ""},
+					{Id: VAR, Offset: 42, Type: typelabel.Float32, Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VARphA, Offset: 44, Type: typelabel.Float32, Units: "var", Label: "VAR phase A", Description: ""},
+					{Id: VARphB, Offset: 46, Type: typelabel.Float32, Units: "var", Label: "VAR phase B", Description: ""},
+					{Id: VARphC, Offset: 48, Type: typelabel.Float32, Units: "var", Label: "VAR phase C", Description: ""},
+					{Id: PF, Offset: 50, Type: typelabel.Float32, Units: "PF", Label: "PF", Description: "Power Factor"},
+					{Id: PFphA, Offset: 52, Type: typelabel.Float32, Units: "PF", Label: "PF phase A", Description: ""},
+					{Id: PFphB, Offset: 54, Type: typelabel.Float32, Units: "PF", Label: "PF phase B", Description: ""},
+					{Id: PFphC, Offset: 56, Type: typelabel.Float32, Units: "PF", Label: "PF phase C", Description: ""},
+					{Id: TotWhExp, Offset: 58, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhExpPhA, Offset: 60, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase A", Description: ""},
+					{Id: TotWhExpPhB, Offset: 62, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase B", Description: ""},
+					{Id: TotWhExpPhC, Offset: 64, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Exported phase C", Description: ""},
+					{Id: TotWhImp, Offset: 66, Type: typelabel.Float32, Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWhImpPhA, Offset: 68, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase A", Description: ""},
+					{Id: TotWhImpPhB, Offset: 70, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase B", Description: ""},
+					{Id: TotWhImpPhC, Offset: 72, Type: typelabel.Float32, Units: "Wh", Label: "Total Watt-hours Imported phase C", Description: ""},
+					{Id: TotVAhExp, Offset: 74, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhExpPhA, Offset: 76, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase A", Description: ""},
+					{Id: TotVAhExpPhB, Offset: 78, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase B", Description: ""},
+					{Id: TotVAhExpPhC, Offset: 80, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Exported phase C", Description: ""},
+					{Id: TotVAhImp, Offset: 82, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAhImpPhA, Offset: 84, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase A", Description: ""},
+					{Id: TotVAhImpPhB, Offset: 86, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase B", Description: ""},
+					{Id: TotVAhImpPhC, Offset: 88, Type: typelabel.Float32, Units: "VAh", Label: "Total VA-hours Imported phase C", Description: ""},
+					{Id: TotVArhImpQ1, Offset: 90, Type: typelabel.Float32, Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ1phA, Offset: 92, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase A", Description: ""},
+					{Id: TotVArhImpQ1phB, Offset: 94, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase B", Description: ""},
+					{Id: TotVArhImpQ1phC, Offset: 96, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q1 phase C", Description: ""},
+					{Id: TotVArhImpQ2, Offset: 98, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhImpQ2phA, Offset: 100, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase A", Description: ""},
+					{Id: TotVArhImpQ2phB, Offset: 102, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase B", Description: ""},
+					{Id: TotVArhImpQ2phC, Offset: 104, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Imported Q2 phase C", Description: ""},
+					{Id: TotVArhExpQ3, Offset: 106, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ3phA, Offset: 108, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase A", Description: ""},
+					{Id: TotVArhExpQ3phB, Offset: 110, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase B", Description: ""},
+					{Id: TotVArhExpQ3phC, Offset: 112, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q3 phase C", Description: ""},
+					{Id: TotVArhExpQ4, Offset: 114, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArhExpQ4phA, Offset: 116, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase A", Description: ""},
+					{Id: TotVArhExpQ4phB, Offset: 118, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase B", Description: ""},
+					{Id: TotVArhExpQ4phC, Offset: 120, Type: typelabel.Float32, Units: "varh", Label: "Total VAr-hours Exported Q4 Imported phase C", Description: ""},
+					{Id: Evt, Offset: 122, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
 				},
 			},
 		}})

--- a/models/model220/model.go
+++ b/models/model220/model.go
@@ -54,42 +54,42 @@ const (
 )
 
 type Block220Repeat struct {
-	DS uint16 `sunspec:"offset=0,len=1"`
+	DS uint16 `sunspec:"offset=0"`
 }
 
 type Block220 struct {
-	A            int16               `sunspec:"offset=0,len=1,sf=A_SF"`
-	A_SF         sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	PhV          int16               `sunspec:"offset=2,len=1,sf=V_SF"`
-	V_SF         sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	Hz           int16               `sunspec:"offset=4,len=1,sf=Hz_SF"`
-	Hz_SF        sunspec.ScaleFactor `sunspec:"offset=5,len=1"`
-	W            int16               `sunspec:"offset=6,len=1,sf=W_SF"`
-	W_SF         sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	VA           int16               `sunspec:"offset=8,len=1,sf=VA_SF"`
-	VA_SF        sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
-	VAR          int16               `sunspec:"offset=10,len=1,sf=VAR_SF"`
-	VAR_SF       sunspec.ScaleFactor `sunspec:"offset=11,len=1"`
-	PF           int16               `sunspec:"offset=12,len=1,sf=PF_SF"`
-	PF_SF        sunspec.ScaleFactor `sunspec:"offset=13,len=1"`
-	TotWhExp     sunspec.Acc32       `sunspec:"offset=14,len=2,sf=TotWh_SF"`
-	TotWhImp     sunspec.Acc32       `sunspec:"offset=16,len=2,sf=TotWh_SF"`
-	TotWh_SF     sunspec.ScaleFactor `sunspec:"offset=18,len=1"`
-	TotVAhExp    sunspec.Acc32       `sunspec:"offset=19,len=2,sf=TotVAh_SF"`
-	TotVAhImp    sunspec.Acc32       `sunspec:"offset=21,len=2,sf=TotVAh_SF"`
-	TotVAh_SF    sunspec.ScaleFactor `sunspec:"offset=23,len=1"`
-	TotVArhImpQ1 sunspec.Acc32       `sunspec:"offset=24,len=2,sf=TotVArh_SF"`
-	TotVArhImpQ2 sunspec.Acc32       `sunspec:"offset=26,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ3 sunspec.Acc32       `sunspec:"offset=28,len=2,sf=TotVArh_SF"`
-	TotVArhExpQ4 sunspec.Acc32       `sunspec:"offset=30,len=2,sf=TotVArh_SF"`
-	TotVArh_SF   sunspec.ScaleFactor `sunspec:"offset=32,len=1"`
-	Evt          sunspec.Bitfield32  `sunspec:"offset=33,len=2"`
-	Rsrvd        sunspec.Pad         `sunspec:"offset=35,len=1"`
-	Ts           uint32              `sunspec:"offset=36,len=2"`
-	Ms           uint16              `sunspec:"offset=38,len=1"`
-	Seq          uint16              `sunspec:"offset=39,len=1"`
-	Alg          sunspec.Enum16      `sunspec:"offset=40,len=1"`
-	N            uint16              `sunspec:"offset=41,len=1"`
+	A            int16               `sunspec:"offset=0,sf=A_SF"`
+	A_SF         sunspec.ScaleFactor `sunspec:"offset=1"`
+	PhV          int16               `sunspec:"offset=2,sf=V_SF"`
+	V_SF         sunspec.ScaleFactor `sunspec:"offset=3"`
+	Hz           int16               `sunspec:"offset=4,sf=Hz_SF"`
+	Hz_SF        sunspec.ScaleFactor `sunspec:"offset=5"`
+	W            int16               `sunspec:"offset=6,sf=W_SF"`
+	W_SF         sunspec.ScaleFactor `sunspec:"offset=7"`
+	VA           int16               `sunspec:"offset=8,sf=VA_SF"`
+	VA_SF        sunspec.ScaleFactor `sunspec:"offset=9"`
+	VAR          int16               `sunspec:"offset=10,sf=VAR_SF"`
+	VAR_SF       sunspec.ScaleFactor `sunspec:"offset=11"`
+	PF           int16               `sunspec:"offset=12,sf=PF_SF"`
+	PF_SF        sunspec.ScaleFactor `sunspec:"offset=13"`
+	TotWhExp     sunspec.Acc32       `sunspec:"offset=14,sf=TotWh_SF"`
+	TotWhImp     sunspec.Acc32       `sunspec:"offset=16,sf=TotWh_SF"`
+	TotWh_SF     sunspec.ScaleFactor `sunspec:"offset=18"`
+	TotVAhExp    sunspec.Acc32       `sunspec:"offset=19,sf=TotVAh_SF"`
+	TotVAhImp    sunspec.Acc32       `sunspec:"offset=21,sf=TotVAh_SF"`
+	TotVAh_SF    sunspec.ScaleFactor `sunspec:"offset=23"`
+	TotVArhImpQ1 sunspec.Acc32       `sunspec:"offset=24,sf=TotVArh_SF"`
+	TotVArhImpQ2 sunspec.Acc32       `sunspec:"offset=26,sf=TotVArh_SF"`
+	TotVArhExpQ3 sunspec.Acc32       `sunspec:"offset=28,sf=TotVArh_SF"`
+	TotVArhExpQ4 sunspec.Acc32       `sunspec:"offset=30,sf=TotVArh_SF"`
+	TotVArh_SF   sunspec.ScaleFactor `sunspec:"offset=32"`
+	Evt          sunspec.Bitfield32  `sunspec:"offset=33"`
+	Rsrvd        sunspec.Pad         `sunspec:"offset=35"`
+	Ts           uint32              `sunspec:"offset=36"`
+	Ms           uint16              `sunspec:"offset=38"`
+	Seq          uint16              `sunspec:"offset=39"`
+	Alg          sunspec.Enum16      `sunspec:"offset=40"`
+	N            uint16              `sunspec:"offset=41"`
 
 	Repeats []Block220Repeat
 }
@@ -110,45 +110,45 @@ func init() {
 				Length: 42,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total AC Current"},
-					{Id: A_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: PhV, Offset: 2, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Voltage", Description: "Average phase or line voltage"},
-					{Id: V_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Hz, Offset: 4, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Length: 1, Mandatory: true, Label: "Hz", Description: "Frequency"},
-					{Id: Hz_SF, Offset: 5, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: W, Offset: 6, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Watts", Description: "Total Real Power"},
-					{Id: W_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: VA, Offset: 8, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Length: 1, Label: "VA", Description: "AC Apparent Power"},
-					{Id: VA_SF, Offset: 9, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: VAR, Offset: 10, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Length: 1, Label: "VAR", Description: "Reactive Power"},
-					{Id: VAR_SF, Offset: 11, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: PF, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Length: 1, Label: "PF", Description: "Power Factor"},
-					{Id: PF_SF, Offset: 13, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotWhExp, Offset: 14, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
-					{Id: TotWhImp, Offset: 16, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
-					{Id: TotWh_SF, Offset: 18, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: TotVAhExp, Offset: 19, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
-					{Id: TotVAhImp, Offset: 21, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Length: 2, Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
-					{Id: TotVAh_SF, Offset: 23, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: TotVArhImpQ1, Offset: 24, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
-					{Id: TotVArhImpQ2, Offset: 26, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
-					{Id: TotVArhExpQ3, Offset: 28, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
-					{Id: TotVArhExpQ4, Offset: 30, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Length: 2, Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
-					{Id: TotVArh_SF, Offset: 32, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Evt, Offset: 33, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
-					{Id: Rsrvd, Offset: 35, Type: typelabel.Pad, Length: 1, Mandatory: true},
-					{Id: Ts, Offset: 36, Type: typelabel.Uint32, Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 38, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 39, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
-					{Id: Alg, Offset: 40, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 41, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
+					{Id: A, Offset: 0, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total AC Current"},
+					{Id: A_SF, Offset: 1, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: PhV, Offset: 2, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Voltage", Description: "Average phase or line voltage"},
+					{Id: V_SF, Offset: 3, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Hz, Offset: 4, Type: typelabel.Int16, ScaleFactor: "Hz_SF", Units: "Hz", Mandatory: true, Label: "Hz", Description: "Frequency"},
+					{Id: Hz_SF, Offset: 5, Type: typelabel.ScaleFactor},
+					{Id: W, Offset: 6, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Watts", Description: "Total Real Power"},
+					{Id: W_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: VA, Offset: 8, Type: typelabel.Int16, ScaleFactor: "VA_SF", Units: "VA", Label: "VA", Description: "AC Apparent Power"},
+					{Id: VA_SF, Offset: 9, Type: typelabel.ScaleFactor},
+					{Id: VAR, Offset: 10, Type: typelabel.Int16, ScaleFactor: "VAR_SF", Units: "var", Label: "VAR", Description: "Reactive Power"},
+					{Id: VAR_SF, Offset: 11, Type: typelabel.ScaleFactor},
+					{Id: PF, Offset: 12, Type: typelabel.Int16, ScaleFactor: "PF_SF", Units: "Pct", Label: "PF", Description: "Power Factor"},
+					{Id: PF_SF, Offset: 13, Type: typelabel.ScaleFactor},
+					{Id: TotWhExp, Offset: 14, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Exported", Description: "Total Real Energy Exported"},
+					{Id: TotWhImp, Offset: 16, Type: typelabel.Acc32, ScaleFactor: "TotWh_SF", Units: "Wh", Mandatory: true, Label: "Total Watt-hours Imported", Description: "Total Real Energy Imported"},
+					{Id: TotWh_SF, Offset: 18, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: TotVAhExp, Offset: 19, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Exported", Description: "Total Apparent Energy Exported"},
+					{Id: TotVAhImp, Offset: 21, Type: typelabel.Acc32, ScaleFactor: "TotVAh_SF", Units: "VAh", Label: "Total VA-hours Imported", Description: "Total Apparent Energy Imported"},
+					{Id: TotVAh_SF, Offset: 23, Type: typelabel.ScaleFactor},
+					{Id: TotVArhImpQ1, Offset: 24, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAR-hours Imported Q1", Description: "Total Reactive Energy Imported Quadrant 1"},
+					{Id: TotVArhImpQ2, Offset: 26, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Imported Q2", Description: "Total Reactive Power Imported Quadrant 2"},
+					{Id: TotVArhExpQ3, Offset: 28, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q3", Description: "Total Reactive Power Exported Quadrant 3"},
+					{Id: TotVArhExpQ4, Offset: 30, Type: typelabel.Acc32, ScaleFactor: "TotVArh_SF", Units: "varh", Label: "Total VAr-hours Exported Q4", Description: "Total Reactive Power Exported Quadrant 4"},
+					{Id: TotVArh_SF, Offset: 32, Type: typelabel.ScaleFactor},
+					{Id: Evt, Offset: 33, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Meter Event Flags"},
+					{Id: Rsrvd, Offset: 35, Type: typelabel.Pad, Mandatory: true},
+					{Id: Ts, Offset: 36, Type: typelabel.Uint32, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 38, Type: typelabel.Uint16, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 39, Type: typelabel.Uint16, Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
+					{Id: Alg, Offset: 40, Type: typelabel.Enum16, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 41, Type: typelabel.Uint16, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: DS, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true},
+					{Id: DS, Offset: 0, Type: typelabel.Uint16, Mandatory: true},
 				},
 			},
 		}})

--- a/models/model3/model.go
+++ b/models/model3/model.go
@@ -79,67 +79,67 @@ const (
 )
 
 type Block3Repeat struct {
-	DS uint16 `sunspec:"offset=0,len=1"`
+	DS uint16 `sunspec:"offset=0"`
 }
 
 type Block3 struct {
-	X     uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Off1  uint16         `sunspec:"offset=1,len=1,access=rw"`
-	Off2  uint16         `sunspec:"offset=2,len=1,access=rw"`
-	Off3  uint16         `sunspec:"offset=3,len=1,access=rw"`
-	Off4  uint16         `sunspec:"offset=4,len=1,access=rw"`
-	Off5  uint16         `sunspec:"offset=5,len=1,access=rw"`
-	Off6  uint16         `sunspec:"offset=6,len=1,access=rw"`
-	Off7  uint16         `sunspec:"offset=7,len=1,access=rw"`
-	Off8  uint16         `sunspec:"offset=8,len=1,access=rw"`
-	Off9  uint16         `sunspec:"offset=9,len=1,access=rw"`
-	Off10 uint16         `sunspec:"offset=10,len=1,access=rw"`
-	Off11 uint16         `sunspec:"offset=11,len=1,access=rw"`
-	Off12 uint16         `sunspec:"offset=12,len=1,access=rw"`
-	Off13 uint16         `sunspec:"offset=13,len=1,access=rw"`
-	Off14 uint16         `sunspec:"offset=14,len=1,access=rw"`
-	Off15 uint16         `sunspec:"offset=15,len=1,access=rw"`
-	Off16 uint16         `sunspec:"offset=16,len=1,access=rw"`
-	Off17 uint16         `sunspec:"offset=17,len=1,access=rw"`
-	Off18 uint16         `sunspec:"offset=18,len=1,access=rw"`
-	Off19 uint16         `sunspec:"offset=19,len=1,access=rw"`
-	Off20 uint16         `sunspec:"offset=20,len=1,access=rw"`
-	Off21 uint16         `sunspec:"offset=21,len=1,access=rw"`
-	Off22 uint16         `sunspec:"offset=22,len=1,access=rw"`
-	Off23 uint16         `sunspec:"offset=23,len=1,access=rw"`
-	Off24 uint16         `sunspec:"offset=24,len=1,access=rw"`
-	Off25 uint16         `sunspec:"offset=25,len=1,access=rw"`
-	Off26 uint16         `sunspec:"offset=26,len=1,access=rw"`
-	Off27 uint16         `sunspec:"offset=27,len=1,access=rw"`
-	Off28 uint16         `sunspec:"offset=28,len=1,access=rw"`
-	Off29 uint16         `sunspec:"offset=29,len=1,access=rw"`
-	Off30 uint16         `sunspec:"offset=30,len=1,access=rw"`
-	Off31 uint16         `sunspec:"offset=31,len=1,access=rw"`
-	Off32 uint16         `sunspec:"offset=32,len=1,access=rw"`
-	Off33 uint16         `sunspec:"offset=33,len=1,access=rw"`
-	Off34 uint16         `sunspec:"offset=34,len=1,access=rw"`
-	Off35 uint16         `sunspec:"offset=35,len=1,access=rw"`
-	Off36 uint16         `sunspec:"offset=36,len=1,access=rw"`
-	Off37 uint16         `sunspec:"offset=37,len=1,access=rw"`
-	Off38 uint16         `sunspec:"offset=38,len=1,access=rw"`
-	Off39 uint16         `sunspec:"offset=39,len=1,access=rw"`
-	Off40 uint16         `sunspec:"offset=40,len=1,access=rw"`
-	Off41 uint16         `sunspec:"offset=41,len=1,access=rw"`
-	Off42 uint16         `sunspec:"offset=42,len=1,access=rw"`
-	Off43 uint16         `sunspec:"offset=43,len=1,access=rw"`
-	Off44 uint16         `sunspec:"offset=44,len=1,access=rw"`
-	Off45 uint16         `sunspec:"offset=45,len=1,access=rw"`
-	Off46 uint16         `sunspec:"offset=46,len=1,access=rw"`
-	Off47 uint16         `sunspec:"offset=47,len=1,access=rw"`
-	Off48 uint16         `sunspec:"offset=48,len=1,access=rw"`
-	Off49 uint16         `sunspec:"offset=49,len=1,access=rw"`
-	Off50 uint16         `sunspec:"offset=50,len=1,access=rw"`
-	Ts    uint32         `sunspec:"offset=51,len=2,access=rw"`
-	Ms    uint16         `sunspec:"offset=53,len=1,access=rw"`
-	Seq   uint16         `sunspec:"offset=54,len=1,access=rw"`
-	Role  uint16         `sunspec:"offset=55,len=1,access=rw"`
-	Alg   sunspec.Enum16 `sunspec:"offset=56,len=1"`
-	N     uint16         `sunspec:"offset=57,len=1"`
+	X     uint16         `sunspec:"offset=0,access=rw"`
+	Off1  uint16         `sunspec:"offset=1,access=rw"`
+	Off2  uint16         `sunspec:"offset=2,access=rw"`
+	Off3  uint16         `sunspec:"offset=3,access=rw"`
+	Off4  uint16         `sunspec:"offset=4,access=rw"`
+	Off5  uint16         `sunspec:"offset=5,access=rw"`
+	Off6  uint16         `sunspec:"offset=6,access=rw"`
+	Off7  uint16         `sunspec:"offset=7,access=rw"`
+	Off8  uint16         `sunspec:"offset=8,access=rw"`
+	Off9  uint16         `sunspec:"offset=9,access=rw"`
+	Off10 uint16         `sunspec:"offset=10,access=rw"`
+	Off11 uint16         `sunspec:"offset=11,access=rw"`
+	Off12 uint16         `sunspec:"offset=12,access=rw"`
+	Off13 uint16         `sunspec:"offset=13,access=rw"`
+	Off14 uint16         `sunspec:"offset=14,access=rw"`
+	Off15 uint16         `sunspec:"offset=15,access=rw"`
+	Off16 uint16         `sunspec:"offset=16,access=rw"`
+	Off17 uint16         `sunspec:"offset=17,access=rw"`
+	Off18 uint16         `sunspec:"offset=18,access=rw"`
+	Off19 uint16         `sunspec:"offset=19,access=rw"`
+	Off20 uint16         `sunspec:"offset=20,access=rw"`
+	Off21 uint16         `sunspec:"offset=21,access=rw"`
+	Off22 uint16         `sunspec:"offset=22,access=rw"`
+	Off23 uint16         `sunspec:"offset=23,access=rw"`
+	Off24 uint16         `sunspec:"offset=24,access=rw"`
+	Off25 uint16         `sunspec:"offset=25,access=rw"`
+	Off26 uint16         `sunspec:"offset=26,access=rw"`
+	Off27 uint16         `sunspec:"offset=27,access=rw"`
+	Off28 uint16         `sunspec:"offset=28,access=rw"`
+	Off29 uint16         `sunspec:"offset=29,access=rw"`
+	Off30 uint16         `sunspec:"offset=30,access=rw"`
+	Off31 uint16         `sunspec:"offset=31,access=rw"`
+	Off32 uint16         `sunspec:"offset=32,access=rw"`
+	Off33 uint16         `sunspec:"offset=33,access=rw"`
+	Off34 uint16         `sunspec:"offset=34,access=rw"`
+	Off35 uint16         `sunspec:"offset=35,access=rw"`
+	Off36 uint16         `sunspec:"offset=36,access=rw"`
+	Off37 uint16         `sunspec:"offset=37,access=rw"`
+	Off38 uint16         `sunspec:"offset=38,access=rw"`
+	Off39 uint16         `sunspec:"offset=39,access=rw"`
+	Off40 uint16         `sunspec:"offset=40,access=rw"`
+	Off41 uint16         `sunspec:"offset=41,access=rw"`
+	Off42 uint16         `sunspec:"offset=42,access=rw"`
+	Off43 uint16         `sunspec:"offset=43,access=rw"`
+	Off44 uint16         `sunspec:"offset=44,access=rw"`
+	Off45 uint16         `sunspec:"offset=45,access=rw"`
+	Off46 uint16         `sunspec:"offset=46,access=rw"`
+	Off47 uint16         `sunspec:"offset=47,access=rw"`
+	Off48 uint16         `sunspec:"offset=48,access=rw"`
+	Off49 uint16         `sunspec:"offset=49,access=rw"`
+	Off50 uint16         `sunspec:"offset=50,access=rw"`
+	Ts    uint32         `sunspec:"offset=51,access=rw"`
+	Ms    uint16         `sunspec:"offset=53,access=rw"`
+	Seq   uint16         `sunspec:"offset=54,access=rw"`
+	Role  uint16         `sunspec:"offset=55,access=rw"`
+	Alg   sunspec.Enum16 `sunspec:"offset=56"`
+	N     uint16         `sunspec:"offset=57"`
 
 	Repeats []Block3Repeat
 }
@@ -160,70 +160,70 @@ func init() {
 				Length: 58,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: X, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "X", Description: "Number of registers being requested"},
-					{Id: Off1, Offset: 1, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Offset1", Description: "Offset of value to read"},
-					{Id: Off2, Offset: 2, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off3, Offset: 3, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off4, Offset: 4, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off5, Offset: 5, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off6, Offset: 6, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off7, Offset: 7, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off8, Offset: 8, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off9, Offset: 9, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off10, Offset: 10, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off11, Offset: 11, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off12, Offset: 12, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off13, Offset: 13, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off14, Offset: 14, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off15, Offset: 15, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off16, Offset: 16, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off17, Offset: 17, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off18, Offset: 18, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off19, Offset: 19, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off20, Offset: 20, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off21, Offset: 21, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off22, Offset: 22, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off23, Offset: 23, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off24, Offset: 24, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off25, Offset: 25, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off26, Offset: 26, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off27, Offset: 27, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off28, Offset: 28, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off29, Offset: 29, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off30, Offset: 30, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off31, Offset: 31, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off32, Offset: 32, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off33, Offset: 33, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off34, Offset: 34, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off35, Offset: 35, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off36, Offset: 36, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off37, Offset: 37, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off38, Offset: 38, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off39, Offset: 39, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off40, Offset: 40, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off41, Offset: 41, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off42, Offset: 42, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off43, Offset: 43, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off44, Offset: 44, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off45, Offset: 45, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off46, Offset: 46, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off47, Offset: 47, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off48, Offset: 48, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off49, Offset: 49, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off50, Offset: 50, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Ts, Offset: 51, Type: typelabel.Uint32, Access: "rw", Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 53, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 54, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
-					{Id: Role, Offset: 55, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Role", Description: "Digital Signature ID"},
-					{Id: Alg, Offset: 56, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 57, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
+					{Id: X, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "X", Description: "Number of registers being requested"},
+					{Id: Off1, Offset: 1, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Offset1", Description: "Offset of value to read"},
+					{Id: Off2, Offset: 2, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off3, Offset: 3, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off4, Offset: 4, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off5, Offset: 5, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off6, Offset: 6, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off7, Offset: 7, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off8, Offset: 8, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off9, Offset: 9, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off10, Offset: 10, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off11, Offset: 11, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off12, Offset: 12, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off13, Offset: 13, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off14, Offset: 14, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off15, Offset: 15, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off16, Offset: 16, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off17, Offset: 17, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off18, Offset: 18, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off19, Offset: 19, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off20, Offset: 20, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off21, Offset: 21, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off22, Offset: 22, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off23, Offset: 23, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off24, Offset: 24, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off25, Offset: 25, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off26, Offset: 26, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off27, Offset: 27, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off28, Offset: 28, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off29, Offset: 29, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off30, Offset: 30, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off31, Offset: 31, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off32, Offset: 32, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off33, Offset: 33, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off34, Offset: 34, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off35, Offset: 35, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off36, Offset: 36, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off37, Offset: 37, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off38, Offset: 38, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off39, Offset: 39, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off40, Offset: 40, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off41, Offset: 41, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off42, Offset: 42, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off43, Offset: 43, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off44, Offset: 44, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off45, Offset: 45, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off46, Offset: 46, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off47, Offset: 47, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off48, Offset: 48, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off49, Offset: 49, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off50, Offset: 50, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Ts, Offset: 51, Type: typelabel.Uint32, Access: "rw", Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 53, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 54, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
+					{Id: Role, Offset: 55, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Role", Description: "Digital Signature ID"},
+					{Id: Alg, Offset: 56, Type: typelabel.Enum16, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 57, Type: typelabel.Uint16, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: DS, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "DS", Description: "Digital Signature"},
+					{Id: DS, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "DS", Description: "Digital Signature"},
 				},
 			},
 		}})

--- a/models/model302/model.go
+++ b/models/model302/model.go
@@ -26,11 +26,11 @@ const (
 )
 
 type Block302Repeat struct {
-	GHI  uint16 `sunspec:"offset=0,len=1"`
-	POAI uint16 `sunspec:"offset=1,len=1"`
-	DFI  uint16 `sunspec:"offset=2,len=1"`
-	DNI  uint16 `sunspec:"offset=3,len=1"`
-	OTI  uint16 `sunspec:"offset=4,len=1"`
+	GHI  uint16 `sunspec:"offset=0"`
+	POAI uint16 `sunspec:"offset=1"`
+	DFI  uint16 `sunspec:"offset=2"`
+	DNI  uint16 `sunspec:"offset=3"`
+	OTI  uint16 `sunspec:"offset=4"`
 }
 
 type Block302 struct {
@@ -53,11 +53,11 @@ func init() {
 				Length: 5,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: GHI, Offset: 0, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "GHI", Description: "Global Horizontal Irradiance"},
-					{Id: POAI, Offset: 1, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "POAI", Description: "Plane-of-Array Irradiance"},
-					{Id: DFI, Offset: 2, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "DFI", Description: "Diffuse Irradiance"},
-					{Id: DNI, Offset: 3, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "DNI", Description: "Direct Normal Irradiance"},
-					{Id: OTI, Offset: 4, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "OTI", Description: "Other Irradiance"},
+					{Id: GHI, Offset: 0, Type: typelabel.Uint16, Units: "W/m2", Label: "GHI", Description: "Global Horizontal Irradiance"},
+					{Id: POAI, Offset: 1, Type: typelabel.Uint16, Units: "W/m2", Label: "POAI", Description: "Plane-of-Array Irradiance"},
+					{Id: DFI, Offset: 2, Type: typelabel.Uint16, Units: "W/m2", Label: "DFI", Description: "Diffuse Irradiance"},
+					{Id: DNI, Offset: 3, Type: typelabel.Uint16, Units: "W/m2", Label: "DNI", Description: "Direct Normal Irradiance"},
+					{Id: OTI, Offset: 4, Type: typelabel.Uint16, Units: "W/m2", Label: "OTI", Description: "Other Irradiance"},
 				},
 			},
 		}})

--- a/models/model303/model.go
+++ b/models/model303/model.go
@@ -22,7 +22,7 @@ const (
 )
 
 type Block303Repeat struct {
-	TmpBOM int16 `sunspec:"offset=0,len=1,sf=-1"`
+	TmpBOM int16 `sunspec:"offset=0,sf=-1"`
 }
 
 type Block303 struct {
@@ -45,7 +45,7 @@ func init() {
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: TmpBOM, Offset: 0, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Length: 1, Mandatory: true, Label: "Temp", Description: "Back of module temperature measurement"},
+					{Id: TmpBOM, Offset: 0, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Mandatory: true, Label: "Temp", Description: "Back of module temperature measurement"},
 				},
 			},
 		}})

--- a/models/model304/model.go
+++ b/models/model304/model.go
@@ -24,9 +24,9 @@ const (
 )
 
 type Block304Repeat struct {
-	Inclx int32 `sunspec:"offset=0,len=2,sf=-2"`
-	Incly int32 `sunspec:"offset=2,len=2,sf=-2"`
-	Inclz int32 `sunspec:"offset=4,len=2,sf=-2"`
+	Inclx int32 `sunspec:"offset=0,sf=-2"`
+	Incly int32 `sunspec:"offset=2,sf=-2"`
+	Inclz int32 `sunspec:"offset=4,sf=-2"`
 }
 
 type Block304 struct {
@@ -49,9 +49,9 @@ func init() {
 				Length: 6,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: Inclx, Offset: 0, Type: typelabel.Int32, ScaleFactor: "-2", Units: "Degrees", Length: 2, Mandatory: true, Label: "X", Description: "X-Axis inclination"},
-					{Id: Incly, Offset: 2, Type: typelabel.Int32, ScaleFactor: "-2", Units: "Degrees", Length: 2, Label: "Y", Description: "Y-Axis inclination"},
-					{Id: Inclz, Offset: 4, Type: typelabel.Int32, ScaleFactor: "-2", Units: "Degrees", Length: 2, Label: "Z", Description: "Z-Axis inclination"},
+					{Id: Inclx, Offset: 0, Type: typelabel.Int32, ScaleFactor: "-2", Units: "Degrees", Mandatory: true, Label: "X", Description: "X-Axis inclination"},
+					{Id: Incly, Offset: 2, Type: typelabel.Int32, ScaleFactor: "-2", Units: "Degrees", Label: "Y", Description: "Y-Axis inclination"},
+					{Id: Inclz, Offset: 4, Type: typelabel.Int32, ScaleFactor: "-2", Units: "Degrees", Label: "Z", Description: "Z-Axis inclination"},
 				},
 			},
 		}})

--- a/models/model305/model.go
+++ b/models/model305/model.go
@@ -30,9 +30,9 @@ type Block305 struct {
 	Tm   string `sunspec:"offset=0,len=6"`
 	Date string `sunspec:"offset=6,len=4"`
 	Loc  string `sunspec:"offset=10,len=20"`
-	Lat  int32  `sunspec:"offset=30,len=2,sf=-7"`
-	Long int32  `sunspec:"offset=32,len=2,sf=-7"`
-	Alt  int32  `sunspec:"offset=34,len=2"`
+	Lat  int32  `sunspec:"offset=30,sf=-7"`
+	Long int32  `sunspec:"offset=32,sf=-7"`
+	Alt  int32  `sunspec:"offset=34"`
 }
 
 func (block *Block305) GetId() sunspec.ModelId {
@@ -54,9 +54,9 @@ func init() {
 					{Id: Tm, Offset: 0, Type: typelabel.String, Units: "hhmmss.sssZ", Length: 6, Label: "Tm", Description: "UTC 24 hour time stamp to millisecond hhmmss.sssZ format"},
 					{Id: Date, Offset: 6, Type: typelabel.String, Units: "YYYYMMDD", Length: 4, Label: "Date", Description: "UTC Date string YYYYMMDD format"},
 					{Id: Loc, Offset: 10, Type: typelabel.String, Units: "text", Length: 20, Label: "Location", Description: "Location string (40 chars max)"},
-					{Id: Lat, Offset: 30, Type: typelabel.Int32, ScaleFactor: "-7", Units: "Degrees", Length: 2, Label: "Lat", Description: "Latitude with seven degrees of precision"},
-					{Id: Long, Offset: 32, Type: typelabel.Int32, ScaleFactor: "-7", Units: "Degrees", Length: 2, Label: "Long", Description: "Longitude with seven degrees of precision"},
-					{Id: Alt, Offset: 34, Type: typelabel.Int32, Units: "meters", Length: 2, Label: "Altitude", Description: "Altitude measurement in meters"},
+					{Id: Lat, Offset: 30, Type: typelabel.Int32, ScaleFactor: "-7", Units: "Degrees", Label: "Lat", Description: "Latitude with seven degrees of precision"},
+					{Id: Long, Offset: 32, Type: typelabel.Int32, ScaleFactor: "-7", Units: "Degrees", Label: "Long", Description: "Longitude with seven degrees of precision"},
+					{Id: Alt, Offset: 34, Type: typelabel.Int32, Units: "meters", Label: "Altitude", Description: "Altitude measurement in meters"},
 				},
 			},
 		}})

--- a/models/model306/model.go
+++ b/models/model306/model.go
@@ -25,10 +25,10 @@ const (
 )
 
 type Block306 struct {
-	GHI uint16 `sunspec:"offset=0,len=1"`
-	A   uint16 `sunspec:"offset=1,len=1"`
-	V   uint16 `sunspec:"offset=2,len=1"`
-	Tmp uint16 `sunspec:"offset=3,len=1"`
+	GHI uint16 `sunspec:"offset=0"`
+	A   uint16 `sunspec:"offset=1"`
+	V   uint16 `sunspec:"offset=2"`
+	Tmp uint16 `sunspec:"offset=3"`
 }
 
 func (block *Block306) GetId() sunspec.ModelId {
@@ -47,10 +47,10 @@ func init() {
 				Length: 4,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: GHI, Offset: 0, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "GHI", Description: "Global Horizontal Irradiance"},
-					{Id: A, Offset: 1, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "Amps", Description: "Current measurement at reference point"},
-					{Id: V, Offset: 2, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "Voltage", Description: "Voltage  measurement at reference point"},
-					{Id: Tmp, Offset: 3, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "Temperature", Description: "Temperature measurement at reference point"},
+					{Id: GHI, Offset: 0, Type: typelabel.Uint16, Units: "W/m2", Label: "GHI", Description: "Global Horizontal Irradiance"},
+					{Id: A, Offset: 1, Type: typelabel.Uint16, Units: "W/m2", Label: "Amps", Description: "Current measurement at reference point"},
+					{Id: V, Offset: 2, Type: typelabel.Uint16, Units: "W/m2", Label: "Voltage", Description: "Voltage  measurement at reference point"},
+					{Id: Tmp, Offset: 3, Type: typelabel.Uint16, Units: "W/m2", Label: "Temperature", Description: "Temperature measurement at reference point"},
 				},
 			},
 		}})

--- a/models/model307/model.go
+++ b/models/model307/model.go
@@ -32,17 +32,17 @@ const (
 )
 
 type Block307 struct {
-	TmpAmb  int16 `sunspec:"offset=0,len=1,sf=-1"`
-	RH      int16 `sunspec:"offset=1,len=1"`
-	Pres    int16 `sunspec:"offset=2,len=1"`
-	WndSpd  int16 `sunspec:"offset=3,len=1"`
-	WndDir  int16 `sunspec:"offset=4,len=1"`
-	Rain    int16 `sunspec:"offset=5,len=1"`
-	Snw     int16 `sunspec:"offset=6,len=1"`
-	PPT     int16 `sunspec:"offset=7,len=1"`
-	ElecFld int16 `sunspec:"offset=8,len=1"`
-	SurWet  int16 `sunspec:"offset=9,len=1"`
-	SoilWet int16 `sunspec:"offset=10,len=1"`
+	TmpAmb  int16 `sunspec:"offset=0,sf=-1"`
+	RH      int16 `sunspec:"offset=1"`
+	Pres    int16 `sunspec:"offset=2"`
+	WndSpd  int16 `sunspec:"offset=3"`
+	WndDir  int16 `sunspec:"offset=4"`
+	Rain    int16 `sunspec:"offset=5"`
+	Snw     int16 `sunspec:"offset=6"`
+	PPT     int16 `sunspec:"offset=7"`
+	ElecFld int16 `sunspec:"offset=8"`
+	SurWet  int16 `sunspec:"offset=9"`
+	SoilWet int16 `sunspec:"offset=10"`
 }
 
 func (block *Block307) GetId() sunspec.ModelId {
@@ -61,17 +61,17 @@ func init() {
 				Length: 11,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: TmpAmb, Offset: 0, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Length: 1, Label: "Ambient Temperature", Description: ""},
-					{Id: RH, Offset: 1, Type: typelabel.Int16, Units: "Pct", Length: 1, Label: "Relative Humidity", Description: ""},
-					{Id: Pres, Offset: 2, Type: typelabel.Int16, Units: "HPa", Length: 1, Label: "Barometric Pressure", Description: ""},
-					{Id: WndSpd, Offset: 3, Type: typelabel.Int16, Units: "mps", Length: 1, Label: "Wind Speed", Description: ""},
-					{Id: WndDir, Offset: 4, Type: typelabel.Int16, Units: "deg", Length: 1, Label: "Wind Direction", Description: ""},
-					{Id: Rain, Offset: 5, Type: typelabel.Int16, Units: "mm", Length: 1, Label: "Rainfall", Description: ""},
-					{Id: Snw, Offset: 6, Type: typelabel.Int16, Units: "mm", Length: 1, Label: "Snow Depth", Description: ""},
-					{Id: PPT, Offset: 7, Type: typelabel.Int16, Length: 1, Label: "Precipitation Type", Description: " Precipitation Type (WMO 4680 SYNOP code reference)"},
-					{Id: ElecFld, Offset: 8, Type: typelabel.Int16, Units: "Vm", Length: 1, Label: "Electric Field", Description: ""},
-					{Id: SurWet, Offset: 9, Type: typelabel.Int16, Units: "kO", Length: 1, Label: "Surface Wetness", Description: ""},
-					{Id: SoilWet, Offset: 10, Type: typelabel.Int16, Units: "Pct", Length: 1, Label: "Soil Wetness", Description: ""},
+					{Id: TmpAmb, Offset: 0, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Label: "Ambient Temperature", Description: ""},
+					{Id: RH, Offset: 1, Type: typelabel.Int16, Units: "Pct", Label: "Relative Humidity", Description: ""},
+					{Id: Pres, Offset: 2, Type: typelabel.Int16, Units: "HPa", Label: "Barometric Pressure", Description: ""},
+					{Id: WndSpd, Offset: 3, Type: typelabel.Int16, Units: "mps", Label: "Wind Speed", Description: ""},
+					{Id: WndDir, Offset: 4, Type: typelabel.Int16, Units: "deg", Label: "Wind Direction", Description: ""},
+					{Id: Rain, Offset: 5, Type: typelabel.Int16, Units: "mm", Label: "Rainfall", Description: ""},
+					{Id: Snw, Offset: 6, Type: typelabel.Int16, Units: "mm", Label: "Snow Depth", Description: ""},
+					{Id: PPT, Offset: 7, Type: typelabel.Int16, Label: "Precipitation Type", Description: " Precipitation Type (WMO 4680 SYNOP code reference)"},
+					{Id: ElecFld, Offset: 8, Type: typelabel.Int16, Units: "Vm", Label: "Electric Field", Description: ""},
+					{Id: SurWet, Offset: 9, Type: typelabel.Int16, Units: "kO", Label: "Surface Wetness", Description: ""},
+					{Id: SoilWet, Offset: 10, Type: typelabel.Int16, Units: "Pct", Label: "Soil Wetness", Description: ""},
 				},
 			},
 		}})

--- a/models/model308/model.go
+++ b/models/model308/model.go
@@ -25,10 +25,10 @@ const (
 )
 
 type Block308 struct {
-	GHI    uint16 `sunspec:"offset=0,len=1"`
-	TmpBOM int16  `sunspec:"offset=1,len=1,sf=-1"`
-	TmpAmb int16  `sunspec:"offset=2,len=1,sf=-1"`
-	WndSpd uint16 `sunspec:"offset=3,len=1"`
+	GHI    uint16 `sunspec:"offset=0"`
+	TmpBOM int16  `sunspec:"offset=1,sf=-1"`
+	TmpAmb int16  `sunspec:"offset=2,sf=-1"`
+	WndSpd uint16 `sunspec:"offset=3"`
 }
 
 func (block *Block308) GetId() sunspec.ModelId {
@@ -47,10 +47,10 @@ func init() {
 				Length: 4,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: GHI, Offset: 0, Type: typelabel.Uint16, Units: "W/m2", Length: 1, Label: "GHI", Description: "Global Horizontal Irradiance"},
-					{Id: TmpBOM, Offset: 1, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Length: 1, Label: "Temp", Description: "Back of module temperature measurement"},
-					{Id: TmpAmb, Offset: 2, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Length: 1, Label: "Ambient Temperature", Description: ""},
-					{Id: WndSpd, Offset: 3, Type: typelabel.Uint16, Units: "m/s", Length: 1, Label: "Wind Speed", Description: ""},
+					{Id: GHI, Offset: 0, Type: typelabel.Uint16, Units: "W/m2", Label: "GHI", Description: "Global Horizontal Irradiance"},
+					{Id: TmpBOM, Offset: 1, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Label: "Temp", Description: "Back of module temperature measurement"},
+					{Id: TmpAmb, Offset: 2, Type: typelabel.Int16, ScaleFactor: "-1", Units: "C", Label: "Ambient Temperature", Description: ""},
+					{Id: WndSpd, Offset: 3, Type: typelabel.Uint16, Units: "m/s", Label: "Wind Speed", Description: ""},
 				},
 			},
 		}})

--- a/models/model4/model.go
+++ b/models/model4/model.go
@@ -81,69 +81,69 @@ const (
 )
 
 type Block4Repeat struct {
-	DS uint16 `sunspec:"offset=0,len=1"`
+	DS uint16 `sunspec:"offset=0"`
 }
 
 type Block4 struct {
-	RqSeq uint16         `sunspec:"offset=0,len=1"`
-	Sts   sunspec.Enum16 `sunspec:"offset=1,len=1"`
-	X     uint16         `sunspec:"offset=2,len=1"`
-	Val1  uint16         `sunspec:"offset=3,len=1"`
-	Val2  uint16         `sunspec:"offset=4,len=1"`
-	Val3  uint16         `sunspec:"offset=5,len=1"`
-	Val4  uint16         `sunspec:"offset=6,len=1"`
-	Val5  uint16         `sunspec:"offset=7,len=1"`
-	Val6  uint16         `sunspec:"offset=8,len=1"`
-	Val7  uint16         `sunspec:"offset=9,len=1"`
-	Val8  uint16         `sunspec:"offset=10,len=1"`
-	Val9  uint16         `sunspec:"offset=11,len=1"`
-	Val10 uint16         `sunspec:"offset=12,len=1"`
-	Val11 uint16         `sunspec:"offset=13,len=1"`
-	Val12 uint16         `sunspec:"offset=14,len=1"`
-	Val13 uint16         `sunspec:"offset=15,len=1"`
-	Val14 uint16         `sunspec:"offset=16,len=1"`
-	Val15 uint16         `sunspec:"offset=17,len=1"`
-	Val16 uint16         `sunspec:"offset=18,len=1"`
-	Val17 uint16         `sunspec:"offset=19,len=1"`
-	Val18 uint16         `sunspec:"offset=20,len=1"`
-	Val19 uint16         `sunspec:"offset=21,len=1"`
-	Val20 uint16         `sunspec:"offset=22,len=1"`
-	Val21 uint16         `sunspec:"offset=23,len=1"`
-	Val22 uint16         `sunspec:"offset=24,len=1"`
-	Val23 uint16         `sunspec:"offset=25,len=1"`
-	Val24 uint16         `sunspec:"offset=26,len=1"`
-	Val25 uint16         `sunspec:"offset=27,len=1"`
-	Val26 uint16         `sunspec:"offset=28,len=1"`
-	Val27 uint16         `sunspec:"offset=29,len=1"`
-	Val28 uint16         `sunspec:"offset=30,len=1"`
-	Val29 uint16         `sunspec:"offset=31,len=1"`
-	Val30 uint16         `sunspec:"offset=32,len=1"`
-	Val31 uint16         `sunspec:"offset=33,len=1"`
-	Val32 uint16         `sunspec:"offset=34,len=1"`
-	Val33 uint16         `sunspec:"offset=35,len=1"`
-	Val34 uint16         `sunspec:"offset=36,len=1"`
-	Val35 uint16         `sunspec:"offset=37,len=1"`
-	Val36 uint16         `sunspec:"offset=38,len=1"`
-	Val37 uint16         `sunspec:"offset=39,len=1"`
-	Val38 uint16         `sunspec:"offset=40,len=1"`
-	Val39 uint16         `sunspec:"offset=41,len=1"`
-	Val40 uint16         `sunspec:"offset=42,len=1"`
-	Val41 uint16         `sunspec:"offset=43,len=1"`
-	Val42 uint16         `sunspec:"offset=44,len=1"`
-	Val43 uint16         `sunspec:"offset=45,len=1"`
-	Val44 uint16         `sunspec:"offset=46,len=1"`
-	Val45 uint16         `sunspec:"offset=47,len=1"`
-	Val46 uint16         `sunspec:"offset=48,len=1"`
-	Val47 uint16         `sunspec:"offset=49,len=1"`
-	Val48 uint16         `sunspec:"offset=50,len=1"`
-	Val49 uint16         `sunspec:"offset=51,len=1"`
-	Val50 uint16         `sunspec:"offset=52,len=1"`
-	Ts    uint32         `sunspec:"offset=53,len=2"`
-	Ms    uint16         `sunspec:"offset=55,len=1"`
-	Seq   uint16         `sunspec:"offset=56,len=1"`
-	Alm   sunspec.Enum16 `sunspec:"offset=57,len=1"`
-	Alg   sunspec.Enum16 `sunspec:"offset=58,len=1"`
-	N     uint16         `sunspec:"offset=59,len=1"`
+	RqSeq uint16         `sunspec:"offset=0"`
+	Sts   sunspec.Enum16 `sunspec:"offset=1"`
+	X     uint16         `sunspec:"offset=2"`
+	Val1  uint16         `sunspec:"offset=3"`
+	Val2  uint16         `sunspec:"offset=4"`
+	Val3  uint16         `sunspec:"offset=5"`
+	Val4  uint16         `sunspec:"offset=6"`
+	Val5  uint16         `sunspec:"offset=7"`
+	Val6  uint16         `sunspec:"offset=8"`
+	Val7  uint16         `sunspec:"offset=9"`
+	Val8  uint16         `sunspec:"offset=10"`
+	Val9  uint16         `sunspec:"offset=11"`
+	Val10 uint16         `sunspec:"offset=12"`
+	Val11 uint16         `sunspec:"offset=13"`
+	Val12 uint16         `sunspec:"offset=14"`
+	Val13 uint16         `sunspec:"offset=15"`
+	Val14 uint16         `sunspec:"offset=16"`
+	Val15 uint16         `sunspec:"offset=17"`
+	Val16 uint16         `sunspec:"offset=18"`
+	Val17 uint16         `sunspec:"offset=19"`
+	Val18 uint16         `sunspec:"offset=20"`
+	Val19 uint16         `sunspec:"offset=21"`
+	Val20 uint16         `sunspec:"offset=22"`
+	Val21 uint16         `sunspec:"offset=23"`
+	Val22 uint16         `sunspec:"offset=24"`
+	Val23 uint16         `sunspec:"offset=25"`
+	Val24 uint16         `sunspec:"offset=26"`
+	Val25 uint16         `sunspec:"offset=27"`
+	Val26 uint16         `sunspec:"offset=28"`
+	Val27 uint16         `sunspec:"offset=29"`
+	Val28 uint16         `sunspec:"offset=30"`
+	Val29 uint16         `sunspec:"offset=31"`
+	Val30 uint16         `sunspec:"offset=32"`
+	Val31 uint16         `sunspec:"offset=33"`
+	Val32 uint16         `sunspec:"offset=34"`
+	Val33 uint16         `sunspec:"offset=35"`
+	Val34 uint16         `sunspec:"offset=36"`
+	Val35 uint16         `sunspec:"offset=37"`
+	Val36 uint16         `sunspec:"offset=38"`
+	Val37 uint16         `sunspec:"offset=39"`
+	Val38 uint16         `sunspec:"offset=40"`
+	Val39 uint16         `sunspec:"offset=41"`
+	Val40 uint16         `sunspec:"offset=42"`
+	Val41 uint16         `sunspec:"offset=43"`
+	Val42 uint16         `sunspec:"offset=44"`
+	Val43 uint16         `sunspec:"offset=45"`
+	Val44 uint16         `sunspec:"offset=46"`
+	Val45 uint16         `sunspec:"offset=47"`
+	Val46 uint16         `sunspec:"offset=48"`
+	Val47 uint16         `sunspec:"offset=49"`
+	Val48 uint16         `sunspec:"offset=50"`
+	Val49 uint16         `sunspec:"offset=51"`
+	Val50 uint16         `sunspec:"offset=52"`
+	Ts    uint32         `sunspec:"offset=53"`
+	Ms    uint16         `sunspec:"offset=55"`
+	Seq   uint16         `sunspec:"offset=56"`
+	Alm   sunspec.Enum16 `sunspec:"offset=57"`
+	Alg   sunspec.Enum16 `sunspec:"offset=58"`
+	N     uint16         `sunspec:"offset=59"`
 
 	Repeats []Block4Repeat
 }
@@ -164,72 +164,72 @@ func init() {
 				Length: 60,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: RqSeq, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Request Sequence", Description: "Sequence number from the request"},
-					{Id: Sts, Offset: 1, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Status", Description: "Status of last read operation"},
-					{Id: X, Offset: 2, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "X", Description: "Number of values from the request"},
-					{Id: Val1, Offset: 3, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Value1", Description: "Copy of value from register Off1."},
-					{Id: Val2, Offset: 4, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val3, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val4, Offset: 6, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val5, Offset: 7, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val6, Offset: 8, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val7, Offset: 9, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val8, Offset: 10, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val9, Offset: 11, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val10, Offset: 12, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val11, Offset: 13, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val12, Offset: 14, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val13, Offset: 15, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val14, Offset: 16, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val15, Offset: 17, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val16, Offset: 18, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val17, Offset: 19, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val18, Offset: 20, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val19, Offset: 21, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val20, Offset: 22, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val21, Offset: 23, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val22, Offset: 24, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val23, Offset: 25, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val24, Offset: 26, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val25, Offset: 27, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val26, Offset: 28, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val27, Offset: 29, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val28, Offset: 30, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val29, Offset: 31, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val30, Offset: 32, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val31, Offset: 33, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val32, Offset: 34, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val33, Offset: 35, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val34, Offset: 36, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val35, Offset: 37, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val36, Offset: 38, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val37, Offset: 39, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val38, Offset: 40, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val39, Offset: 41, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val40, Offset: 42, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val41, Offset: 43, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val42, Offset: 44, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val43, Offset: 45, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val44, Offset: 46, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val45, Offset: 47, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val46, Offset: 48, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val47, Offset: 49, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val48, Offset: 50, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val49, Offset: 51, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Val50, Offset: 52, Type: typelabel.Uint16, Length: 1, Mandatory: true},
-					{Id: Ts, Offset: 53, Type: typelabel.Uint32, Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 55, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 56, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of response"},
-					{Id: Alm, Offset: 57, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Alarm", Description: "Bitmask alarm code"},
-					{Id: Alg, Offset: 58, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 59, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
+					{Id: RqSeq, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Request Sequence", Description: "Sequence number from the request"},
+					{Id: Sts, Offset: 1, Type: typelabel.Enum16, Mandatory: true, Label: "Status", Description: "Status of last read operation"},
+					{Id: X, Offset: 2, Type: typelabel.Uint16, Mandatory: true, Label: "X", Description: "Number of values from the request"},
+					{Id: Val1, Offset: 3, Type: typelabel.Uint16, Mandatory: true, Label: "Value1", Description: "Copy of value from register Off1."},
+					{Id: Val2, Offset: 4, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val3, Offset: 5, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val4, Offset: 6, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val5, Offset: 7, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val6, Offset: 8, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val7, Offset: 9, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val8, Offset: 10, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val9, Offset: 11, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val10, Offset: 12, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val11, Offset: 13, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val12, Offset: 14, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val13, Offset: 15, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val14, Offset: 16, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val15, Offset: 17, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val16, Offset: 18, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val17, Offset: 19, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val18, Offset: 20, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val19, Offset: 21, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val20, Offset: 22, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val21, Offset: 23, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val22, Offset: 24, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val23, Offset: 25, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val24, Offset: 26, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val25, Offset: 27, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val26, Offset: 28, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val27, Offset: 29, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val28, Offset: 30, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val29, Offset: 31, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val30, Offset: 32, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val31, Offset: 33, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val32, Offset: 34, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val33, Offset: 35, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val34, Offset: 36, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val35, Offset: 37, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val36, Offset: 38, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val37, Offset: 39, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val38, Offset: 40, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val39, Offset: 41, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val40, Offset: 42, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val41, Offset: 43, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val42, Offset: 44, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val43, Offset: 45, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val44, Offset: 46, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val45, Offset: 47, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val46, Offset: 48, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val47, Offset: 49, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val48, Offset: 50, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val49, Offset: 51, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Val50, Offset: 52, Type: typelabel.Uint16, Mandatory: true},
+					{Id: Ts, Offset: 53, Type: typelabel.Uint32, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 55, Type: typelabel.Uint16, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 56, Type: typelabel.Uint16, Mandatory: true, Label: "Sequence", Description: "Sequence number of response"},
+					{Id: Alm, Offset: 57, Type: typelabel.Enum16, Mandatory: true, Label: "Alarm", Description: "Bitmask alarm code"},
+					{Id: Alg, Offset: 58, Type: typelabel.Enum16, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 59, Type: typelabel.Uint16, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: DS, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "DS", Description: "Digital Signature"},
+					{Id: DS, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "DS", Description: "Digital Signature"},
 				},
 			},
 		}})

--- a/models/model401/model.go
+++ b/models/model401/model.go
@@ -37,25 +37,25 @@ const (
 )
 
 type Block401Repeat struct {
-	InID     uint16             `sunspec:"offset=0,len=1"`
-	InEvt    sunspec.Bitfield32 `sunspec:"offset=1,len=2"`
-	InEvtVnd sunspec.Bitfield32 `sunspec:"offset=3,len=2"`
-	InDCA    int16              `sunspec:"offset=5,len=1,sf=DCA_SF"`
-	InDCAhr  uint32             `sunspec:"offset=6,len=2,sf=DCAhr_SF"`
+	InID     uint16             `sunspec:"offset=0"`
+	InEvt    sunspec.Bitfield32 `sunspec:"offset=1"`
+	InEvtVnd sunspec.Bitfield32 `sunspec:"offset=3"`
+	InDCA    int16              `sunspec:"offset=5,sf=DCA_SF"`
+	InDCAhr  uint32             `sunspec:"offset=6,sf=DCAhr_SF"`
 }
 
 type Block401 struct {
-	DCA_SF   sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	DCAhr_SF sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	DCV_SF   sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	DCAMax   uint16              `sunspec:"offset=3,len=1,sf=DCA_SF"`
-	N        sunspec.Count       `sunspec:"offset=4,len=1"`
-	Evt      sunspec.Bitfield32  `sunspec:"offset=5,len=2"`
-	EvtVnd   sunspec.Bitfield32  `sunspec:"offset=7,len=2"`
-	DCA      int16               `sunspec:"offset=9,len=1,sf=DCA_SF"`
-	DCAhr    uint32              `sunspec:"offset=10,len=2,sf=DCAhr_SF"`
-	DCV      uint16              `sunspec:"offset=12,len=1,sf=DCV_SF"`
-	Tmp      int16               `sunspec:"offset=13,len=1"`
+	DCA_SF   sunspec.ScaleFactor `sunspec:"offset=0"`
+	DCAhr_SF sunspec.ScaleFactor `sunspec:"offset=1"`
+	DCV_SF   sunspec.ScaleFactor `sunspec:"offset=2"`
+	DCAMax   uint16              `sunspec:"offset=3,sf=DCA_SF"`
+	N        sunspec.Count       `sunspec:"offset=4"`
+	Evt      sunspec.Bitfield32  `sunspec:"offset=5"`
+	EvtVnd   sunspec.Bitfield32  `sunspec:"offset=7"`
+	DCA      int16               `sunspec:"offset=9,sf=DCA_SF"`
+	DCAhr    uint32              `sunspec:"offset=10,sf=DCAhr_SF"`
+	DCV      uint16              `sunspec:"offset=12,sf=DCV_SF"`
+	Tmp      int16               `sunspec:"offset=13"`
 
 	Repeats []Block401Repeat
 }
@@ -76,28 +76,28 @@ func init() {
 				Length: 14,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCAMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Rating", Description: "Maximum DC Current Rating"},
-					{Id: N, Offset: 4, Type: typelabel.Count, Length: 1, Mandatory: true, Label: "N", Description: "Number of Inputs"},
-					{Id: Evt, Offset: 5, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
-					{Id: EvtVnd, Offset: 7, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
-					{Id: DCA, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total measured current"},
-					{Id: DCAhr, Offset: 10, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "Total metered Amp-hours"},
-					{Id: DCV, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "Voltage", Description: "Output Voltage"},
-					{Id: Tmp, Offset: 13, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Temp", Description: "Internal operating temperature"},
+					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor},
+					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor},
+					{Id: DCAMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Rating", Description: "Maximum DC Current Rating"},
+					{Id: N, Offset: 4, Type: typelabel.Count, Mandatory: true, Label: "N", Description: "Number of Inputs"},
+					{Id: Evt, Offset: 5, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
+					{Id: EvtVnd, Offset: 7, Type: typelabel.Bitfield32, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
+					{Id: DCA, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total measured current"},
+					{Id: DCAhr, Offset: 10, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "Total metered Amp-hours"},
+					{Id: DCV, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "Voltage", Description: "Output Voltage"},
+					{Id: Tmp, Offset: 13, Type: typelabel.Int16, Units: "C", Label: "Temp", Description: "Internal operating temperature"},
 				},
 			},
 			{Name: "string",
 				Length: 8,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: InID, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
-					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
-					{Id: InEvtVnd, Offset: 3, Type: typelabel.Bitfield32, Length: 2, Label: "Input Event Vendor", Description: "String Input Vendor Event Flags"},
-					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "String Input Current"},
-					{Id: InDCAhr, Offset: 6, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "String Input Amp-Hours"},
+					{Id: InID, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
+					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
+					{Id: InEvtVnd, Offset: 3, Type: typelabel.Bitfield32, Label: "Input Event Vendor", Description: "String Input Vendor Event Flags"},
+					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "String Input Current"},
+					{Id: InDCAhr, Offset: 6, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "String Input Amp-Hours"},
 				},
 			},
 		}})

--- a/models/model402/model.go
+++ b/models/model402/model.go
@@ -46,35 +46,35 @@ const (
 )
 
 type Block402Repeat struct {
-	InID    uint16             `sunspec:"offset=0,len=1"`
-	InEvt   sunspec.Bitfield32 `sunspec:"offset=1,len=2"`
-	EvtVnd  sunspec.Bitfield32 `sunspec:"offset=3,len=2"`
-	InDCA   int16              `sunspec:"offset=5,len=1,sf=DCA_SF"`
-	InDCAhr uint32             `sunspec:"offset=6,len=2,sf=DCAhr_SF"`
-	InDCV   uint16             `sunspec:"offset=8,len=1,sf=DCV_SF"`
-	InDCW   int16              `sunspec:"offset=9,len=1,sf=DCWh_SF"`
-	InDCWh  uint32             `sunspec:"offset=10,len=2"`
-	InDCPR  uint16             `sunspec:"offset=12,len=1"`
-	InN     uint16             `sunspec:"offset=13,len=1"`
+	InID    uint16             `sunspec:"offset=0"`
+	InEvt   sunspec.Bitfield32 `sunspec:"offset=1"`
+	EvtVnd  sunspec.Bitfield32 `sunspec:"offset=3"`
+	InDCA   int16              `sunspec:"offset=5,sf=DCA_SF"`
+	InDCAhr uint32             `sunspec:"offset=6,sf=DCAhr_SF"`
+	InDCV   uint16             `sunspec:"offset=8,sf=DCV_SF"`
+	InDCW   int16              `sunspec:"offset=9,sf=DCWh_SF"`
+	InDCWh  uint32             `sunspec:"offset=10"`
+	InDCPR  uint16             `sunspec:"offset=12"`
+	InN     uint16             `sunspec:"offset=13"`
 }
 
 type Block402 struct {
-	DCA_SF   sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	DCAhr_SF sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	DCV_SF   sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	DCW_SF   sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	DCWh_SF  sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	DCAMax   uint16              `sunspec:"offset=5,len=1"`
-	N        sunspec.Count       `sunspec:"offset=6,len=1"`
-	Evt      sunspec.Bitfield32  `sunspec:"offset=7,len=2"`
-	EvtVnd   sunspec.Bitfield32  `sunspec:"offset=9,len=2"`
-	DCA      int16               `sunspec:"offset=11,len=1,sf=DCA_SF"`
-	DCAhr    uint32              `sunspec:"offset=12,len=2,sf=DCAhr_SF"`
-	DCV      uint16              `sunspec:"offset=14,len=1,sf=DCV_SF"`
-	Tmp      int16               `sunspec:"offset=15,len=1"`
-	DCW      int16               `sunspec:"offset=16,len=1,sf=DCW_SF"`
-	DCPR     uint16              `sunspec:"offset=17,len=1"`
-	DCWh     uint32              `sunspec:"offset=18,len=2,sf=DCWh_SF"`
+	DCA_SF   sunspec.ScaleFactor `sunspec:"offset=0"`
+	DCAhr_SF sunspec.ScaleFactor `sunspec:"offset=1"`
+	DCV_SF   sunspec.ScaleFactor `sunspec:"offset=2"`
+	DCW_SF   sunspec.ScaleFactor `sunspec:"offset=3"`
+	DCWh_SF  sunspec.ScaleFactor `sunspec:"offset=4"`
+	DCAMax   uint16              `sunspec:"offset=5"`
+	N        sunspec.Count       `sunspec:"offset=6"`
+	Evt      sunspec.Bitfield32  `sunspec:"offset=7"`
+	EvtVnd   sunspec.Bitfield32  `sunspec:"offset=9"`
+	DCA      int16               `sunspec:"offset=11,sf=DCA_SF"`
+	DCAhr    uint32              `sunspec:"offset=12,sf=DCAhr_SF"`
+	DCV      uint16              `sunspec:"offset=14,sf=DCV_SF"`
+	Tmp      int16               `sunspec:"offset=15"`
+	DCW      int16               `sunspec:"offset=16,sf=DCW_SF"`
+	DCPR     uint16              `sunspec:"offset=17"`
+	DCWh     uint32              `sunspec:"offset=18,sf=DCWh_SF"`
 
 	Repeats []Block402Repeat
 }
@@ -95,38 +95,38 @@ func init() {
 				Length: 20,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCW_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCWh_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCAMax, Offset: 5, Type: typelabel.Uint16, Units: "A", Length: 1, Label: "Rating", Description: "Maximum DC Current Rating"},
-					{Id: N, Offset: 6, Type: typelabel.Count, Length: 1, Label: "N", Description: "Number of Inputs"},
-					{Id: Evt, Offset: 7, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
-					{Id: EvtVnd, Offset: 9, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
-					{Id: DCA, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total measured current"},
-					{Id: DCAhr, Offset: 12, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "Total metered Amp-hours"},
-					{Id: DCV, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "Voltage", Description: "Output Voltage"},
-					{Id: Tmp, Offset: 15, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Temp", Description: "Internal operating temperature"},
-					{Id: DCW, Offset: 16, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Length: 1, Label: "Watts", Description: "Output power"},
-					{Id: DCPR, Offset: 17, Type: typelabel.Uint16, Units: "Pct", Length: 1, Label: "PR", Description: "DC Performance ratio value"},
-					{Id: DCWh, Offset: 18, Type: typelabel.Uint32, ScaleFactor: "DCWh_SF", Units: "Wh", Length: 2, Mandatory: true, Label: "Watt-hours", Description: "Output energy"},
+					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor},
+					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor},
+					{Id: DCW_SF, Offset: 3, Type: typelabel.ScaleFactor},
+					{Id: DCWh_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCAMax, Offset: 5, Type: typelabel.Uint16, Units: "A", Label: "Rating", Description: "Maximum DC Current Rating"},
+					{Id: N, Offset: 6, Type: typelabel.Count, Label: "N", Description: "Number of Inputs"},
+					{Id: Evt, Offset: 7, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
+					{Id: EvtVnd, Offset: 9, Type: typelabel.Bitfield32, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
+					{Id: DCA, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total measured current"},
+					{Id: DCAhr, Offset: 12, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "Total metered Amp-hours"},
+					{Id: DCV, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "Voltage", Description: "Output Voltage"},
+					{Id: Tmp, Offset: 15, Type: typelabel.Int16, Units: "C", Label: "Temp", Description: "Internal operating temperature"},
+					{Id: DCW, Offset: 16, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Label: "Watts", Description: "Output power"},
+					{Id: DCPR, Offset: 17, Type: typelabel.Uint16, Units: "Pct", Label: "PR", Description: "DC Performance ratio value"},
+					{Id: DCWh, Offset: 18, Type: typelabel.Uint32, ScaleFactor: "DCWh_SF", Units: "Wh", Mandatory: true, Label: "Watt-hours", Description: "Output energy"},
 				},
 			},
 			{Name: "string",
 				Length: 14,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: InID, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
-					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
-					{Id: EvtVnd, Offset: 3, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
-					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "String Input Current"},
-					{Id: InDCAhr, Offset: 6, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "String Input Amp-Hours"},
-					{Id: InDCV, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "Voltage", Description: "String Input Voltage"},
-					{Id: InDCW, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DCWh_SF", Units: "W", Length: 1, Label: "Watts", Description: "String Input Power"},
-					{Id: InDCWh, Offset: 10, Type: typelabel.Uint32, Units: "Wh", Length: 2, Label: "Watt-hours", Description: "String Input Energy"},
-					{Id: InDCPR, Offset: 12, Type: typelabel.Uint16, Units: "Pct", Length: 1, Label: "PR", Description: "String Performance Ratio"},
-					{Id: InN, Offset: 13, Type: typelabel.Uint16, Length: 1, Label: "N", Description: "Number of modules in this input string"},
+					{Id: InID, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
+					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
+					{Id: EvtVnd, Offset: 3, Type: typelabel.Bitfield32, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
+					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "String Input Current"},
+					{Id: InDCAhr, Offset: 6, Type: typelabel.Uint32, ScaleFactor: "DCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "String Input Amp-Hours"},
+					{Id: InDCV, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "DCV_SF", Units: "V", Label: "Voltage", Description: "String Input Voltage"},
+					{Id: InDCW, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DCWh_SF", Units: "W", Label: "Watts", Description: "String Input Power"},
+					{Id: InDCWh, Offset: 10, Type: typelabel.Uint32, Units: "Wh", Label: "Watt-hours", Description: "String Input Energy"},
+					{Id: InDCPR, Offset: 12, Type: typelabel.Uint16, Units: "Pct", Label: "PR", Description: "String Performance Ratio"},
+					{Id: InN, Offset: 13, Type: typelabel.Uint16, Label: "N", Description: "Number of modules in this input string"},
 				},
 			},
 		}})

--- a/models/model403/model.go
+++ b/models/model403/model.go
@@ -39,27 +39,27 @@ const (
 )
 
 type Block403Repeat struct {
-	InID     uint16             `sunspec:"offset=0,len=1"`
-	InEvt    sunspec.Bitfield32 `sunspec:"offset=1,len=2"`
-	InEvtVnd sunspec.Bitfield32 `sunspec:"offset=3,len=2"`
-	InDCA    int16              `sunspec:"offset=5,len=1,sf=InDCA_SF"`
-	InDCAhr  sunspec.Acc32      `sunspec:"offset=6,len=2,sf=InDCAhr_SF"`
+	InID     uint16             `sunspec:"offset=0"`
+	InEvt    sunspec.Bitfield32 `sunspec:"offset=1"`
+	InEvtVnd sunspec.Bitfield32 `sunspec:"offset=3"`
+	InDCA    int16              `sunspec:"offset=5,sf=InDCA_SF"`
+	InDCAhr  sunspec.Acc32      `sunspec:"offset=6,sf=InDCAhr_SF"`
 }
 
 type Block403 struct {
-	DCA_SF     sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	DCAhr_SF   sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	DCV_SF     sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	DCAMax     uint16              `sunspec:"offset=3,len=1,sf=DCA_SF"`
-	N          sunspec.Count       `sunspec:"offset=4,len=1"`
-	Evt        sunspec.Bitfield32  `sunspec:"offset=5,len=2"`
-	EvtVnd     sunspec.Bitfield32  `sunspec:"offset=7,len=2"`
-	DCA        int16               `sunspec:"offset=9,len=1,sf=DCA_SF"`
-	DCAhr      sunspec.Acc32       `sunspec:"offset=10,len=2,sf=DCAhr_SF"`
-	DCV        int16               `sunspec:"offset=12,len=1,sf=DCV_SF"`
-	Tmp        int16               `sunspec:"offset=13,len=1"`
-	InDCA_SF   sunspec.ScaleFactor `sunspec:"offset=14,len=1"`
-	InDCAhr_SF sunspec.ScaleFactor `sunspec:"offset=15,len=1"`
+	DCA_SF     sunspec.ScaleFactor `sunspec:"offset=0"`
+	DCAhr_SF   sunspec.ScaleFactor `sunspec:"offset=1"`
+	DCV_SF     sunspec.ScaleFactor `sunspec:"offset=2"`
+	DCAMax     uint16              `sunspec:"offset=3,sf=DCA_SF"`
+	N          sunspec.Count       `sunspec:"offset=4"`
+	Evt        sunspec.Bitfield32  `sunspec:"offset=5"`
+	EvtVnd     sunspec.Bitfield32  `sunspec:"offset=7"`
+	DCA        int16               `sunspec:"offset=9,sf=DCA_SF"`
+	DCAhr      sunspec.Acc32       `sunspec:"offset=10,sf=DCAhr_SF"`
+	DCV        int16               `sunspec:"offset=12,sf=DCV_SF"`
+	Tmp        int16               `sunspec:"offset=13"`
+	InDCA_SF   sunspec.ScaleFactor `sunspec:"offset=14"`
+	InDCAhr_SF sunspec.ScaleFactor `sunspec:"offset=15"`
 
 	Repeats []Block403Repeat
 }
@@ -80,30 +80,30 @@ func init() {
 				Length: 16,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCAMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Rating", Description: "Maximum DC Current Rating"},
-					{Id: N, Offset: 4, Type: typelabel.Count, Length: 1, Mandatory: true, Label: "N", Description: "Number of Inputs"},
-					{Id: Evt, Offset: 5, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
-					{Id: EvtVnd, Offset: 7, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
-					{Id: DCA, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total measured current"},
-					{Id: DCAhr, Offset: 10, Type: typelabel.Acc32, ScaleFactor: "DCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "Total metered Amp-hours"},
-					{Id: DCV, Offset: 12, Type: typelabel.Int16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "Voltage", Description: "Output Voltage"},
-					{Id: Tmp, Offset: 13, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Temp", Description: "Internal operating temperature"},
-					{Id: InDCA_SF, Offset: 14, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: InDCAhr_SF, Offset: 15, Type: typelabel.ScaleFactor, Length: 1},
+					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor},
+					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor},
+					{Id: DCAMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Rating", Description: "Maximum DC Current Rating"},
+					{Id: N, Offset: 4, Type: typelabel.Count, Mandatory: true, Label: "N", Description: "Number of Inputs"},
+					{Id: Evt, Offset: 5, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
+					{Id: EvtVnd, Offset: 7, Type: typelabel.Bitfield32, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
+					{Id: DCA, Offset: 9, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total measured current"},
+					{Id: DCAhr, Offset: 10, Type: typelabel.Acc32, ScaleFactor: "DCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "Total metered Amp-hours"},
+					{Id: DCV, Offset: 12, Type: typelabel.Int16, ScaleFactor: "DCV_SF", Units: "V", Label: "Voltage", Description: "Output Voltage"},
+					{Id: Tmp, Offset: 13, Type: typelabel.Int16, Units: "C", Label: "Temp", Description: "Internal operating temperature"},
+					{Id: InDCA_SF, Offset: 14, Type: typelabel.ScaleFactor},
+					{Id: InDCAhr_SF, Offset: 15, Type: typelabel.ScaleFactor},
 				},
 			},
 			{Name: "string",
 				Length: 8,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: InID, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
-					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
-					{Id: InEvtVnd, Offset: 3, Type: typelabel.Bitfield32, Length: 2, Label: "Input Event Vendor", Description: "String Input Vendor Event Flags"},
-					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "InDCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "String Input Current"},
-					{Id: InDCAhr, Offset: 6, Type: typelabel.Acc32, ScaleFactor: "InDCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "String Input Amp-Hours"},
+					{Id: InID, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
+					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
+					{Id: InEvtVnd, Offset: 3, Type: typelabel.Bitfield32, Label: "Input Event Vendor", Description: "String Input Vendor Event Flags"},
+					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "InDCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "String Input Current"},
+					{Id: InDCAhr, Offset: 6, Type: typelabel.Acc32, ScaleFactor: "InDCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "String Input Amp-Hours"},
 				},
 			},
 		}})

--- a/models/model404/model.go
+++ b/models/model404/model.go
@@ -52,40 +52,40 @@ const (
 )
 
 type Block404Repeat struct {
-	InID     uint16             `sunspec:"offset=0,len=1"`
-	InEvt    sunspec.Bitfield32 `sunspec:"offset=1,len=2"`
-	InEvtVnd sunspec.Bitfield32 `sunspec:"offset=3,len=2"`
-	InDCA    int16              `sunspec:"offset=5,len=1,sf=InDCA_SF"`
-	InDCAhr  sunspec.Acc32      `sunspec:"offset=6,len=2,sf=InDCAhr_SF"`
-	InDCV    int16              `sunspec:"offset=8,len=1,sf=InDCV_SF"`
-	InDCW    int16              `sunspec:"offset=9,len=1,sf=InDCW_SF"`
-	InDCWh   sunspec.Acc32      `sunspec:"offset=10,len=2,sf=InDCWh_SF"`
-	InDCPR   uint16             `sunspec:"offset=12,len=1"`
-	InN      uint16             `sunspec:"offset=13,len=1"`
+	InID     uint16             `sunspec:"offset=0"`
+	InEvt    sunspec.Bitfield32 `sunspec:"offset=1"`
+	InEvtVnd sunspec.Bitfield32 `sunspec:"offset=3"`
+	InDCA    int16              `sunspec:"offset=5,sf=InDCA_SF"`
+	InDCAhr  sunspec.Acc32      `sunspec:"offset=6,sf=InDCAhr_SF"`
+	InDCV    int16              `sunspec:"offset=8,sf=InDCV_SF"`
+	InDCW    int16              `sunspec:"offset=9,sf=InDCW_SF"`
+	InDCWh   sunspec.Acc32      `sunspec:"offset=10,sf=InDCWh_SF"`
+	InDCPR   uint16             `sunspec:"offset=12"`
+	InN      uint16             `sunspec:"offset=13"`
 }
 
 type Block404 struct {
-	DCA_SF     sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	DCAhr_SF   sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	DCV_SF     sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	DCW_SF     sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	DCWh_SF    sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	DCAMax     uint16              `sunspec:"offset=5,len=1,sf=DCA_SF"`
-	N          sunspec.Count       `sunspec:"offset=6,len=1"`
-	Evt        sunspec.Bitfield32  `sunspec:"offset=7,len=2"`
-	EvtVnd     sunspec.Bitfield32  `sunspec:"offset=9,len=2"`
-	DCA        int16               `sunspec:"offset=11,len=1,sf=DCA_SF"`
-	DCAhr      sunspec.Acc32       `sunspec:"offset=12,len=2,sf=DCAhr_SF"`
-	DCV        int16               `sunspec:"offset=14,len=1,sf=DCV_SF"`
-	Tmp        int16               `sunspec:"offset=15,len=1"`
-	DCW        int16               `sunspec:"offset=16,len=1,sf=DCW_SF"`
-	DCPR       int16               `sunspec:"offset=17,len=1"`
-	DCWh       sunspec.Acc32       `sunspec:"offset=18,len=2,sf=DCWh_SF"`
-	InDCA_SF   sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	InDCAhr_SF sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	InDCV_SF   sunspec.ScaleFactor `sunspec:"offset=22,len=1"`
-	InDCW_SF   sunspec.ScaleFactor `sunspec:"offset=23,len=1"`
-	InDCWh_SF  sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
+	DCA_SF     sunspec.ScaleFactor `sunspec:"offset=0"`
+	DCAhr_SF   sunspec.ScaleFactor `sunspec:"offset=1"`
+	DCV_SF     sunspec.ScaleFactor `sunspec:"offset=2"`
+	DCW_SF     sunspec.ScaleFactor `sunspec:"offset=3"`
+	DCWh_SF    sunspec.ScaleFactor `sunspec:"offset=4"`
+	DCAMax     uint16              `sunspec:"offset=5,sf=DCA_SF"`
+	N          sunspec.Count       `sunspec:"offset=6"`
+	Evt        sunspec.Bitfield32  `sunspec:"offset=7"`
+	EvtVnd     sunspec.Bitfield32  `sunspec:"offset=9"`
+	DCA        int16               `sunspec:"offset=11,sf=DCA_SF"`
+	DCAhr      sunspec.Acc32       `sunspec:"offset=12,sf=DCAhr_SF"`
+	DCV        int16               `sunspec:"offset=14,sf=DCV_SF"`
+	Tmp        int16               `sunspec:"offset=15"`
+	DCW        int16               `sunspec:"offset=16,sf=DCW_SF"`
+	DCPR       int16               `sunspec:"offset=17"`
+	DCWh       sunspec.Acc32       `sunspec:"offset=18,sf=DCWh_SF"`
+	InDCA_SF   sunspec.ScaleFactor `sunspec:"offset=20"`
+	InDCAhr_SF sunspec.ScaleFactor `sunspec:"offset=21"`
+	InDCV_SF   sunspec.ScaleFactor `sunspec:"offset=22"`
+	InDCW_SF   sunspec.ScaleFactor `sunspec:"offset=23"`
+	InDCWh_SF  sunspec.ScaleFactor `sunspec:"offset=24"`
 
 	Repeats []Block404Repeat
 }
@@ -106,43 +106,43 @@ func init() {
 				Length: 25,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCW_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCWh_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DCAMax, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Rating", Description: "Maximum DC Current Rating"},
-					{Id: N, Offset: 6, Type: typelabel.Count, Length: 1, Mandatory: true, Label: "N", Description: "Number of Inputs"},
-					{Id: Evt, Offset: 7, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
-					{Id: EvtVnd, Offset: 9, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
-					{Id: DCA, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "Total measured current"},
-					{Id: DCAhr, Offset: 12, Type: typelabel.Acc32, ScaleFactor: "DCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "Total metered Amp-hours"},
-					{Id: DCV, Offset: 14, Type: typelabel.Int16, ScaleFactor: "DCV_SF", Units: "V", Length: 1, Label: "Voltage", Description: "Output Voltage"},
-					{Id: Tmp, Offset: 15, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Temp", Description: "Internal operating temperature"},
-					{Id: DCW, Offset: 16, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Length: 1, Label: "Watts", Description: "Output power"},
-					{Id: DCPR, Offset: 17, Type: typelabel.Int16, Units: "Pct", Length: 1, Label: "PR", Description: "DC Performance ratio value"},
-					{Id: DCWh, Offset: 18, Type: typelabel.Acc32, ScaleFactor: "DCWh_SF", Units: "Wh", Length: 2, Label: "Watt-hours", Description: "Output energy"},
-					{Id: InDCA_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: InDCAhr_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: InDCV_SF, Offset: 22, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: InDCW_SF, Offset: 23, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: InDCWh_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1},
+					{Id: DCA_SF, Offset: 0, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DCAhr_SF, Offset: 1, Type: typelabel.ScaleFactor},
+					{Id: DCV_SF, Offset: 2, Type: typelabel.ScaleFactor},
+					{Id: DCW_SF, Offset: 3, Type: typelabel.ScaleFactor},
+					{Id: DCWh_SF, Offset: 4, Type: typelabel.ScaleFactor},
+					{Id: DCAMax, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Rating", Description: "Maximum DC Current Rating"},
+					{Id: N, Offset: 6, Type: typelabel.Count, Mandatory: true, Label: "N", Description: "Number of Inputs"},
+					{Id: Evt, Offset: 7, Type: typelabel.Bitfield32, Mandatory: true, Label: "Event", Description: "Bitmask value.  Events"},
+					{Id: EvtVnd, Offset: 9, Type: typelabel.Bitfield32, Label: "Vendor Event", Description: "Bitmask value.  Vendor defined events"},
+					{Id: DCA, Offset: 11, Type: typelabel.Int16, ScaleFactor: "DCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "Total measured current"},
+					{Id: DCAhr, Offset: 12, Type: typelabel.Acc32, ScaleFactor: "DCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "Total metered Amp-hours"},
+					{Id: DCV, Offset: 14, Type: typelabel.Int16, ScaleFactor: "DCV_SF", Units: "V", Label: "Voltage", Description: "Output Voltage"},
+					{Id: Tmp, Offset: 15, Type: typelabel.Int16, Units: "C", Label: "Temp", Description: "Internal operating temperature"},
+					{Id: DCW, Offset: 16, Type: typelabel.Int16, ScaleFactor: "DCW_SF", Units: "W", Label: "Watts", Description: "Output power"},
+					{Id: DCPR, Offset: 17, Type: typelabel.Int16, Units: "Pct", Label: "PR", Description: "DC Performance ratio value"},
+					{Id: DCWh, Offset: 18, Type: typelabel.Acc32, ScaleFactor: "DCWh_SF", Units: "Wh", Label: "Watt-hours", Description: "Output energy"},
+					{Id: InDCA_SF, Offset: 20, Type: typelabel.ScaleFactor},
+					{Id: InDCAhr_SF, Offset: 21, Type: typelabel.ScaleFactor},
+					{Id: InDCV_SF, Offset: 22, Type: typelabel.ScaleFactor},
+					{Id: InDCW_SF, Offset: 23, Type: typelabel.ScaleFactor},
+					{Id: InDCWh_SF, Offset: 24, Type: typelabel.ScaleFactor},
 				},
 			},
 			{Name: "string",
 				Length: 14,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: InID, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
-					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
-					{Id: InEvtVnd, Offset: 3, Type: typelabel.Bitfield32, Length: 2, Label: "Input Event Vendor", Description: "String Input Vendor Event Flags"},
-					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "InDCA_SF", Units: "A", Length: 1, Mandatory: true, Label: "Amps", Description: "String Input Current"},
-					{Id: InDCAhr, Offset: 6, Type: typelabel.Acc32, ScaleFactor: "InDCAhr_SF", Units: "Ah", Length: 2, Label: "Amp-hours", Description: "String Input Amp-Hours"},
-					{Id: InDCV, Offset: 8, Type: typelabel.Int16, ScaleFactor: "InDCV_SF", Units: "V", Length: 1, Label: "Voltage", Description: "String Input Voltage"},
-					{Id: InDCW, Offset: 9, Type: typelabel.Int16, ScaleFactor: "InDCW_SF", Units: "W", Length: 1, Label: "Watts", Description: "String Input Power"},
-					{Id: InDCWh, Offset: 10, Type: typelabel.Acc32, ScaleFactor: "InDCWh_SF", Units: "Wh", Length: 2, Label: "Watt-hours", Description: "String Input Energy"},
-					{Id: InDCPR, Offset: 12, Type: typelabel.Uint16, Units: "Pct", Length: 1, Label: "PR", Description: "String Performance Ratio"},
-					{Id: InN, Offset: 13, Type: typelabel.Uint16, Length: 1, Label: "N", Description: "Number of modules in this input string"},
+					{Id: InID, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "ID", Description: "Uniquely identifies this input set"},
+					{Id: InEvt, Offset: 1, Type: typelabel.Bitfield32, Mandatory: true, Label: "Input Event", Description: "String Input Event Flags"},
+					{Id: InEvtVnd, Offset: 3, Type: typelabel.Bitfield32, Label: "Input Event Vendor", Description: "String Input Vendor Event Flags"},
+					{Id: InDCA, Offset: 5, Type: typelabel.Int16, ScaleFactor: "InDCA_SF", Units: "A", Mandatory: true, Label: "Amps", Description: "String Input Current"},
+					{Id: InDCAhr, Offset: 6, Type: typelabel.Acc32, ScaleFactor: "InDCAhr_SF", Units: "Ah", Label: "Amp-hours", Description: "String Input Amp-Hours"},
+					{Id: InDCV, Offset: 8, Type: typelabel.Int16, ScaleFactor: "InDCV_SF", Units: "V", Label: "Voltage", Description: "String Input Voltage"},
+					{Id: InDCW, Offset: 9, Type: typelabel.Int16, ScaleFactor: "InDCW_SF", Units: "W", Label: "Watts", Description: "String Input Power"},
+					{Id: InDCWh, Offset: 10, Type: typelabel.Acc32, ScaleFactor: "InDCWh_SF", Units: "Wh", Label: "Watt-hours", Description: "String Input Energy"},
+					{Id: InDCPR, Offset: 12, Type: typelabel.Uint16, Units: "Pct", Label: "PR", Description: "String Performance Ratio"},
+					{Id: InN, Offset: 13, Type: typelabel.Uint16, Label: "N", Description: "Number of modules in this input string"},
 				},
 			},
 		}})

--- a/models/model5/model.go
+++ b/models/model5/model.go
@@ -109,97 +109,97 @@ const (
 )
 
 type Block5Repeat struct {
-	DS uint16 `sunspec:"offset=0,len=1,access=rw"`
+	DS uint16 `sunspec:"offset=0,access=rw"`
 }
 
 type Block5 struct {
-	X     uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Off1  uint16         `sunspec:"offset=1,len=1,access=rw"`
-	Val1  uint16         `sunspec:"offset=2,len=1,access=rw"`
-	Off2  uint16         `sunspec:"offset=3,len=1,access=rw"`
-	Val2  uint16         `sunspec:"offset=4,len=1,access=rw"`
-	Off3  uint16         `sunspec:"offset=5,len=1,access=rw"`
-	Val3  uint16         `sunspec:"offset=6,len=1,access=rw"`
-	Off4  uint16         `sunspec:"offset=7,len=1,access=rw"`
-	Val4  uint16         `sunspec:"offset=8,len=1,access=rw"`
-	Off5  uint16         `sunspec:"offset=9,len=1,access=rw"`
-	Val5  uint16         `sunspec:"offset=10,len=1,access=rw"`
-	Off6  uint16         `sunspec:"offset=11,len=1,access=rw"`
-	Val6  uint16         `sunspec:"offset=12,len=1,access=rw"`
-	Off7  uint16         `sunspec:"offset=13,len=1,access=rw"`
-	Val7  uint16         `sunspec:"offset=14,len=1,access=rw"`
-	Off8  uint16         `sunspec:"offset=15,len=1,access=rw"`
-	Val8  uint16         `sunspec:"offset=16,len=1,access=rw"`
-	Off9  uint16         `sunspec:"offset=17,len=1,access=rw"`
-	Val9  uint16         `sunspec:"offset=18,len=1,access=rw"`
-	Off10 uint16         `sunspec:"offset=19,len=1,access=rw"`
-	Val10 uint16         `sunspec:"offset=20,len=1,access=rw"`
-	Off11 uint16         `sunspec:"offset=21,len=1,access=rw"`
-	Val11 uint16         `sunspec:"offset=22,len=1,access=rw"`
-	Off12 uint16         `sunspec:"offset=23,len=1,access=rw"`
-	Val12 uint16         `sunspec:"offset=24,len=1,access=rw"`
-	Off13 uint16         `sunspec:"offset=25,len=1,access=rw"`
-	Val13 uint16         `sunspec:"offset=26,len=1,access=rw"`
-	Off14 uint16         `sunspec:"offset=27,len=1,access=rw"`
-	Val14 uint16         `sunspec:"offset=28,len=1,access=rw"`
-	Off15 uint16         `sunspec:"offset=29,len=1,access=rw"`
-	Val15 uint16         `sunspec:"offset=30,len=1,access=rw"`
-	Off16 uint16         `sunspec:"offset=31,len=1,access=rw"`
-	Val16 uint16         `sunspec:"offset=32,len=1,access=rw"`
-	Off17 uint16         `sunspec:"offset=33,len=1,access=rw"`
-	Val17 uint16         `sunspec:"offset=34,len=1,access=rw"`
-	Off18 uint16         `sunspec:"offset=35,len=1,access=rw"`
-	Val18 uint16         `sunspec:"offset=36,len=1,access=rw"`
-	Off19 uint16         `sunspec:"offset=37,len=1,access=rw"`
-	Val19 uint16         `sunspec:"offset=38,len=1,access=rw"`
-	Off20 uint16         `sunspec:"offset=39,len=1,access=rw"`
-	Val20 uint16         `sunspec:"offset=40,len=1,access=rw"`
-	Off21 uint16         `sunspec:"offset=41,len=1,access=rw"`
-	Val21 uint16         `sunspec:"offset=42,len=1,access=rw"`
-	Off22 uint16         `sunspec:"offset=43,len=1,access=rw"`
-	Val22 uint16         `sunspec:"offset=44,len=1,access=rw"`
-	Off23 uint16         `sunspec:"offset=45,len=1,access=rw"`
-	Val23 uint16         `sunspec:"offset=46,len=1,access=rw"`
-	Off24 uint16         `sunspec:"offset=47,len=1,access=rw"`
-	Val24 uint16         `sunspec:"offset=48,len=1,access=rw"`
-	Off25 uint16         `sunspec:"offset=49,len=1,access=rw"`
-	Val25 uint16         `sunspec:"offset=50,len=1,access=rw"`
-	Off26 uint16         `sunspec:"offset=51,len=1,access=rw"`
-	Val26 uint16         `sunspec:"offset=52,len=1,access=rw"`
-	Off27 uint16         `sunspec:"offset=53,len=1,access=rw"`
-	Val27 uint16         `sunspec:"offset=54,len=1,access=rw"`
-	Off28 uint16         `sunspec:"offset=55,len=1,access=rw"`
-	Val28 uint16         `sunspec:"offset=56,len=1,access=rw"`
-	Off29 uint16         `sunspec:"offset=57,len=1,access=rw"`
-	Val29 uint16         `sunspec:"offset=58,len=1,access=rw"`
-	Off30 uint16         `sunspec:"offset=59,len=1,access=rw"`
-	Val30 uint16         `sunspec:"offset=60,len=1,access=rw"`
-	Off31 uint16         `sunspec:"offset=61,len=1,access=rw"`
-	Val31 uint16         `sunspec:"offset=62,len=1,access=rw"`
-	Off32 uint16         `sunspec:"offset=63,len=1,access=rw"`
-	Val32 uint16         `sunspec:"offset=64,len=1,access=rw"`
-	Off33 uint16         `sunspec:"offset=65,len=1,access=rw"`
-	Val33 uint16         `sunspec:"offset=66,len=1,access=rw"`
-	Off34 uint16         `sunspec:"offset=67,len=1,access=rw"`
-	Val34 uint16         `sunspec:"offset=68,len=1,access=rw"`
-	Off35 uint16         `sunspec:"offset=69,len=1,access=rw"`
-	Val35 uint16         `sunspec:"offset=70,len=1,access=rw"`
-	Off36 uint16         `sunspec:"offset=71,len=1,access=rw"`
-	Val36 uint16         `sunspec:"offset=72,len=1,access=rw"`
-	Off37 uint16         `sunspec:"offset=73,len=1,access=rw"`
-	Val37 uint16         `sunspec:"offset=74,len=1,access=rw"`
-	Off38 uint16         `sunspec:"offset=75,len=1,access=rw"`
-	Val38 uint16         `sunspec:"offset=76,len=1,access=rw"`
-	Off39 uint16         `sunspec:"offset=77,len=1,access=rw"`
-	Val39 uint16         `sunspec:"offset=78,len=1,access=rw"`
-	Off40 uint16         `sunspec:"offset=79,len=1,access=rw"`
-	Val40 uint16         `sunspec:"offset=80,len=1,access=rw"`
-	Ts    uint32         `sunspec:"offset=81,len=2,access=rw"`
-	Ms    uint16         `sunspec:"offset=83,len=1,access=rw"`
-	Seq   uint16         `sunspec:"offset=84,len=1,access=rw"`
-	Role  uint16         `sunspec:"offset=85,len=1,access=rw"`
-	Alg   sunspec.Enum16 `sunspec:"offset=86,len=1,access=rw"`
-	N     uint16         `sunspec:"offset=87,len=1,access=rw"`
+	X     uint16         `sunspec:"offset=0,access=rw"`
+	Off1  uint16         `sunspec:"offset=1,access=rw"`
+	Val1  uint16         `sunspec:"offset=2,access=rw"`
+	Off2  uint16         `sunspec:"offset=3,access=rw"`
+	Val2  uint16         `sunspec:"offset=4,access=rw"`
+	Off3  uint16         `sunspec:"offset=5,access=rw"`
+	Val3  uint16         `sunspec:"offset=6,access=rw"`
+	Off4  uint16         `sunspec:"offset=7,access=rw"`
+	Val4  uint16         `sunspec:"offset=8,access=rw"`
+	Off5  uint16         `sunspec:"offset=9,access=rw"`
+	Val5  uint16         `sunspec:"offset=10,access=rw"`
+	Off6  uint16         `sunspec:"offset=11,access=rw"`
+	Val6  uint16         `sunspec:"offset=12,access=rw"`
+	Off7  uint16         `sunspec:"offset=13,access=rw"`
+	Val7  uint16         `sunspec:"offset=14,access=rw"`
+	Off8  uint16         `sunspec:"offset=15,access=rw"`
+	Val8  uint16         `sunspec:"offset=16,access=rw"`
+	Off9  uint16         `sunspec:"offset=17,access=rw"`
+	Val9  uint16         `sunspec:"offset=18,access=rw"`
+	Off10 uint16         `sunspec:"offset=19,access=rw"`
+	Val10 uint16         `sunspec:"offset=20,access=rw"`
+	Off11 uint16         `sunspec:"offset=21,access=rw"`
+	Val11 uint16         `sunspec:"offset=22,access=rw"`
+	Off12 uint16         `sunspec:"offset=23,access=rw"`
+	Val12 uint16         `sunspec:"offset=24,access=rw"`
+	Off13 uint16         `sunspec:"offset=25,access=rw"`
+	Val13 uint16         `sunspec:"offset=26,access=rw"`
+	Off14 uint16         `sunspec:"offset=27,access=rw"`
+	Val14 uint16         `sunspec:"offset=28,access=rw"`
+	Off15 uint16         `sunspec:"offset=29,access=rw"`
+	Val15 uint16         `sunspec:"offset=30,access=rw"`
+	Off16 uint16         `sunspec:"offset=31,access=rw"`
+	Val16 uint16         `sunspec:"offset=32,access=rw"`
+	Off17 uint16         `sunspec:"offset=33,access=rw"`
+	Val17 uint16         `sunspec:"offset=34,access=rw"`
+	Off18 uint16         `sunspec:"offset=35,access=rw"`
+	Val18 uint16         `sunspec:"offset=36,access=rw"`
+	Off19 uint16         `sunspec:"offset=37,access=rw"`
+	Val19 uint16         `sunspec:"offset=38,access=rw"`
+	Off20 uint16         `sunspec:"offset=39,access=rw"`
+	Val20 uint16         `sunspec:"offset=40,access=rw"`
+	Off21 uint16         `sunspec:"offset=41,access=rw"`
+	Val21 uint16         `sunspec:"offset=42,access=rw"`
+	Off22 uint16         `sunspec:"offset=43,access=rw"`
+	Val22 uint16         `sunspec:"offset=44,access=rw"`
+	Off23 uint16         `sunspec:"offset=45,access=rw"`
+	Val23 uint16         `sunspec:"offset=46,access=rw"`
+	Off24 uint16         `sunspec:"offset=47,access=rw"`
+	Val24 uint16         `sunspec:"offset=48,access=rw"`
+	Off25 uint16         `sunspec:"offset=49,access=rw"`
+	Val25 uint16         `sunspec:"offset=50,access=rw"`
+	Off26 uint16         `sunspec:"offset=51,access=rw"`
+	Val26 uint16         `sunspec:"offset=52,access=rw"`
+	Off27 uint16         `sunspec:"offset=53,access=rw"`
+	Val27 uint16         `sunspec:"offset=54,access=rw"`
+	Off28 uint16         `sunspec:"offset=55,access=rw"`
+	Val28 uint16         `sunspec:"offset=56,access=rw"`
+	Off29 uint16         `sunspec:"offset=57,access=rw"`
+	Val29 uint16         `sunspec:"offset=58,access=rw"`
+	Off30 uint16         `sunspec:"offset=59,access=rw"`
+	Val30 uint16         `sunspec:"offset=60,access=rw"`
+	Off31 uint16         `sunspec:"offset=61,access=rw"`
+	Val31 uint16         `sunspec:"offset=62,access=rw"`
+	Off32 uint16         `sunspec:"offset=63,access=rw"`
+	Val32 uint16         `sunspec:"offset=64,access=rw"`
+	Off33 uint16         `sunspec:"offset=65,access=rw"`
+	Val33 uint16         `sunspec:"offset=66,access=rw"`
+	Off34 uint16         `sunspec:"offset=67,access=rw"`
+	Val34 uint16         `sunspec:"offset=68,access=rw"`
+	Off35 uint16         `sunspec:"offset=69,access=rw"`
+	Val35 uint16         `sunspec:"offset=70,access=rw"`
+	Off36 uint16         `sunspec:"offset=71,access=rw"`
+	Val36 uint16         `sunspec:"offset=72,access=rw"`
+	Off37 uint16         `sunspec:"offset=73,access=rw"`
+	Val37 uint16         `sunspec:"offset=74,access=rw"`
+	Off38 uint16         `sunspec:"offset=75,access=rw"`
+	Val38 uint16         `sunspec:"offset=76,access=rw"`
+	Off39 uint16         `sunspec:"offset=77,access=rw"`
+	Val39 uint16         `sunspec:"offset=78,access=rw"`
+	Off40 uint16         `sunspec:"offset=79,access=rw"`
+	Val40 uint16         `sunspec:"offset=80,access=rw"`
+	Ts    uint32         `sunspec:"offset=81,access=rw"`
+	Ms    uint16         `sunspec:"offset=83,access=rw"`
+	Seq   uint16         `sunspec:"offset=84,access=rw"`
+	Role  uint16         `sunspec:"offset=85,access=rw"`
+	Alg   sunspec.Enum16 `sunspec:"offset=86,access=rw"`
+	N     uint16         `sunspec:"offset=87,access=rw"`
 
 	Repeats []Block5Repeat
 }
@@ -220,100 +220,100 @@ func init() {
 				Length: 88,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: X, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "X", Description: "Number of (offset, value) pairs being written"},
-					{Id: Off1, Offset: 1, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Offset1", Description: "Offset of control register to write value to"},
-					{Id: Val1, Offset: 2, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Value1", Description: "Value to write to control register at offset"},
-					{Id: Off2, Offset: 3, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val2, Offset: 4, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off3, Offset: 5, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val3, Offset: 6, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off4, Offset: 7, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val4, Offset: 8, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off5, Offset: 9, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val5, Offset: 10, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off6, Offset: 11, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val6, Offset: 12, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off7, Offset: 13, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val7, Offset: 14, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off8, Offset: 15, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val8, Offset: 16, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off9, Offset: 17, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val9, Offset: 18, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off10, Offset: 19, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val10, Offset: 20, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off11, Offset: 21, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val11, Offset: 22, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off12, Offset: 23, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val12, Offset: 24, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off13, Offset: 25, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val13, Offset: 26, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off14, Offset: 27, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val14, Offset: 28, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off15, Offset: 29, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val15, Offset: 30, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off16, Offset: 31, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val16, Offset: 32, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off17, Offset: 33, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val17, Offset: 34, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off18, Offset: 35, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val18, Offset: 36, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off19, Offset: 37, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val19, Offset: 38, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off20, Offset: 39, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val20, Offset: 40, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off21, Offset: 41, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val21, Offset: 42, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off22, Offset: 43, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val22, Offset: 44, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off23, Offset: 45, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val23, Offset: 46, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off24, Offset: 47, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val24, Offset: 48, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off25, Offset: 49, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val25, Offset: 50, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off26, Offset: 51, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val26, Offset: 52, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off27, Offset: 53, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val27, Offset: 54, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off28, Offset: 55, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val28, Offset: 56, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off29, Offset: 57, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val29, Offset: 58, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off30, Offset: 59, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val30, Offset: 60, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off31, Offset: 61, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val31, Offset: 62, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off32, Offset: 63, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val32, Offset: 64, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off33, Offset: 65, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val33, Offset: 66, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off34, Offset: 67, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val34, Offset: 68, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off35, Offset: 69, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val35, Offset: 70, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off36, Offset: 71, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val36, Offset: 72, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off37, Offset: 73, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val37, Offset: 74, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off38, Offset: 75, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val38, Offset: 76, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off39, Offset: 77, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val39, Offset: 78, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Off40, Offset: 79, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val40, Offset: 80, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Ts, Offset: 81, Type: typelabel.Uint32, Access: "rw", Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 83, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 84, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
-					{Id: Role, Offset: 85, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Role", Description: "Signing key used 0-5"},
-					{Id: Alg, Offset: 86, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 87, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
+					{Id: X, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "X", Description: "Number of (offset, value) pairs being written"},
+					{Id: Off1, Offset: 1, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Offset1", Description: "Offset of control register to write value to"},
+					{Id: Val1, Offset: 2, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Value1", Description: "Value to write to control register at offset"},
+					{Id: Off2, Offset: 3, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val2, Offset: 4, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off3, Offset: 5, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val3, Offset: 6, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off4, Offset: 7, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val4, Offset: 8, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off5, Offset: 9, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val5, Offset: 10, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off6, Offset: 11, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val6, Offset: 12, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off7, Offset: 13, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val7, Offset: 14, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off8, Offset: 15, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val8, Offset: 16, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off9, Offset: 17, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val9, Offset: 18, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off10, Offset: 19, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val10, Offset: 20, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off11, Offset: 21, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val11, Offset: 22, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off12, Offset: 23, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val12, Offset: 24, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off13, Offset: 25, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val13, Offset: 26, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off14, Offset: 27, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val14, Offset: 28, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off15, Offset: 29, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val15, Offset: 30, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off16, Offset: 31, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val16, Offset: 32, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off17, Offset: 33, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val17, Offset: 34, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off18, Offset: 35, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val18, Offset: 36, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off19, Offset: 37, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val19, Offset: 38, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off20, Offset: 39, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val20, Offset: 40, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off21, Offset: 41, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val21, Offset: 42, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off22, Offset: 43, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val22, Offset: 44, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off23, Offset: 45, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val23, Offset: 46, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off24, Offset: 47, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val24, Offset: 48, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off25, Offset: 49, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val25, Offset: 50, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off26, Offset: 51, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val26, Offset: 52, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off27, Offset: 53, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val27, Offset: 54, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off28, Offset: 55, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val28, Offset: 56, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off29, Offset: 57, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val29, Offset: 58, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off30, Offset: 59, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val30, Offset: 60, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off31, Offset: 61, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val31, Offset: 62, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off32, Offset: 63, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val32, Offset: 64, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off33, Offset: 65, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val33, Offset: 66, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off34, Offset: 67, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val34, Offset: 68, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off35, Offset: 69, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val35, Offset: 70, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off36, Offset: 71, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val36, Offset: 72, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off37, Offset: 73, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val37, Offset: 74, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off38, Offset: 75, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val38, Offset: 76, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off39, Offset: 77, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val39, Offset: 78, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Off40, Offset: 79, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val40, Offset: 80, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Ts, Offset: 81, Type: typelabel.Uint32, Access: "rw", Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 83, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 84, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
+					{Id: Role, Offset: 85, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Role", Description: "Signing key used 0-5"},
+					{Id: Alg, Offset: 86, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 87, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: DS, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "DS", Description: "Digital Signature"},
+					{Id: DS, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "DS", Description: "Digital Signature"},
 				},
 			},
 		}})

--- a/models/model501/model.go
+++ b/models/model501/model.go
@@ -38,23 +38,23 @@ const (
 )
 
 type Block501 struct {
-	Stat     sunspec.Enum16     `sunspec:"offset=0,len=1"`
-	StatVend sunspec.Enum16     `sunspec:"offset=1,len=1"`
-	Evt      sunspec.Bitfield32 `sunspec:"offset=2,len=2"`
-	EvtVend  sunspec.Bitfield32 `sunspec:"offset=4,len=2"`
-	Ctl      sunspec.Enum16     `sunspec:"offset=6,len=1,access=rw"`
-	CtlVend  sunspec.Enum32     `sunspec:"offset=7,len=2,access=rw"`
-	CtlVal   int32              `sunspec:"offset=9,len=2,access=rw"`
-	Tms      uint32             `sunspec:"offset=11,len=2"`
-	OutA     float32            `sunspec:"offset=13,len=2"`
-	OutV     float32            `sunspec:"offset=15,len=2"`
-	OutWh    float32            `sunspec:"offset=17,len=2"`
-	OutW     float32            `sunspec:"offset=19,len=2"`
-	Tmp      float32            `sunspec:"offset=21,len=2"`
-	InA      float32            `sunspec:"offset=23,len=2"`
-	InV      float32            `sunspec:"offset=25,len=2"`
-	InWh     float32            `sunspec:"offset=27,len=2"`
-	InW      float32            `sunspec:"offset=29,len=2"`
+	Stat     sunspec.Enum16     `sunspec:"offset=0"`
+	StatVend sunspec.Enum16     `sunspec:"offset=1"`
+	Evt      sunspec.Bitfield32 `sunspec:"offset=2"`
+	EvtVend  sunspec.Bitfield32 `sunspec:"offset=4"`
+	Ctl      sunspec.Enum16     `sunspec:"offset=6,access=rw"`
+	CtlVend  sunspec.Enum32     `sunspec:"offset=7,access=rw"`
+	CtlVal   int32              `sunspec:"offset=9,access=rw"`
+	Tms      uint32             `sunspec:"offset=11"`
+	OutA     float32            `sunspec:"offset=13"`
+	OutV     float32            `sunspec:"offset=15"`
+	OutWh    float32            `sunspec:"offset=17"`
+	OutW     float32            `sunspec:"offset=19"`
+	Tmp      float32            `sunspec:"offset=21"`
+	InA      float32            `sunspec:"offset=23"`
+	InV      float32            `sunspec:"offset=25"`
+	InWh     float32            `sunspec:"offset=27"`
+	InW      float32            `sunspec:"offset=29"`
 }
 
 func (block *Block501) GetId() sunspec.ModelId {
@@ -73,23 +73,23 @@ func init() {
 				Length: 31,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Stat, Offset: 0, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Status", Description: "Enumerated value.  Module Status Code"},
-					{Id: StatVend, Offset: 1, Type: typelabel.Enum16, Length: 1, Label: "Vendor Status", Description: "Module Vendor Status Code"},
-					{Id: Evt, Offset: 2, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Bitmask value.  Module Event Flags"},
-					{Id: EvtVend, Offset: 4, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Module Event Flags", Description: "Vendor specific flags"},
-					{Id: Ctl, Offset: 6, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Control", Description: "Module Control"},
-					{Id: CtlVend, Offset: 7, Type: typelabel.Enum32, Access: "rw", Length: 2, Label: "Vendor Control", Description: "Vendor Module Control"},
-					{Id: CtlVal, Offset: 9, Type: typelabel.Int32, Access: "rw", Length: 2, Label: "Control Value", Description: "Module Control Value"},
-					{Id: Tms, Offset: 11, Type: typelabel.Uint32, Units: "Secs", Length: 2, Label: "Timestamp", Description: "Time in seconds since 2000 epoch"},
-					{Id: OutA, Offset: 13, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Output Current", Description: "Output Current"},
-					{Id: OutV, Offset: 15, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Output Voltage", Description: "Output Voltage"},
-					{Id: OutWh, Offset: 17, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Output Energy", Description: "Output Energy"},
-					{Id: OutW, Offset: 19, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Output Power", Description: "Output Power"},
-					{Id: Tmp, Offset: 21, Type: typelabel.Float32, Units: "C", Length: 2, Label: "Temp", Description: "Module Temperature"},
-					{Id: InA, Offset: 23, Type: typelabel.Float32, Units: "A", Length: 2, Label: "Input Current", Description: "Input Current"},
-					{Id: InV, Offset: 25, Type: typelabel.Float32, Units: "V", Length: 2, Label: "Input Voltage", Description: "Input Voltage"},
-					{Id: InWh, Offset: 27, Type: typelabel.Float32, Units: "Wh", Length: 2, Label: "Input Energy", Description: "Input Energy"},
-					{Id: InW, Offset: 29, Type: typelabel.Float32, Units: "W", Length: 2, Label: "Input Power", Description: "Input Power"},
+					{Id: Stat, Offset: 0, Type: typelabel.Enum16, Mandatory: true, Label: "Status", Description: "Enumerated value.  Module Status Code"},
+					{Id: StatVend, Offset: 1, Type: typelabel.Enum16, Label: "Vendor Status", Description: "Module Vendor Status Code"},
+					{Id: Evt, Offset: 2, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Bitmask value.  Module Event Flags"},
+					{Id: EvtVend, Offset: 4, Type: typelabel.Bitfield32, Label: "Vendor Module Event Flags", Description: "Vendor specific flags"},
+					{Id: Ctl, Offset: 6, Type: typelabel.Enum16, Access: "rw", Label: "Control", Description: "Module Control"},
+					{Id: CtlVend, Offset: 7, Type: typelabel.Enum32, Access: "rw", Label: "Vendor Control", Description: "Vendor Module Control"},
+					{Id: CtlVal, Offset: 9, Type: typelabel.Int32, Access: "rw", Label: "Control Value", Description: "Module Control Value"},
+					{Id: Tms, Offset: 11, Type: typelabel.Uint32, Units: "Secs", Label: "Timestamp", Description: "Time in seconds since 2000 epoch"},
+					{Id: OutA, Offset: 13, Type: typelabel.Float32, Units: "A", Label: "Output Current", Description: "Output Current"},
+					{Id: OutV, Offset: 15, Type: typelabel.Float32, Units: "V", Label: "Output Voltage", Description: "Output Voltage"},
+					{Id: OutWh, Offset: 17, Type: typelabel.Float32, Units: "Wh", Label: "Output Energy", Description: "Output Energy"},
+					{Id: OutW, Offset: 19, Type: typelabel.Float32, Units: "W", Label: "Output Power", Description: "Output Power"},
+					{Id: Tmp, Offset: 21, Type: typelabel.Float32, Units: "C", Label: "Temp", Description: "Module Temperature"},
+					{Id: InA, Offset: 23, Type: typelabel.Float32, Units: "A", Label: "Input Current", Description: "Input Current"},
+					{Id: InV, Offset: 25, Type: typelabel.Float32, Units: "V", Label: "Input Voltage", Description: "Input Voltage"},
+					{Id: InWh, Offset: 27, Type: typelabel.Float32, Units: "Wh", Label: "Input Energy", Description: "Input Energy"},
+					{Id: InW, Offset: 29, Type: typelabel.Float32, Units: "W", Label: "Input Power", Description: "Input Power"},
 				},
 			},
 		}})

--- a/models/model502/model.go
+++ b/models/model502/model.go
@@ -42,27 +42,27 @@ const (
 )
 
 type Block502 struct {
-	A_SF     sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	V_SF     sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	W_SF     sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	Wh_SF    sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	Stat     sunspec.Enum16      `sunspec:"offset=4,len=1"`
-	StatVend sunspec.Enum16      `sunspec:"offset=5,len=1"`
-	Evt      sunspec.Bitfield32  `sunspec:"offset=6,len=2"`
-	EvtVend  sunspec.Bitfield32  `sunspec:"offset=8,len=2"`
-	Ctl      sunspec.Enum16      `sunspec:"offset=10,len=1,access=rw"`
-	CtlVend  sunspec.Enum32      `sunspec:"offset=11,len=2,access=rw"`
-	CtlVal   int32               `sunspec:"offset=13,len=2,access=rw"`
-	Tms      uint32              `sunspec:"offset=15,len=2"`
-	OutA     int16               `sunspec:"offset=17,len=1,sf=A_SF"`
-	OutV     int16               `sunspec:"offset=18,len=1,sf=V_SF"`
-	OutWh    sunspec.Acc32       `sunspec:"offset=19,len=2,sf=Wh_SF"`
-	OutPw    int16               `sunspec:"offset=21,len=1,sf=W_SF"`
-	Tmp      int16               `sunspec:"offset=22,len=1"`
-	InA      int16               `sunspec:"offset=23,len=1,sf=A_SF"`
-	InV      int16               `sunspec:"offset=24,len=1,sf=V_SF"`
-	InWh     sunspec.Acc32       `sunspec:"offset=25,len=2,sf=Wh_SF"`
-	InW      int16               `sunspec:"offset=27,len=1,sf=W_SF"`
+	A_SF     sunspec.ScaleFactor `sunspec:"offset=0"`
+	V_SF     sunspec.ScaleFactor `sunspec:"offset=1"`
+	W_SF     sunspec.ScaleFactor `sunspec:"offset=2"`
+	Wh_SF    sunspec.ScaleFactor `sunspec:"offset=3"`
+	Stat     sunspec.Enum16      `sunspec:"offset=4"`
+	StatVend sunspec.Enum16      `sunspec:"offset=5"`
+	Evt      sunspec.Bitfield32  `sunspec:"offset=6"`
+	EvtVend  sunspec.Bitfield32  `sunspec:"offset=8"`
+	Ctl      sunspec.Enum16      `sunspec:"offset=10,access=rw"`
+	CtlVend  sunspec.Enum32      `sunspec:"offset=11,access=rw"`
+	CtlVal   int32               `sunspec:"offset=13,access=rw"`
+	Tms      uint32              `sunspec:"offset=15"`
+	OutA     int16               `sunspec:"offset=17,sf=A_SF"`
+	OutV     int16               `sunspec:"offset=18,sf=V_SF"`
+	OutWh    sunspec.Acc32       `sunspec:"offset=19,sf=Wh_SF"`
+	OutPw    int16               `sunspec:"offset=21,sf=W_SF"`
+	Tmp      int16               `sunspec:"offset=22"`
+	InA      int16               `sunspec:"offset=23,sf=A_SF"`
+	InV      int16               `sunspec:"offset=24,sf=V_SF"`
+	InWh     sunspec.Acc32       `sunspec:"offset=25,sf=Wh_SF"`
+	InW      int16               `sunspec:"offset=27,sf=W_SF"`
 }
 
 func (block *Block502) GetId() sunspec.ModelId {
@@ -81,27 +81,27 @@ func init() {
 				Length: 28,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: A_SF, Offset: 0, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: V_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: W_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Wh_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Stat, Offset: 4, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Status", Description: "Enumerated value.  Module Status Code"},
-					{Id: StatVend, Offset: 5, Type: typelabel.Enum16, Length: 1, Label: "Vendor Status", Description: "Module Vendor Status Code"},
-					{Id: Evt, Offset: 6, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Events", Description: "Bitmask value.  Module Event Flags"},
-					{Id: EvtVend, Offset: 8, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Module Event Flags", Description: "Vendor specific flags"},
-					{Id: Ctl, Offset: 10, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Control", Description: "Module Control"},
-					{Id: CtlVend, Offset: 11, Type: typelabel.Enum32, Access: "rw", Length: 2, Label: "Vendor Control", Description: "Vendor Module Control"},
-					{Id: CtlVal, Offset: 13, Type: typelabel.Int32, Access: "rw", Length: 2, Label: "Control Value", Description: "Module Control Value"},
-					{Id: Tms, Offset: 15, Type: typelabel.Uint32, Units: "Secs", Length: 2, Label: "Timestamp", Description: "Time in seconds since 2000 epoch"},
-					{Id: OutA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Output Current", Description: "Output Current"},
-					{Id: OutV, Offset: 18, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Output Voltage", Description: "Output Voltage"},
-					{Id: OutWh, Offset: 19, Type: typelabel.Acc32, ScaleFactor: "Wh_SF", Units: "Wh", Length: 2, Label: "Output Energy", Description: "Output Energy"},
-					{Id: OutPw, Offset: 21, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Output Power", Description: "Output Power"},
-					{Id: Tmp, Offset: 22, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Temp", Description: "Module Temperature"},
-					{Id: InA, Offset: 23, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Input Current", Description: "Input Current"},
-					{Id: InV, Offset: 24, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Input Voltage", Description: "Input Voltage"},
-					{Id: InWh, Offset: 25, Type: typelabel.Acc32, ScaleFactor: "Wh_SF", Units: "Wh", Length: 2, Label: "Input Energy", Description: "Input Energy"},
-					{Id: InW, Offset: 27, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Input Power", Description: "Input Power"},
+					{Id: A_SF, Offset: 0, Type: typelabel.ScaleFactor},
+					{Id: V_SF, Offset: 1, Type: typelabel.ScaleFactor},
+					{Id: W_SF, Offset: 2, Type: typelabel.ScaleFactor},
+					{Id: Wh_SF, Offset: 3, Type: typelabel.ScaleFactor},
+					{Id: Stat, Offset: 4, Type: typelabel.Enum16, Mandatory: true, Label: "Status", Description: "Enumerated value.  Module Status Code"},
+					{Id: StatVend, Offset: 5, Type: typelabel.Enum16, Label: "Vendor Status", Description: "Module Vendor Status Code"},
+					{Id: Evt, Offset: 6, Type: typelabel.Bitfield32, Mandatory: true, Label: "Events", Description: "Bitmask value.  Module Event Flags"},
+					{Id: EvtVend, Offset: 8, Type: typelabel.Bitfield32, Label: "Vendor Module Event Flags", Description: "Vendor specific flags"},
+					{Id: Ctl, Offset: 10, Type: typelabel.Enum16, Access: "rw", Label: "Control", Description: "Module Control"},
+					{Id: CtlVend, Offset: 11, Type: typelabel.Enum32, Access: "rw", Label: "Vendor Control", Description: "Vendor Module Control"},
+					{Id: CtlVal, Offset: 13, Type: typelabel.Int32, Access: "rw", Label: "Control Value", Description: "Module Control Value"},
+					{Id: Tms, Offset: 15, Type: typelabel.Uint32, Units: "Secs", Label: "Timestamp", Description: "Time in seconds since 2000 epoch"},
+					{Id: OutA, Offset: 17, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Output Current", Description: "Output Current"},
+					{Id: OutV, Offset: 18, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Output Voltage", Description: "Output Voltage"},
+					{Id: OutWh, Offset: 19, Type: typelabel.Acc32, ScaleFactor: "Wh_SF", Units: "Wh", Label: "Output Energy", Description: "Output Energy"},
+					{Id: OutPw, Offset: 21, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Output Power", Description: "Output Power"},
+					{Id: Tmp, Offset: 22, Type: typelabel.Int16, Units: "C", Label: "Temp", Description: "Module Temperature"},
+					{Id: InA, Offset: 23, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Input Current", Description: "Input Current"},
+					{Id: InV, Offset: 24, Type: typelabel.Int16, ScaleFactor: "V_SF", Units: "V", Label: "Input Voltage", Description: "Input Voltage"},
+					{Id: InWh, Offset: 25, Type: typelabel.Acc32, ScaleFactor: "Wh_SF", Units: "Wh", Label: "Input Energy", Description: "Input Energy"},
+					{Id: InW, Offset: 27, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Input Power", Description: "Input Power"},
 				},
 			},
 		}})

--- a/models/model6/model.go
+++ b/models/model6/model.go
@@ -111,99 +111,99 @@ const (
 )
 
 type Block6Repeat struct {
-	DS uint16 `sunspec:"offset=0,len=1,access=rw"`
+	DS uint16 `sunspec:"offset=0,access=rw"`
 }
 
 type Block6 struct {
-	X     uint16         `sunspec:"offset=0,len=1,access=rw"`
-	Off   uint16         `sunspec:"offset=1,len=1,access=rw"`
-	Val1  uint16         `sunspec:"offset=2,len=1,access=rw"`
-	Val2  uint16         `sunspec:"offset=3,len=1,access=rw"`
-	Val3  uint16         `sunspec:"offset=4,len=1,access=rw"`
-	Val4  uint16         `sunspec:"offset=5,len=1,access=rw"`
-	Val5  uint16         `sunspec:"offset=6,len=1,access=rw"`
-	Val6  uint16         `sunspec:"offset=7,len=1,access=rw"`
-	Val7  uint16         `sunspec:"offset=8,len=1,access=rw"`
-	Val8  uint16         `sunspec:"offset=9,len=1,access=rw"`
-	Val9  uint16         `sunspec:"offset=10,len=1,access=rw"`
-	Val10 uint16         `sunspec:"offset=11,len=1,access=rw"`
-	Val11 uint16         `sunspec:"offset=12,len=1,access=rw"`
-	Val12 uint16         `sunspec:"offset=13,len=1,access=rw"`
-	Val13 uint16         `sunspec:"offset=14,len=1,access=rw"`
-	Val14 uint16         `sunspec:"offset=15,len=1,access=rw"`
-	Val15 uint16         `sunspec:"offset=16,len=1,access=rw"`
-	Val16 uint16         `sunspec:"offset=17,len=1,access=rw"`
-	Val17 uint16         `sunspec:"offset=18,len=1,access=rw"`
-	Val18 uint16         `sunspec:"offset=19,len=1,access=rw"`
-	Val19 uint16         `sunspec:"offset=20,len=1,access=rw"`
-	Val20 uint16         `sunspec:"offset=21,len=1,access=rw"`
-	Val21 uint16         `sunspec:"offset=22,len=1,access=rw"`
-	Val22 uint16         `sunspec:"offset=23,len=1,access=rw"`
-	Val23 uint16         `sunspec:"offset=24,len=1,access=rw"`
-	Val24 uint16         `sunspec:"offset=25,len=1,access=rw"`
-	Val25 uint16         `sunspec:"offset=26,len=1,access=rw"`
-	Val26 uint16         `sunspec:"offset=27,len=1,access=rw"`
-	Val27 uint16         `sunspec:"offset=28,len=1,access=rw"`
-	Val28 uint16         `sunspec:"offset=29,len=1,access=rw"`
-	Val29 uint16         `sunspec:"offset=30,len=1,access=rw"`
-	Val30 uint16         `sunspec:"offset=31,len=1,access=rw"`
-	Val31 uint16         `sunspec:"offset=32,len=1,access=rw"`
-	Val32 uint16         `sunspec:"offset=33,len=1,access=rw"`
-	Val33 uint16         `sunspec:"offset=34,len=1,access=rw"`
-	Val34 uint16         `sunspec:"offset=35,len=1,access=rw"`
-	Val35 uint16         `sunspec:"offset=36,len=1,access=rw"`
-	Val36 uint16         `sunspec:"offset=37,len=1,access=rw"`
-	Val37 uint16         `sunspec:"offset=38,len=1,access=rw"`
-	Val38 uint16         `sunspec:"offset=39,len=1,access=rw"`
-	Val39 uint16         `sunspec:"offset=40,len=1,access=rw"`
-	Val40 uint16         `sunspec:"offset=41,len=1,access=rw"`
-	Val41 uint16         `sunspec:"offset=42,len=1,access=rw"`
-	Val42 uint16         `sunspec:"offset=43,len=1,access=rw"`
-	Val43 uint16         `sunspec:"offset=44,len=1,access=rw"`
-	Val44 uint16         `sunspec:"offset=45,len=1,access=rw"`
-	Val45 uint16         `sunspec:"offset=46,len=1,access=rw"`
-	Val46 uint16         `sunspec:"offset=47,len=1,access=rw"`
-	Val47 uint16         `sunspec:"offset=48,len=1,access=rw"`
-	Val48 uint16         `sunspec:"offset=49,len=1,access=rw"`
-	Val49 uint16         `sunspec:"offset=50,len=1,access=rw"`
-	Val50 uint16         `sunspec:"offset=51,len=1,access=rw"`
-	Val51 uint16         `sunspec:"offset=52,len=1,access=rw"`
-	Val52 uint16         `sunspec:"offset=53,len=1,access=rw"`
-	Val53 uint16         `sunspec:"offset=54,len=1,access=rw"`
-	Val54 uint16         `sunspec:"offset=55,len=1,access=rw"`
-	Val55 uint16         `sunspec:"offset=56,len=1,access=rw"`
-	Val56 uint16         `sunspec:"offset=57,len=1,access=rw"`
-	Val57 uint16         `sunspec:"offset=58,len=1,access=rw"`
-	Val58 uint16         `sunspec:"offset=59,len=1,access=rw"`
-	Val59 uint16         `sunspec:"offset=60,len=1,access=rw"`
-	Val60 uint16         `sunspec:"offset=61,len=1,access=rw"`
-	Val61 uint16         `sunspec:"offset=62,len=1,access=rw"`
-	Val62 uint16         `sunspec:"offset=63,len=1,access=rw"`
-	Val63 uint16         `sunspec:"offset=64,len=1,access=rw"`
-	Val64 uint16         `sunspec:"offset=65,len=1,access=rw"`
-	Val65 uint16         `sunspec:"offset=66,len=1,access=rw"`
-	Val66 uint16         `sunspec:"offset=67,len=1,access=rw"`
-	Val67 uint16         `sunspec:"offset=68,len=1,access=rw"`
-	Val68 uint16         `sunspec:"offset=69,len=1,access=rw"`
-	Val69 uint16         `sunspec:"offset=70,len=1,access=rw"`
-	Val70 uint16         `sunspec:"offset=71,len=1,access=rw"`
-	Val71 uint16         `sunspec:"offset=72,len=1,access=rw"`
-	Val72 uint16         `sunspec:"offset=73,len=1,access=rw"`
-	Val73 uint16         `sunspec:"offset=74,len=1,access=rw"`
-	Val74 uint16         `sunspec:"offset=75,len=1,access=rw"`
-	Val75 uint16         `sunspec:"offset=76,len=1,access=rw"`
-	Val76 uint16         `sunspec:"offset=77,len=1,access=rw"`
-	Val77 uint16         `sunspec:"offset=78,len=1,access=rw"`
-	Val78 uint16         `sunspec:"offset=79,len=1,access=rw"`
-	Val79 uint16         `sunspec:"offset=80,len=1,access=rw"`
-	Val80 uint16         `sunspec:"offset=81,len=1,access=rw"`
-	Ts    uint32         `sunspec:"offset=82,len=2,access=rw"`
-	Ms    uint16         `sunspec:"offset=84,len=1,access=rw"`
-	Seq   uint16         `sunspec:"offset=85,len=1,access=rw"`
-	Role  uint16         `sunspec:"offset=86,len=1,access=rw"`
-	Rsrvd sunspec.Pad    `sunspec:"offset=87,len=1,access=rw"`
-	Alg   sunspec.Enum16 `sunspec:"offset=88,len=1,access=rw"`
-	N     uint16         `sunspec:"offset=89,len=1,access=rw"`
+	X     uint16         `sunspec:"offset=0,access=rw"`
+	Off   uint16         `sunspec:"offset=1,access=rw"`
+	Val1  uint16         `sunspec:"offset=2,access=rw"`
+	Val2  uint16         `sunspec:"offset=3,access=rw"`
+	Val3  uint16         `sunspec:"offset=4,access=rw"`
+	Val4  uint16         `sunspec:"offset=5,access=rw"`
+	Val5  uint16         `sunspec:"offset=6,access=rw"`
+	Val6  uint16         `sunspec:"offset=7,access=rw"`
+	Val7  uint16         `sunspec:"offset=8,access=rw"`
+	Val8  uint16         `sunspec:"offset=9,access=rw"`
+	Val9  uint16         `sunspec:"offset=10,access=rw"`
+	Val10 uint16         `sunspec:"offset=11,access=rw"`
+	Val11 uint16         `sunspec:"offset=12,access=rw"`
+	Val12 uint16         `sunspec:"offset=13,access=rw"`
+	Val13 uint16         `sunspec:"offset=14,access=rw"`
+	Val14 uint16         `sunspec:"offset=15,access=rw"`
+	Val15 uint16         `sunspec:"offset=16,access=rw"`
+	Val16 uint16         `sunspec:"offset=17,access=rw"`
+	Val17 uint16         `sunspec:"offset=18,access=rw"`
+	Val18 uint16         `sunspec:"offset=19,access=rw"`
+	Val19 uint16         `sunspec:"offset=20,access=rw"`
+	Val20 uint16         `sunspec:"offset=21,access=rw"`
+	Val21 uint16         `sunspec:"offset=22,access=rw"`
+	Val22 uint16         `sunspec:"offset=23,access=rw"`
+	Val23 uint16         `sunspec:"offset=24,access=rw"`
+	Val24 uint16         `sunspec:"offset=25,access=rw"`
+	Val25 uint16         `sunspec:"offset=26,access=rw"`
+	Val26 uint16         `sunspec:"offset=27,access=rw"`
+	Val27 uint16         `sunspec:"offset=28,access=rw"`
+	Val28 uint16         `sunspec:"offset=29,access=rw"`
+	Val29 uint16         `sunspec:"offset=30,access=rw"`
+	Val30 uint16         `sunspec:"offset=31,access=rw"`
+	Val31 uint16         `sunspec:"offset=32,access=rw"`
+	Val32 uint16         `sunspec:"offset=33,access=rw"`
+	Val33 uint16         `sunspec:"offset=34,access=rw"`
+	Val34 uint16         `sunspec:"offset=35,access=rw"`
+	Val35 uint16         `sunspec:"offset=36,access=rw"`
+	Val36 uint16         `sunspec:"offset=37,access=rw"`
+	Val37 uint16         `sunspec:"offset=38,access=rw"`
+	Val38 uint16         `sunspec:"offset=39,access=rw"`
+	Val39 uint16         `sunspec:"offset=40,access=rw"`
+	Val40 uint16         `sunspec:"offset=41,access=rw"`
+	Val41 uint16         `sunspec:"offset=42,access=rw"`
+	Val42 uint16         `sunspec:"offset=43,access=rw"`
+	Val43 uint16         `sunspec:"offset=44,access=rw"`
+	Val44 uint16         `sunspec:"offset=45,access=rw"`
+	Val45 uint16         `sunspec:"offset=46,access=rw"`
+	Val46 uint16         `sunspec:"offset=47,access=rw"`
+	Val47 uint16         `sunspec:"offset=48,access=rw"`
+	Val48 uint16         `sunspec:"offset=49,access=rw"`
+	Val49 uint16         `sunspec:"offset=50,access=rw"`
+	Val50 uint16         `sunspec:"offset=51,access=rw"`
+	Val51 uint16         `sunspec:"offset=52,access=rw"`
+	Val52 uint16         `sunspec:"offset=53,access=rw"`
+	Val53 uint16         `sunspec:"offset=54,access=rw"`
+	Val54 uint16         `sunspec:"offset=55,access=rw"`
+	Val55 uint16         `sunspec:"offset=56,access=rw"`
+	Val56 uint16         `sunspec:"offset=57,access=rw"`
+	Val57 uint16         `sunspec:"offset=58,access=rw"`
+	Val58 uint16         `sunspec:"offset=59,access=rw"`
+	Val59 uint16         `sunspec:"offset=60,access=rw"`
+	Val60 uint16         `sunspec:"offset=61,access=rw"`
+	Val61 uint16         `sunspec:"offset=62,access=rw"`
+	Val62 uint16         `sunspec:"offset=63,access=rw"`
+	Val63 uint16         `sunspec:"offset=64,access=rw"`
+	Val64 uint16         `sunspec:"offset=65,access=rw"`
+	Val65 uint16         `sunspec:"offset=66,access=rw"`
+	Val66 uint16         `sunspec:"offset=67,access=rw"`
+	Val67 uint16         `sunspec:"offset=68,access=rw"`
+	Val68 uint16         `sunspec:"offset=69,access=rw"`
+	Val69 uint16         `sunspec:"offset=70,access=rw"`
+	Val70 uint16         `sunspec:"offset=71,access=rw"`
+	Val71 uint16         `sunspec:"offset=72,access=rw"`
+	Val72 uint16         `sunspec:"offset=73,access=rw"`
+	Val73 uint16         `sunspec:"offset=74,access=rw"`
+	Val74 uint16         `sunspec:"offset=75,access=rw"`
+	Val75 uint16         `sunspec:"offset=76,access=rw"`
+	Val76 uint16         `sunspec:"offset=77,access=rw"`
+	Val77 uint16         `sunspec:"offset=78,access=rw"`
+	Val78 uint16         `sunspec:"offset=79,access=rw"`
+	Val79 uint16         `sunspec:"offset=80,access=rw"`
+	Val80 uint16         `sunspec:"offset=81,access=rw"`
+	Ts    uint32         `sunspec:"offset=82,access=rw"`
+	Ms    uint16         `sunspec:"offset=84,access=rw"`
+	Seq   uint16         `sunspec:"offset=85,access=rw"`
+	Role  uint16         `sunspec:"offset=86,access=rw"`
+	Rsrvd sunspec.Pad    `sunspec:"offset=87,access=rw"`
+	Alg   sunspec.Enum16 `sunspec:"offset=88,access=rw"`
+	N     uint16         `sunspec:"offset=89,access=rw"`
 
 	Repeats []Block6Repeat
 }
@@ -224,102 +224,102 @@ func init() {
 				Length: 90,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: X, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "X", Description: "Number of (offset, value) pairs being written"},
-					{Id: Off, Offset: 1, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Offset", Description: "Starting offset for write operation"},
-					{Id: Val1, Offset: 2, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Value1", Description: "Value to write to control register at offset"},
-					{Id: Val2, Offset: 3, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val3, Offset: 4, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val4, Offset: 5, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val5, Offset: 6, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val6, Offset: 7, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val7, Offset: 8, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val8, Offset: 9, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val9, Offset: 10, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val10, Offset: 11, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val11, Offset: 12, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val12, Offset: 13, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val13, Offset: 14, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val14, Offset: 15, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val15, Offset: 16, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val16, Offset: 17, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val17, Offset: 18, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val18, Offset: 19, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val19, Offset: 20, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val20, Offset: 21, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val21, Offset: 22, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val22, Offset: 23, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val23, Offset: 24, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val24, Offset: 25, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val25, Offset: 26, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val26, Offset: 27, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val27, Offset: 28, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val28, Offset: 29, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val29, Offset: 30, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val30, Offset: 31, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val31, Offset: 32, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val32, Offset: 33, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val33, Offset: 34, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val34, Offset: 35, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val35, Offset: 36, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val36, Offset: 37, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val37, Offset: 38, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val38, Offset: 39, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val39, Offset: 40, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val40, Offset: 41, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val41, Offset: 42, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val42, Offset: 43, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val43, Offset: 44, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val44, Offset: 45, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val45, Offset: 46, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val46, Offset: 47, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val47, Offset: 48, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val48, Offset: 49, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val49, Offset: 50, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val50, Offset: 51, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val51, Offset: 52, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val52, Offset: 53, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val53, Offset: 54, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val54, Offset: 55, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val55, Offset: 56, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val56, Offset: 57, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val57, Offset: 58, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val58, Offset: 59, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val59, Offset: 60, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val60, Offset: 61, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val61, Offset: 62, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val62, Offset: 63, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val63, Offset: 64, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val64, Offset: 65, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val65, Offset: 66, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val66, Offset: 67, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val67, Offset: 68, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val68, Offset: 69, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val69, Offset: 70, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val70, Offset: 71, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val71, Offset: 72, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val72, Offset: 73, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val73, Offset: 74, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val74, Offset: 75, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val75, Offset: 76, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val76, Offset: 77, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val77, Offset: 78, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val78, Offset: 79, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val79, Offset: 80, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Val80, Offset: 81, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Ts, Offset: 82, Type: typelabel.Uint32, Access: "rw", Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 84, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 85, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
-					{Id: Role, Offset: 86, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Role", Description: "Signing key used 0-5"},
-					{Id: Rsrvd, Offset: 87, Type: typelabel.Pad, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Alg, Offset: 88, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 89, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
+					{Id: X, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "X", Description: "Number of (offset, value) pairs being written"},
+					{Id: Off, Offset: 1, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Offset", Description: "Starting offset for write operation"},
+					{Id: Val1, Offset: 2, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Value1", Description: "Value to write to control register at offset"},
+					{Id: Val2, Offset: 3, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val3, Offset: 4, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val4, Offset: 5, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val5, Offset: 6, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val6, Offset: 7, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val7, Offset: 8, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val8, Offset: 9, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val9, Offset: 10, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val10, Offset: 11, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val11, Offset: 12, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val12, Offset: 13, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val13, Offset: 14, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val14, Offset: 15, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val15, Offset: 16, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val16, Offset: 17, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val17, Offset: 18, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val18, Offset: 19, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val19, Offset: 20, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val20, Offset: 21, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val21, Offset: 22, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val22, Offset: 23, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val23, Offset: 24, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val24, Offset: 25, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val25, Offset: 26, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val26, Offset: 27, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val27, Offset: 28, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val28, Offset: 29, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val29, Offset: 30, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val30, Offset: 31, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val31, Offset: 32, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val32, Offset: 33, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val33, Offset: 34, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val34, Offset: 35, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val35, Offset: 36, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val36, Offset: 37, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val37, Offset: 38, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val38, Offset: 39, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val39, Offset: 40, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val40, Offset: 41, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val41, Offset: 42, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val42, Offset: 43, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val43, Offset: 44, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val44, Offset: 45, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val45, Offset: 46, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val46, Offset: 47, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val47, Offset: 48, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val48, Offset: 49, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val49, Offset: 50, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val50, Offset: 51, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val51, Offset: 52, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val52, Offset: 53, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val53, Offset: 54, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val54, Offset: 55, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val55, Offset: 56, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val56, Offset: 57, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val57, Offset: 58, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val58, Offset: 59, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val59, Offset: 60, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val60, Offset: 61, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val61, Offset: 62, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val62, Offset: 63, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val63, Offset: 64, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val64, Offset: 65, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val65, Offset: 66, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val66, Offset: 67, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val67, Offset: 68, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val68, Offset: 69, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val69, Offset: 70, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val70, Offset: 71, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val71, Offset: 72, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val72, Offset: 73, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val73, Offset: 74, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val74, Offset: 75, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val75, Offset: 76, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val76, Offset: 77, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val77, Offset: 78, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val78, Offset: 79, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val79, Offset: 80, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Val80, Offset: 81, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Ts, Offset: 82, Type: typelabel.Uint32, Access: "rw", Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 84, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 85, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
+					{Id: Role, Offset: 86, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Role", Description: "Signing key used 0-5"},
+					{Id: Rsrvd, Offset: 87, Type: typelabel.Pad, Access: "rw", Mandatory: true},
+					{Id: Alg, Offset: 88, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 89, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: DS, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "DS", Description: "Digital Signature"},
+					{Id: DS, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "DS", Description: "Digital Signature"},
 				},
 			},
 		}})

--- a/models/model601/model.go
+++ b/models/model601/model.go
@@ -42,28 +42,28 @@ const (
 
 type Block601Repeat struct {
 	Id     string             `sunspec:"offset=0,len=8"`
-	ElTrgt int32              `sunspec:"offset=8,len=2,sf=Dgr_SF"`
-	AzTrgt int32              `sunspec:"offset=10,len=2,sf=Dgr_SF"`
-	ElPos  int32              `sunspec:"offset=12,len=2,sf=Dgr_SF"`
-	AzPos  int32              `sunspec:"offset=14,len=2,sf=Dgr_SF"`
-	ElCtl  int32              `sunspec:"offset=16,len=2,sf=Dgr_SF,access=rw"`
-	AzCtl  int32              `sunspec:"offset=18,len=2,sf=Dgr_SF,access=rw"`
-	Ctl    sunspec.Enum16     `sunspec:"offset=20,len=1,access=rw"`
-	Alm    sunspec.Bitfield16 `sunspec:"offset=21,len=1"`
+	ElTrgt int32              `sunspec:"offset=8,sf=Dgr_SF"`
+	AzTrgt int32              `sunspec:"offset=10,sf=Dgr_SF"`
+	ElPos  int32              `sunspec:"offset=12,sf=Dgr_SF"`
+	AzPos  int32              `sunspec:"offset=14,sf=Dgr_SF"`
+	ElCtl  int32              `sunspec:"offset=16,sf=Dgr_SF,access=rw"`
+	AzCtl  int32              `sunspec:"offset=18,sf=Dgr_SF,access=rw"`
+	Ctl    sunspec.Enum16     `sunspec:"offset=20,access=rw"`
+	Alm    sunspec.Bitfield16 `sunspec:"offset=21"`
 }
 
 type Block601 struct {
 	Nam       string              `sunspec:"offset=0,len=8"`
-	Typ       sunspec.Enum16      `sunspec:"offset=8,len=1"`
+	Typ       sunspec.Enum16      `sunspec:"offset=8"`
 	DtLoc     string              `sunspec:"offset=9,len=5"`
 	TmLoc     string              `sunspec:"offset=14,len=3"`
-	Day       uint16              `sunspec:"offset=17,len=1"`
-	GlblElCtl int32               `sunspec:"offset=18,len=2,sf=Dgr_SF,access=rw"`
-	GlblAzCtl int32               `sunspec:"offset=20,len=2,sf=Dgr_SF,access=rw"`
-	GlblCtl   sunspec.Enum16      `sunspec:"offset=22,len=1,access=rw"`
-	GlblAlm   sunspec.Bitfield16  `sunspec:"offset=23,len=1"`
-	Dgr_SF    sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	N         uint16              `sunspec:"offset=25,len=1"`
+	Day       uint16              `sunspec:"offset=17"`
+	GlblElCtl int32               `sunspec:"offset=18,sf=Dgr_SF,access=rw"`
+	GlblAzCtl int32               `sunspec:"offset=20,sf=Dgr_SF,access=rw"`
+	GlblCtl   sunspec.Enum16      `sunspec:"offset=22,access=rw"`
+	GlblAlm   sunspec.Bitfield16  `sunspec:"offset=23"`
+	Dgr_SF    sunspec.ScaleFactor `sunspec:"offset=24"`
+	N         uint16              `sunspec:"offset=25"`
 
 	Repeats []Block601Repeat
 }
@@ -85,16 +85,16 @@ func init() {
 				Type:   types.BlockFixed,
 				Points: []types.Point{
 					{Id: Nam, Offset: 0, Type: typelabel.String, Length: 8, Label: "Controller", Description: "Descriptive name for this control unit"},
-					{Id: Typ, Offset: 8, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Type", Description: "Type of tracker"},
+					{Id: Typ, Offset: 8, Type: typelabel.Enum16, Mandatory: true, Label: "Type", Description: "Type of tracker"},
 					{Id: DtLoc, Offset: 9, Type: typelabel.String, Units: "YYYYMMDD", Length: 5, Label: "Date", Description: "Local date in YYYYMMDD format"},
 					{Id: TmLoc, Offset: 14, Type: typelabel.String, Units: "hhmmss", Length: 3, Label: "Time", Description: "24 hour local time stamp to second"},
-					{Id: Day, Offset: 17, Type: typelabel.Uint16, Length: 1, Label: "Day", Description: "Number of the day in the year (1-366)"},
-					{Id: GlblElCtl, Offset: 18, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Length: 2, Label: "Manual Elevation", Description: "Global manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
-					{Id: GlblAzCtl, Offset: 20, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Length: 2, Label: "Manual Azimuth", Description: "Global manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type"},
-					{Id: GlblCtl, Offset: 22, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Global Mode", Description: "Global Control register operates on all trackers. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete."},
-					{Id: GlblAlm, Offset: 23, Type: typelabel.Bitfield16, Length: 1, Label: "Global Alarm", Description: "Global tracker alarm conditions"},
-					{Id: Dgr_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "SF", Description: "Scale Factor for targets and position measurements in degrees"},
-					{Id: N, Offset: 25, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Trackers", Description: "Number of trackers being controlled.  Size of repeating block."},
+					{Id: Day, Offset: 17, Type: typelabel.Uint16, Label: "Day", Description: "Number of the day in the year (1-366)"},
+					{Id: GlblElCtl, Offset: 18, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Label: "Manual Elevation", Description: "Global manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
+					{Id: GlblAzCtl, Offset: 20, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Label: "Manual Azimuth", Description: "Global manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type"},
+					{Id: GlblCtl, Offset: 22, Type: typelabel.Enum16, Access: "rw", Label: "Global Mode", Description: "Global Control register operates on all trackers. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete."},
+					{Id: GlblAlm, Offset: 23, Type: typelabel.Bitfield16, Label: "Global Alarm", Description: "Global tracker alarm conditions"},
+					{Id: Dgr_SF, Offset: 24, Type: typelabel.ScaleFactor, Mandatory: true, Label: "SF", Description: "Scale Factor for targets and position measurements in degrees"},
+					{Id: N, Offset: 25, Type: typelabel.Uint16, Mandatory: true, Label: "Trackers", Description: "Number of trackers being controlled.  Size of repeating block."},
 				},
 			},
 			{Name: "tracker",
@@ -102,14 +102,14 @@ func init() {
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
 					{Id: Id, Offset: 0, Type: typelabel.String, Length: 8, Label: "Tracker", Description: "Descriptive name for this tracker unit"},
-					{Id: ElTrgt, Offset: 8, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Length: 2, Label: "Target Elevation", Description: "Auto target elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
-					{Id: AzTrgt, Offset: 10, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Length: 2, Label: "Target Azimuth", Description: "Auto target azimuth  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type"},
-					{Id: ElPos, Offset: 12, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Length: 2, Label: "Elevation", Description: "Actual elevation position  in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
-					{Id: AzPos, Offset: 14, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Length: 2, Label: "Azimuth", Description: "Actual azimuth position  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type"},
-					{Id: ElCtl, Offset: 16, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Length: 2, Label: "Manual Elevation", Description: "Manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
-					{Id: AzCtl, Offset: 18, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Length: 2, Label: "Manual Azimuth", Description: "Manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type"},
-					{Id: Ctl, Offset: 20, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Mode", Description: "Control register. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete."},
-					{Id: Alm, Offset: 21, Type: typelabel.Bitfield16, Length: 1, Label: "Alarm", Description: "Tracker alarm conditions"},
+					{Id: ElTrgt, Offset: 8, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Label: "Target Elevation", Description: "Auto target elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
+					{Id: AzTrgt, Offset: 10, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Label: "Target Azimuth", Description: "Auto target azimuth  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type"},
+					{Id: ElPos, Offset: 12, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Label: "Elevation", Description: "Actual elevation position  in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
+					{Id: AzPos, Offset: 14, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Label: "Azimuth", Description: "Actual azimuth position  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type"},
+					{Id: ElCtl, Offset: 16, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Label: "Manual Elevation", Description: "Manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"},
+					{Id: AzCtl, Offset: 18, Type: typelabel.Int32, ScaleFactor: "Dgr_SF", Units: "Degrees", Access: "rw", Label: "Manual Azimuth", Description: "Manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type"},
+					{Id: Ctl, Offset: 20, Type: typelabel.Enum16, Access: "rw", Label: "Mode", Description: "Control register. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete."},
+					{Id: Alm, Offset: 21, Type: typelabel.Bitfield16, Label: "Alarm", Description: "Tracker alarm conditions"},
 				},
 			},
 		}})

--- a/models/model63001/model.go
+++ b/models/model63001/model.go
@@ -87,79 +87,79 @@ const (
 )
 
 type Block63001Repeat struct {
-	sunssf_8  sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	int16_11  int16               `sunspec:"offset=1,len=1,sf=sunssf_8,access=rw"`
-	int16_12  int16               `sunspec:"offset=2,len=1,sf=sunssf_9"`
-	int16_u   int16               `sunspec:"offset=3,len=1"`
-	uint16_11 uint16              `sunspec:"offset=4,len=1,sf=sunssf_8,access=rw"`
-	uint16_12 uint16              `sunspec:"offset=5,len=1,sf=sunssf_9"`
-	uint16_13 uint16              `sunspec:"offset=6,len=1"`
-	uint16_u  uint16              `sunspec:"offset=7,len=1"`
-	int32     int32               `sunspec:"offset=8,len=2,sf=sunssf_1,access=rw"`
-	int32_u   int32               `sunspec:"offset=10,len=2"`
-	uint32    uint32              `sunspec:"offset=12,len=2,sf=sunssf_9,access=rw"`
-	uint32_u  uint32              `sunspec:"offset=14,len=2"`
-	sunssf_9  sunspec.ScaleFactor `sunspec:"offset=16,len=1"`
-	pad_2     sunspec.Pad         `sunspec:"offset=17,len=1"`
+	sunssf_8  sunspec.ScaleFactor `sunspec:"offset=0"`
+	int16_11  int16               `sunspec:"offset=1,sf=sunssf_8,access=rw"`
+	int16_12  int16               `sunspec:"offset=2,sf=sunssf_9"`
+	int16_u   int16               `sunspec:"offset=3"`
+	uint16_11 uint16              `sunspec:"offset=4,sf=sunssf_8,access=rw"`
+	uint16_12 uint16              `sunspec:"offset=5,sf=sunssf_9"`
+	uint16_13 uint16              `sunspec:"offset=6"`
+	uint16_u  uint16              `sunspec:"offset=7"`
+	int32     int32               `sunspec:"offset=8,sf=sunssf_1,access=rw"`
+	int32_u   int32               `sunspec:"offset=10"`
+	uint32    uint32              `sunspec:"offset=12,sf=sunssf_9,access=rw"`
+	uint32_u  uint32              `sunspec:"offset=14"`
+	sunssf_9  sunspec.ScaleFactor `sunspec:"offset=16"`
+	pad_2     sunspec.Pad         `sunspec:"offset=17"`
 }
 
 type Block63001 struct {
-	sunssf_1     sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	sunssf_2     sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	sunssf_3     sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	sunssf_4     sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	int16_1      int16               `sunspec:"offset=4,len=1,sf=sunssf_1"`
-	int16_2      int16               `sunspec:"offset=5,len=1,sf=sunssf_2"`
-	int16_3      int16               `sunspec:"offset=6,len=1,sf=sunssf_3"`
-	int16_4      int16               `sunspec:"offset=7,len=1,sf=sunssf_4,access=rw"`
-	int16_5      int16               `sunspec:"offset=8,len=1"`
-	int16_u      int16               `sunspec:"offset=9,len=1"`
-	uint16_1     uint16              `sunspec:"offset=10,len=1,sf=sunssf_1"`
-	uint16_2     uint16              `sunspec:"offset=11,len=1,sf=sunssf_2"`
-	uint16_3     uint16              `sunspec:"offset=12,len=1,sf=sunssf_3"`
-	uint16_4     uint16              `sunspec:"offset=13,len=1,sf=sunssf_4,access=rw"`
-	uint16_5     uint16              `sunspec:"offset=14,len=1"`
-	uint16_u     uint16              `sunspec:"offset=15,len=1"`
-	acc16        sunspec.Acc16       `sunspec:"offset=16,len=1"`
-	acc16_u      sunspec.Acc16       `sunspec:"offset=17,len=1"`
-	enum16       sunspec.Enum16      `sunspec:"offset=18,len=1"`
-	enum16_u     sunspec.Enum16      `sunspec:"offset=19,len=1"`
-	bitfield16   sunspec.Bitfield16  `sunspec:"offset=20,len=1"`
-	bitfield16_u sunspec.Bitfield16  `sunspec:"offset=21,len=1"`
-	int32_1      int32               `sunspec:"offset=22,len=2,sf=sunssf_5"`
-	int32_2      int32               `sunspec:"offset=24,len=2,sf=sunssf_6"`
-	int32_3      int32               `sunspec:"offset=26,len=2,sf=sunssf_7,access=rw"`
-	int32_4      int32               `sunspec:"offset=28,len=2"`
-	int32_5      int32               `sunspec:"offset=30,len=2"`
-	int32_u      int32               `sunspec:"offset=32,len=2"`
-	uint32_1     uint32              `sunspec:"offset=34,len=2,sf=sunssf_5"`
-	uint32_2     uint32              `sunspec:"offset=36,len=2,sf=sunssf_6"`
-	uint32_3     uint32              `sunspec:"offset=38,len=2,sf=sunssf_7,access=rw"`
-	uint32_4     uint32              `sunspec:"offset=40,len=2,sf=1"`
-	uint32_5     uint32              `sunspec:"offset=42,len=2"`
-	uint32_u     uint32              `sunspec:"offset=44,len=2"`
-	acc32        sunspec.Acc32       `sunspec:"offset=46,len=2"`
-	acc32_u      sunspec.Acc32       `sunspec:"offset=48,len=2"`
-	enum32       sunspec.Enum32      `sunspec:"offset=50,len=2"`
-	enum32_u     sunspec.Enum32      `sunspec:"offset=52,len=2"`
-	bitfield32   sunspec.Bitfield32  `sunspec:"offset=54,len=2"`
-	bitfield32_u sunspec.Bitfield32  `sunspec:"offset=56,len=2"`
-	ipaddr       sunspec.Ipaddr      `sunspec:"offset=58,len=2,access=rw"`
-	ipaddr_u     sunspec.Ipaddr      `sunspec:"offset=60,len=2"`
-	int64        int64               `sunspec:"offset=62,len=4,access=rw"`
-	int64_u      int64               `sunspec:"offset=66,len=4"`
-	acc64        sunspec.Acc64       `sunspec:"offset=70,len=4"`
-	acc64_u      sunspec.Acc64       `sunspec:"offset=74,len=4"`
-	ipv6addr     sunspec.Ipv6addr    `sunspec:"offset=78,len=8"`
-	ipv6addr_u   sunspec.Ipv6addr    `sunspec:"offset=86,len=8"`
-	float32      float32             `sunspec:"offset=94,len=2,access=rw"`
-	float32_u    float32             `sunspec:"offset=96,len=2"`
+	sunssf_1     sunspec.ScaleFactor `sunspec:"offset=0"`
+	sunssf_2     sunspec.ScaleFactor `sunspec:"offset=1"`
+	sunssf_3     sunspec.ScaleFactor `sunspec:"offset=2"`
+	sunssf_4     sunspec.ScaleFactor `sunspec:"offset=3"`
+	int16_1      int16               `sunspec:"offset=4,sf=sunssf_1"`
+	int16_2      int16               `sunspec:"offset=5,sf=sunssf_2"`
+	int16_3      int16               `sunspec:"offset=6,sf=sunssf_3"`
+	int16_4      int16               `sunspec:"offset=7,sf=sunssf_4,access=rw"`
+	int16_5      int16               `sunspec:"offset=8"`
+	int16_u      int16               `sunspec:"offset=9"`
+	uint16_1     uint16              `sunspec:"offset=10,sf=sunssf_1"`
+	uint16_2     uint16              `sunspec:"offset=11,sf=sunssf_2"`
+	uint16_3     uint16              `sunspec:"offset=12,sf=sunssf_3"`
+	uint16_4     uint16              `sunspec:"offset=13,sf=sunssf_4,access=rw"`
+	uint16_5     uint16              `sunspec:"offset=14"`
+	uint16_u     uint16              `sunspec:"offset=15"`
+	acc16        sunspec.Acc16       `sunspec:"offset=16"`
+	acc16_u      sunspec.Acc16       `sunspec:"offset=17"`
+	enum16       sunspec.Enum16      `sunspec:"offset=18"`
+	enum16_u     sunspec.Enum16      `sunspec:"offset=19"`
+	bitfield16   sunspec.Bitfield16  `sunspec:"offset=20"`
+	bitfield16_u sunspec.Bitfield16  `sunspec:"offset=21"`
+	int32_1      int32               `sunspec:"offset=22,sf=sunssf_5"`
+	int32_2      int32               `sunspec:"offset=24,sf=sunssf_6"`
+	int32_3      int32               `sunspec:"offset=26,sf=sunssf_7,access=rw"`
+	int32_4      int32               `sunspec:"offset=28"`
+	int32_5      int32               `sunspec:"offset=30"`
+	int32_u      int32               `sunspec:"offset=32"`
+	uint32_1     uint32              `sunspec:"offset=34,sf=sunssf_5"`
+	uint32_2     uint32              `sunspec:"offset=36,sf=sunssf_6"`
+	uint32_3     uint32              `sunspec:"offset=38,sf=sunssf_7,access=rw"`
+	uint32_4     uint32              `sunspec:"offset=40,sf=1"`
+	uint32_5     uint32              `sunspec:"offset=42"`
+	uint32_u     uint32              `sunspec:"offset=44"`
+	acc32        sunspec.Acc32       `sunspec:"offset=46"`
+	acc32_u      sunspec.Acc32       `sunspec:"offset=48"`
+	enum32       sunspec.Enum32      `sunspec:"offset=50"`
+	enum32_u     sunspec.Enum32      `sunspec:"offset=52"`
+	bitfield32   sunspec.Bitfield32  `sunspec:"offset=54"`
+	bitfield32_u sunspec.Bitfield32  `sunspec:"offset=56"`
+	ipaddr       sunspec.Ipaddr      `sunspec:"offset=58,access=rw"`
+	ipaddr_u     sunspec.Ipaddr      `sunspec:"offset=60"`
+	int64        int64               `sunspec:"offset=62,access=rw"`
+	int64_u      int64               `sunspec:"offset=66"`
+	acc64        sunspec.Acc64       `sunspec:"offset=70"`
+	acc64_u      sunspec.Acc64       `sunspec:"offset=74"`
+	ipv6addr     sunspec.Ipv6addr    `sunspec:"offset=78"`
+	ipv6addr_u   sunspec.Ipv6addr    `sunspec:"offset=86"`
+	float32      float32             `sunspec:"offset=94,access=rw"`
+	float32_u    float32             `sunspec:"offset=96"`
 	string       string              `sunspec:"offset=98,len=16,access=rw"`
 	string_u     string              `sunspec:"offset=114,len=16"`
-	sunssf_5     sunspec.ScaleFactor `sunspec:"offset=130,len=1"`
-	sunssf_6     sunspec.ScaleFactor `sunspec:"offset=131,len=1"`
-	sunssf_7     sunspec.ScaleFactor `sunspec:"offset=132,len=1"`
-	pad_1        sunspec.Pad         `sunspec:"offset=133,len=1"`
+	sunssf_5     sunspec.ScaleFactor `sunspec:"offset=130"`
+	sunssf_6     sunspec.ScaleFactor `sunspec:"offset=131"`
+	sunssf_7     sunspec.ScaleFactor `sunspec:"offset=132"`
+	pad_1        sunspec.Pad         `sunspec:"offset=133"`
 
 	Repeats []Block63001Repeat
 }
@@ -180,82 +180,82 @@ func init() {
 				Length: 134,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Sunssf_1, Offset: 0, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Sunssf_2, Offset: 1, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Sunssf_3, Offset: 2, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Sunssf_4, Offset: 3, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Int16_1, Offset: 4, Type: typelabel.Int16, ScaleFactor: "sunssf_1", Length: 1},
-					{Id: Int16_2, Offset: 5, Type: typelabel.Int16, ScaleFactor: "sunssf_2", Length: 1},
-					{Id: Int16_3, Offset: 6, Type: typelabel.Int16, ScaleFactor: "sunssf_3", Length: 1},
-					{Id: Int16_4, Offset: 7, Type: typelabel.Int16, ScaleFactor: "sunssf_4", Access: "rw", Length: 1},
-					{Id: Int16_5, Offset: 8, Type: typelabel.Int16, Length: 1},
-					{Id: Int16_u, Offset: 9, Type: typelabel.Int16, Length: 1},
-					{Id: Uint16_1, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "sunssf_1", Length: 1},
-					{Id: Uint16_2, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "sunssf_2", Length: 1},
-					{Id: Uint16_3, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "sunssf_3", Length: 1},
-					{Id: Uint16_4, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "sunssf_4", Access: "rw", Length: 1},
-					{Id: Uint16_5, Offset: 14, Type: typelabel.Uint16, Length: 1},
-					{Id: Uint16_u, Offset: 15, Type: typelabel.Uint16, Length: 1},
-					{Id: Acc16, Offset: 16, Type: typelabel.Acc16, Length: 1},
-					{Id: Acc16_u, Offset: 17, Type: typelabel.Acc16, Length: 1},
-					{Id: Enum16, Offset: 18, Type: typelabel.Enum16, Length: 1},
-					{Id: Enum16_u, Offset: 19, Type: typelabel.Enum16, Length: 1},
-					{Id: Bitfield16, Offset: 20, Type: typelabel.Bitfield16, Length: 1},
-					{Id: Bitfield16_u, Offset: 21, Type: typelabel.Bitfield16, Length: 1},
-					{Id: Int32_1, Offset: 22, Type: typelabel.Int32, ScaleFactor: "sunssf_5", Length: 2},
-					{Id: Int32_2, Offset: 24, Type: typelabel.Int32, ScaleFactor: "sunssf_6", Length: 2},
-					{Id: Int32_3, Offset: 26, Type: typelabel.Int32, ScaleFactor: "sunssf_7", Access: "rw", Length: 2},
-					{Id: Int32_4, Offset: 28, Type: typelabel.Int32, Length: 2},
-					{Id: Int32_5, Offset: 30, Type: typelabel.Int32, Length: 2},
-					{Id: Int32_u, Offset: 32, Type: typelabel.Int32, Length: 2},
-					{Id: Uint32_1, Offset: 34, Type: typelabel.Uint32, ScaleFactor: "sunssf_5", Length: 2},
-					{Id: Uint32_2, Offset: 36, Type: typelabel.Uint32, ScaleFactor: "sunssf_6", Length: 2},
-					{Id: Uint32_3, Offset: 38, Type: typelabel.Uint32, ScaleFactor: "sunssf_7", Access: "rw", Length: 2},
-					{Id: Uint32_4, Offset: 40, Type: typelabel.Uint32, ScaleFactor: "1", Length: 2},
-					{Id: Uint32_5, Offset: 42, Type: typelabel.Uint32, Length: 2},
-					{Id: Uint32_u, Offset: 44, Type: typelabel.Uint32, Length: 2},
-					{Id: Acc32, Offset: 46, Type: typelabel.Acc32, Length: 2},
-					{Id: Acc32_u, Offset: 48, Type: typelabel.Acc32, Length: 2},
-					{Id: Enum32, Offset: 50, Type: typelabel.Enum32, Length: 2},
-					{Id: Enum32_u, Offset: 52, Type: typelabel.Enum32, Length: 2},
-					{Id: Bitfield32, Offset: 54, Type: typelabel.Bitfield32, Length: 2},
-					{Id: Bitfield32_u, Offset: 56, Type: typelabel.Bitfield32, Length: 2},
-					{Id: Ipaddr, Offset: 58, Type: typelabel.Ipaddr, Access: "rw", Length: 2},
-					{Id: Ipaddr_u, Offset: 60, Type: typelabel.Ipaddr, Length: 2},
-					{Id: Int64, Offset: 62, Type: typelabel.Int64, Access: "rw", Length: 4},
-					{Id: Int64_u, Offset: 66, Type: typelabel.Int64, Length: 4},
-					{Id: Acc64, Offset: 70, Type: typelabel.Acc64, Length: 4},
-					{Id: Acc64_u, Offset: 74, Type: typelabel.Acc64, Length: 4},
-					{Id: Ipv6addr, Offset: 78, Type: typelabel.Ipv6addr, Length: 8},
-					{Id: Ipv6addr_u, Offset: 86, Type: typelabel.Ipv6addr, Length: 8},
-					{Id: Float32, Offset: 94, Type: typelabel.Float32, Access: "rw", Length: 2},
-					{Id: Float32_u, Offset: 96, Type: typelabel.Float32, Length: 2},
+					{Id: Sunssf_1, Offset: 0, Type: typelabel.ScaleFactor},
+					{Id: Sunssf_2, Offset: 1, Type: typelabel.ScaleFactor},
+					{Id: Sunssf_3, Offset: 2, Type: typelabel.ScaleFactor},
+					{Id: Sunssf_4, Offset: 3, Type: typelabel.ScaleFactor},
+					{Id: Int16_1, Offset: 4, Type: typelabel.Int16, ScaleFactor: "sunssf_1"},
+					{Id: Int16_2, Offset: 5, Type: typelabel.Int16, ScaleFactor: "sunssf_2"},
+					{Id: Int16_3, Offset: 6, Type: typelabel.Int16, ScaleFactor: "sunssf_3"},
+					{Id: Int16_4, Offset: 7, Type: typelabel.Int16, ScaleFactor: "sunssf_4", Access: "rw"},
+					{Id: Int16_5, Offset: 8, Type: typelabel.Int16},
+					{Id: Int16_u, Offset: 9, Type: typelabel.Int16},
+					{Id: Uint16_1, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "sunssf_1"},
+					{Id: Uint16_2, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "sunssf_2"},
+					{Id: Uint16_3, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "sunssf_3"},
+					{Id: Uint16_4, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "sunssf_4", Access: "rw"},
+					{Id: Uint16_5, Offset: 14, Type: typelabel.Uint16},
+					{Id: Uint16_u, Offset: 15, Type: typelabel.Uint16},
+					{Id: Acc16, Offset: 16, Type: typelabel.Acc16},
+					{Id: Acc16_u, Offset: 17, Type: typelabel.Acc16},
+					{Id: Enum16, Offset: 18, Type: typelabel.Enum16},
+					{Id: Enum16_u, Offset: 19, Type: typelabel.Enum16},
+					{Id: Bitfield16, Offset: 20, Type: typelabel.Bitfield16},
+					{Id: Bitfield16_u, Offset: 21, Type: typelabel.Bitfield16},
+					{Id: Int32_1, Offset: 22, Type: typelabel.Int32, ScaleFactor: "sunssf_5"},
+					{Id: Int32_2, Offset: 24, Type: typelabel.Int32, ScaleFactor: "sunssf_6"},
+					{Id: Int32_3, Offset: 26, Type: typelabel.Int32, ScaleFactor: "sunssf_7", Access: "rw"},
+					{Id: Int32_4, Offset: 28, Type: typelabel.Int32},
+					{Id: Int32_5, Offset: 30, Type: typelabel.Int32},
+					{Id: Int32_u, Offset: 32, Type: typelabel.Int32},
+					{Id: Uint32_1, Offset: 34, Type: typelabel.Uint32, ScaleFactor: "sunssf_5"},
+					{Id: Uint32_2, Offset: 36, Type: typelabel.Uint32, ScaleFactor: "sunssf_6"},
+					{Id: Uint32_3, Offset: 38, Type: typelabel.Uint32, ScaleFactor: "sunssf_7", Access: "rw"},
+					{Id: Uint32_4, Offset: 40, Type: typelabel.Uint32, ScaleFactor: "1"},
+					{Id: Uint32_5, Offset: 42, Type: typelabel.Uint32},
+					{Id: Uint32_u, Offset: 44, Type: typelabel.Uint32},
+					{Id: Acc32, Offset: 46, Type: typelabel.Acc32},
+					{Id: Acc32_u, Offset: 48, Type: typelabel.Acc32},
+					{Id: Enum32, Offset: 50, Type: typelabel.Enum32},
+					{Id: Enum32_u, Offset: 52, Type: typelabel.Enum32},
+					{Id: Bitfield32, Offset: 54, Type: typelabel.Bitfield32},
+					{Id: Bitfield32_u, Offset: 56, Type: typelabel.Bitfield32},
+					{Id: Ipaddr, Offset: 58, Type: typelabel.Ipaddr, Access: "rw"},
+					{Id: Ipaddr_u, Offset: 60, Type: typelabel.Ipaddr},
+					{Id: Int64, Offset: 62, Type: typelabel.Int64, Access: "rw"},
+					{Id: Int64_u, Offset: 66, Type: typelabel.Int64},
+					{Id: Acc64, Offset: 70, Type: typelabel.Acc64},
+					{Id: Acc64_u, Offset: 74, Type: typelabel.Acc64},
+					{Id: Ipv6addr, Offset: 78, Type: typelabel.Ipv6addr},
+					{Id: Ipv6addr_u, Offset: 86, Type: typelabel.Ipv6addr},
+					{Id: Float32, Offset: 94, Type: typelabel.Float32, Access: "rw"},
+					{Id: Float32_u, Offset: 96, Type: typelabel.Float32},
 					{Id: String, Offset: 98, Type: typelabel.String, Access: "rw", Length: 16},
 					{Id: String_u, Offset: 114, Type: typelabel.String, Length: 16},
-					{Id: Sunssf_5, Offset: 130, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Sunssf_6, Offset: 131, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Sunssf_7, Offset: 132, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Pad_1, Offset: 133, Type: typelabel.Pad, Length: 1},
+					{Id: Sunssf_5, Offset: 130, Type: typelabel.ScaleFactor},
+					{Id: Sunssf_6, Offset: 131, Type: typelabel.ScaleFactor},
+					{Id: Sunssf_7, Offset: 132, Type: typelabel.ScaleFactor},
+					{Id: Pad_1, Offset: 133, Type: typelabel.Pad},
 				},
 			},
 			{
 				Length: 18,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: Sunssf_8, Offset: 0, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Int16_11, Offset: 1, Type: typelabel.Int16, ScaleFactor: "sunssf_8", Access: "rw", Length: 1},
-					{Id: Int16_12, Offset: 2, Type: typelabel.Int16, ScaleFactor: "sunssf_9", Length: 1},
-					{Id: Int16_u, Offset: 3, Type: typelabel.Int16, Length: 1},
-					{Id: Uint16_11, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "sunssf_8", Access: "rw", Length: 1},
-					{Id: Uint16_12, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "sunssf_9", Length: 1},
-					{Id: Uint16_13, Offset: 6, Type: typelabel.Uint16, Length: 1},
-					{Id: Uint16_u, Offset: 7, Type: typelabel.Uint16, Length: 1},
-					{Id: Int32, Offset: 8, Type: typelabel.Int32, ScaleFactor: "sunssf_1", Access: "rw", Length: 2},
-					{Id: Int32_u, Offset: 10, Type: typelabel.Int32, Length: 2},
-					{Id: Uint32, Offset: 12, Type: typelabel.Uint32, ScaleFactor: "sunssf_9", Access: "rw", Length: 2},
-					{Id: Uint32_u, Offset: 14, Type: typelabel.Uint32, Length: 2},
-					{Id: Sunssf_9, Offset: 16, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Pad_2, Offset: 17, Type: typelabel.Pad, Length: 1},
+					{Id: Sunssf_8, Offset: 0, Type: typelabel.ScaleFactor},
+					{Id: Int16_11, Offset: 1, Type: typelabel.Int16, ScaleFactor: "sunssf_8", Access: "rw"},
+					{Id: Int16_12, Offset: 2, Type: typelabel.Int16, ScaleFactor: "sunssf_9"},
+					{Id: Int16_u, Offset: 3, Type: typelabel.Int16},
+					{Id: Uint16_11, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "sunssf_8", Access: "rw"},
+					{Id: Uint16_12, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "sunssf_9"},
+					{Id: Uint16_13, Offset: 6, Type: typelabel.Uint16},
+					{Id: Uint16_u, Offset: 7, Type: typelabel.Uint16},
+					{Id: Int32, Offset: 8, Type: typelabel.Int32, ScaleFactor: "sunssf_1", Access: "rw"},
+					{Id: Int32_u, Offset: 10, Type: typelabel.Int32},
+					{Id: Uint32, Offset: 12, Type: typelabel.Uint32, ScaleFactor: "sunssf_9", Access: "rw"},
+					{Id: Uint32_u, Offset: 14, Type: typelabel.Uint32},
+					{Id: Sunssf_9, Offset: 16, Type: typelabel.ScaleFactor},
+					{Id: Pad_2, Offset: 17, Type: typelabel.Pad},
 				},
 			},
 		}})

--- a/models/model63002/model.go
+++ b/models/model63002/model.go
@@ -25,10 +25,10 @@ const (
 )
 
 type Block63002Repeat struct {
-	sunssf_1 sunspec.ScaleFactor `sunspec:"offset=0,len=1"`
-	int16_1  int16               `sunspec:"offset=1,len=1,sf=sunssf_1,access=rw"`
-	int16_2  int16               `sunspec:"offset=2,len=1,sf=sunssf_2"`
-	sunssf_2 sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
+	sunssf_1 sunspec.ScaleFactor `sunspec:"offset=0"`
+	int16_1  int16               `sunspec:"offset=1,sf=sunssf_1,access=rw"`
+	int16_2  int16               `sunspec:"offset=2,sf=sunssf_2"`
+	sunssf_2 sunspec.ScaleFactor `sunspec:"offset=3"`
 }
 
 type Block63002 struct {
@@ -51,10 +51,10 @@ func init() {
 				Length: 4,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: Sunssf_1, Offset: 0, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: Int16_1, Offset: 1, Type: typelabel.Int16, ScaleFactor: "sunssf_1", Access: "rw", Length: 1},
-					{Id: Int16_2, Offset: 2, Type: typelabel.Int16, ScaleFactor: "sunssf_2", Length: 1},
-					{Id: Sunssf_2, Offset: 3, Type: typelabel.ScaleFactor, Length: 1},
+					{Id: Sunssf_1, Offset: 0, Type: typelabel.ScaleFactor},
+					{Id: Int16_1, Offset: 1, Type: typelabel.Int16, ScaleFactor: "sunssf_1", Access: "rw"},
+					{Id: Int16_2, Offset: 2, Type: typelabel.Int16, ScaleFactor: "sunssf_2"},
+					{Id: Sunssf_2, Offset: 3, Type: typelabel.ScaleFactor},
 				},
 			},
 		}})

--- a/models/model64001/model.go
+++ b/models/model64001/model.go
@@ -56,39 +56,39 @@ const (
 )
 
 type Block64001 struct {
-	Cmd      sunspec.Enum16     `sunspec:"offset=0,len=1,access=rw"`
-	HWRev    uint16             `sunspec:"offset=1,len=1"`
-	RSFWRev  uint16             `sunspec:"offset=2,len=1"`
-	OSFWRev  uint16             `sunspec:"offset=3,len=1"`
+	Cmd      sunspec.Enum16     `sunspec:"offset=0,access=rw"`
+	HWRev    uint16             `sunspec:"offset=1"`
+	RSFWRev  uint16             `sunspec:"offset=2"`
+	OSFWRev  uint16             `sunspec:"offset=3"`
 	ProdRev  string             `sunspec:"offset=4,len=2"`
-	Boots    uint16             `sunspec:"offset=6,len=1"`
-	Switch   sunspec.Bitfield16 `sunspec:"offset=7,len=1"`
-	Sensors  uint16             `sunspec:"offset=8,len=1"`
-	Talking  uint16             `sunspec:"offset=9,len=1"`
-	Status   sunspec.Bitfield16 `sunspec:"offset=10,len=1"`
-	Config   sunspec.Bitfield16 `sunspec:"offset=11,len=1"`
-	LEDblink uint16             `sunspec:"offset=12,len=1"`
-	LEDon    uint16             `sunspec:"offset=13,len=1"`
-	Reserved uint16             `sunspec:"offset=14,len=1"`
+	Boots    uint16             `sunspec:"offset=6"`
+	Switch   sunspec.Bitfield16 `sunspec:"offset=7"`
+	Sensors  uint16             `sunspec:"offset=8"`
+	Talking  uint16             `sunspec:"offset=9"`
+	Status   sunspec.Bitfield16 `sunspec:"offset=10"`
+	Config   sunspec.Bitfield16 `sunspec:"offset=11"`
+	LEDblink uint16             `sunspec:"offset=12"`
+	LEDon    uint16             `sunspec:"offset=13"`
+	Reserved uint16             `sunspec:"offset=14"`
 	Loc      string             `sunspec:"offset=15,len=16"`
-	S1ID     sunspec.Enum16     `sunspec:"offset=31,len=1"`
-	S1Addr   uint16             `sunspec:"offset=32,len=1"`
-	S1OSVer  uint16             `sunspec:"offset=33,len=1"`
+	S1ID     sunspec.Enum16     `sunspec:"offset=31"`
+	S1Addr   uint16             `sunspec:"offset=32"`
+	S1OSVer  uint16             `sunspec:"offset=33"`
 	S1Ver    string             `sunspec:"offset=34,len=2"`
 	S1Serial string             `sunspec:"offset=36,len=5"`
-	S2ID     sunspec.Enum16     `sunspec:"offset=41,len=1"`
-	S2Addr   uint16             `sunspec:"offset=42,len=1"`
-	S2OSVer  uint16             `sunspec:"offset=43,len=1"`
+	S2ID     sunspec.Enum16     `sunspec:"offset=41"`
+	S2Addr   uint16             `sunspec:"offset=42"`
+	S2OSVer  uint16             `sunspec:"offset=43"`
 	S2Ver    string             `sunspec:"offset=44,len=2"`
 	S2Serial string             `sunspec:"offset=46,len=5"`
-	S3ID     sunspec.Enum16     `sunspec:"offset=51,len=1"`
-	S3Addr   uint16             `sunspec:"offset=52,len=1"`
-	S3OSVer  uint16             `sunspec:"offset=53,len=1"`
+	S3ID     sunspec.Enum16     `sunspec:"offset=51"`
+	S3Addr   uint16             `sunspec:"offset=52"`
+	S3OSVer  uint16             `sunspec:"offset=53"`
 	S3Ver    string             `sunspec:"offset=54,len=2"`
 	S3Serial string             `sunspec:"offset=56,len=5"`
-	S4ID     sunspec.Enum16     `sunspec:"offset=61,len=1"`
-	S4Addr   uint16             `sunspec:"offset=62,len=1"`
-	S4OSVer  uint16             `sunspec:"offset=63,len=1"`
+	S4ID     sunspec.Enum16     `sunspec:"offset=61"`
+	S4Addr   uint16             `sunspec:"offset=62"`
+	S4OSVer  uint16             `sunspec:"offset=63"`
 	S4Ver    string             `sunspec:"offset=64,len=2"`
 	S4Serial string             `sunspec:"offset=66,len=5"`
 }
@@ -109,39 +109,39 @@ func init() {
 				Length: 71,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Cmd, Offset: 0, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Command Code", Description: ""},
-					{Id: HWRev, Offset: 1, Type: typelabel.Uint16, Length: 1, Label: "Hardware Revision", Description: ""},
-					{Id: RSFWRev, Offset: 2, Type: typelabel.Uint16, Length: 1, Label: "RS FW Revision", Description: ""},
-					{Id: OSFWRev, Offset: 3, Type: typelabel.Uint16, Length: 1, Label: "OS FW Revision", Description: ""},
+					{Id: Cmd, Offset: 0, Type: typelabel.Enum16, Access: "rw", Label: "Command Code", Description: ""},
+					{Id: HWRev, Offset: 1, Type: typelabel.Uint16, Label: "Hardware Revision", Description: ""},
+					{Id: RSFWRev, Offset: 2, Type: typelabel.Uint16, Label: "RS FW Revision", Description: ""},
+					{Id: OSFWRev, Offset: 3, Type: typelabel.Uint16, Label: "OS FW Revision", Description: ""},
 					{Id: ProdRev, Offset: 4, Type: typelabel.String, Length: 2, Label: "Product Revision", Description: ""},
-					{Id: Boots, Offset: 6, Type: typelabel.Uint16, Length: 1, Label: "Boot Count", Description: ""},
-					{Id: Switch, Offset: 7, Type: typelabel.Bitfield16, Length: 1, Label: "DIP Switches", Description: ""},
-					{Id: Sensors, Offset: 8, Type: typelabel.Uint16, Length: 1, Label: "Num Detected Sensors", Description: ""},
-					{Id: Talking, Offset: 9, Type: typelabel.Uint16, Length: 1, Label: "Num Communicating Sensors", Description: ""},
-					{Id: Status, Offset: 10, Type: typelabel.Bitfield16, Length: 1, Label: "System Status", Description: ""},
-					{Id: Config, Offset: 11, Type: typelabel.Bitfield16, Length: 1, Label: "System Configuration", Description: ""},
-					{Id: LEDblink, Offset: 12, Type: typelabel.Uint16, Units: "Pct", Length: 1, Label: "LED Blink Threshold", Description: ""},
-					{Id: LEDon, Offset: 13, Type: typelabel.Uint16, Units: "Pct", Length: 1, Label: "LED On Threshold", Description: ""},
-					{Id: Reserved, Offset: 14, Type: typelabel.Uint16, Length: 1},
+					{Id: Boots, Offset: 6, Type: typelabel.Uint16, Label: "Boot Count", Description: ""},
+					{Id: Switch, Offset: 7, Type: typelabel.Bitfield16, Label: "DIP Switches", Description: ""},
+					{Id: Sensors, Offset: 8, Type: typelabel.Uint16, Label: "Num Detected Sensors", Description: ""},
+					{Id: Talking, Offset: 9, Type: typelabel.Uint16, Label: "Num Communicating Sensors", Description: ""},
+					{Id: Status, Offset: 10, Type: typelabel.Bitfield16, Label: "System Status", Description: ""},
+					{Id: Config, Offset: 11, Type: typelabel.Bitfield16, Label: "System Configuration", Description: ""},
+					{Id: LEDblink, Offset: 12, Type: typelabel.Uint16, Units: "Pct", Label: "LED Blink Threshold", Description: ""},
+					{Id: LEDon, Offset: 13, Type: typelabel.Uint16, Units: "Pct", Label: "LED On Threshold", Description: ""},
+					{Id: Reserved, Offset: 14, Type: typelabel.Uint16},
 					{Id: Loc, Offset: 15, Type: typelabel.String, Length: 16, Label: "Location String", Description: ""},
-					{Id: S1ID, Offset: 31, Type: typelabel.Enum16, Length: 1, Label: "Sensor 1 Unit ID", Description: ""},
-					{Id: S1Addr, Offset: 32, Type: typelabel.Uint16, Length: 1, Label: "Sensor 1 Address", Description: ""},
-					{Id: S1OSVer, Offset: 33, Type: typelabel.Uint16, Length: 1, Label: "Sensor 1 OS Version", Description: ""},
+					{Id: S1ID, Offset: 31, Type: typelabel.Enum16, Label: "Sensor 1 Unit ID", Description: ""},
+					{Id: S1Addr, Offset: 32, Type: typelabel.Uint16, Label: "Sensor 1 Address", Description: ""},
+					{Id: S1OSVer, Offset: 33, Type: typelabel.Uint16, Label: "Sensor 1 OS Version", Description: ""},
 					{Id: S1Ver, Offset: 34, Type: typelabel.String, Length: 2, Label: "Sensor 1 Product Version", Description: ""},
 					{Id: S1Serial, Offset: 36, Type: typelabel.String, Length: 5, Label: "Sensor 1 Serial Num", Description: ""},
-					{Id: S2ID, Offset: 41, Type: typelabel.Enum16, Length: 1, Label: "Sensor 2 Unit ID", Description: ""},
-					{Id: S2Addr, Offset: 42, Type: typelabel.Uint16, Length: 1, Label: "Sensor 2 Address", Description: ""},
-					{Id: S2OSVer, Offset: 43, Type: typelabel.Uint16, Length: 1, Label: "Sensor 2 OS Version", Description: ""},
+					{Id: S2ID, Offset: 41, Type: typelabel.Enum16, Label: "Sensor 2 Unit ID", Description: ""},
+					{Id: S2Addr, Offset: 42, Type: typelabel.Uint16, Label: "Sensor 2 Address", Description: ""},
+					{Id: S2OSVer, Offset: 43, Type: typelabel.Uint16, Label: "Sensor 2 OS Version", Description: ""},
 					{Id: S2Ver, Offset: 44, Type: typelabel.String, Length: 2, Label: "Sensor 2 Product Version", Description: ""},
 					{Id: S2Serial, Offset: 46, Type: typelabel.String, Length: 5, Label: "Sensor 2 Serial Num", Description: ""},
-					{Id: S3ID, Offset: 51, Type: typelabel.Enum16, Length: 1, Label: "Sensor 3 Unit ID", Description: ""},
-					{Id: S3Addr, Offset: 52, Type: typelabel.Uint16, Length: 1, Label: "Sensor 3 Address", Description: ""},
-					{Id: S3OSVer, Offset: 53, Type: typelabel.Uint16, Length: 1, Label: "Sensor 3 OS Version", Description: ""},
+					{Id: S3ID, Offset: 51, Type: typelabel.Enum16, Label: "Sensor 3 Unit ID", Description: ""},
+					{Id: S3Addr, Offset: 52, Type: typelabel.Uint16, Label: "Sensor 3 Address", Description: ""},
+					{Id: S3OSVer, Offset: 53, Type: typelabel.Uint16, Label: "Sensor 3 OS Version", Description: ""},
 					{Id: S3Ver, Offset: 54, Type: typelabel.String, Length: 2, Label: "Sensor 3 Product Version", Description: ""},
 					{Id: S3Serial, Offset: 56, Type: typelabel.String, Length: 5, Label: "Sensor 3 Serial Num", Description: ""},
-					{Id: S4ID, Offset: 61, Type: typelabel.Enum16, Length: 1, Label: "Sensor 4 Unit ID", Description: ""},
-					{Id: S4Addr, Offset: 62, Type: typelabel.Uint16, Length: 1, Label: "Sensor 4 Address", Description: ""},
-					{Id: S4OSVer, Offset: 63, Type: typelabel.Uint16, Length: 1, Label: "Sensor 4 OS Version", Description: ""},
+					{Id: S4ID, Offset: 61, Type: typelabel.Enum16, Label: "Sensor 4 Unit ID", Description: ""},
+					{Id: S4Addr, Offset: 62, Type: typelabel.Uint16, Label: "Sensor 4 Address", Description: ""},
+					{Id: S4OSVer, Offset: 63, Type: typelabel.Uint16, Label: "Sensor 4 OS Version", Description: ""},
 					{Id: S4Ver, Offset: 64, Type: typelabel.String, Length: 2, Label: "Sensor 4 Product Version", Description: ""},
 					{Id: S4Serial, Offset: 66, Type: typelabel.String, Length: 5, Label: "Sensor 4 Serial Num", Description: ""},
 				},

--- a/models/model64020/model.go
+++ b/models/model64020/model.go
@@ -56,40 +56,40 @@ const (
 type Block64020Repeat struct {
 	SerialNumber string `sunspec:"offset=0,len=9"`
 	Firmware     string `sunspec:"offset=9,len=6"`
-	Hardware     uint16 `sunspec:"offset=15,len=1"`
+	Hardware     uint16 `sunspec:"offset=15"`
 }
 
 type Block64020 struct {
-	Aux0Tmp           int16               `sunspec:"offset=0,len=1"`
-	Aux1Tmp           int16               `sunspec:"offset=1,len=1"`
-	Aux2Tmp           int16               `sunspec:"offset=2,len=1"`
-	Aux3Tmp           int16               `sunspec:"offset=3,len=1"`
-	Aux4Tmp           int16               `sunspec:"offset=4,len=1"`
-	MainTmp           int16               `sunspec:"offset=5,len=1"`
-	ProbeTmp          int16               `sunspec:"offset=6,len=1"`
-	SensorV_SF        sunspec.ScaleFactor `sunspec:"offset=7,len=1"`
-	SensorA_SF        sunspec.ScaleFactor `sunspec:"offset=8,len=1"`
-	SensorHz_SF       sunspec.ScaleFactor `sunspec:"offset=9,len=1"`
-	Sensor1Voltage    int16               `sunspec:"offset=10,len=1,sf=SensorV_SF"`
-	Sensor2Voltage    int16               `sunspec:"offset=11,len=1,sf=SensorV_SF"`
-	Sensor3Voltage    int16               `sunspec:"offset=12,len=1,sf=SensorV_SF"`
-	Sensor4Voltage    int16               `sunspec:"offset=13,len=1,sf=SensorV_SF"`
-	Sensor5Voltage    int16               `sunspec:"offset=14,len=1,sf=SensorV_SF"`
-	Sensor6Voltage    int16               `sunspec:"offset=15,len=1,sf=SensorV_SF"`
-	Sensor7Voltage    int16               `sunspec:"offset=16,len=1,sf=SensorV_SF"`
-	Sensor1Current    int16               `sunspec:"offset=17,len=1,sf=SensorA_SF"`
-	Sensor2Current    int16               `sunspec:"offset=18,len=1,sf=SensorA_SF"`
-	Sensor3Current    int16               `sunspec:"offset=19,len=1,sf=SensorA_SF"`
-	Sensor4Current    int16               `sunspec:"offset=20,len=1,sf=SensorA_SF"`
-	Sensor5Current    int16               `sunspec:"offset=21,len=1,sf=SensorA_SF"`
-	Sensor6Current    int16               `sunspec:"offset=22,len=1,sf=SensorA_SF"`
-	Sensor7Current    int16               `sunspec:"offset=23,len=1,sf=SensorA_SF"`
-	Sensor8           uint16              `sunspec:"offset=24,len=1,sf=SensorHz_SF"`
-	Relay1            uint16              `sunspec:"offset=25,len=1"`
-	Relay2            uint16              `sunspec:"offset=26,len=1"`
-	Relay3            uint16              `sunspec:"offset=27,len=1"`
-	ResetAccumulators uint16              `sunspec:"offset=28,len=1"`
-	Reset             uint16              `sunspec:"offset=29,len=1"`
+	Aux0Tmp           int16               `sunspec:"offset=0"`
+	Aux1Tmp           int16               `sunspec:"offset=1"`
+	Aux2Tmp           int16               `sunspec:"offset=2"`
+	Aux3Tmp           int16               `sunspec:"offset=3"`
+	Aux4Tmp           int16               `sunspec:"offset=4"`
+	MainTmp           int16               `sunspec:"offset=5"`
+	ProbeTmp          int16               `sunspec:"offset=6"`
+	SensorV_SF        sunspec.ScaleFactor `sunspec:"offset=7"`
+	SensorA_SF        sunspec.ScaleFactor `sunspec:"offset=8"`
+	SensorHz_SF       sunspec.ScaleFactor `sunspec:"offset=9"`
+	Sensor1Voltage    int16               `sunspec:"offset=10,sf=SensorV_SF"`
+	Sensor2Voltage    int16               `sunspec:"offset=11,sf=SensorV_SF"`
+	Sensor3Voltage    int16               `sunspec:"offset=12,sf=SensorV_SF"`
+	Sensor4Voltage    int16               `sunspec:"offset=13,sf=SensorV_SF"`
+	Sensor5Voltage    int16               `sunspec:"offset=14,sf=SensorV_SF"`
+	Sensor6Voltage    int16               `sunspec:"offset=15,sf=SensorV_SF"`
+	Sensor7Voltage    int16               `sunspec:"offset=16,sf=SensorV_SF"`
+	Sensor1Current    int16               `sunspec:"offset=17,sf=SensorA_SF"`
+	Sensor2Current    int16               `sunspec:"offset=18,sf=SensorA_SF"`
+	Sensor3Current    int16               `sunspec:"offset=19,sf=SensorA_SF"`
+	Sensor4Current    int16               `sunspec:"offset=20,sf=SensorA_SF"`
+	Sensor5Current    int16               `sunspec:"offset=21,sf=SensorA_SF"`
+	Sensor6Current    int16               `sunspec:"offset=22,sf=SensorA_SF"`
+	Sensor7Current    int16               `sunspec:"offset=23,sf=SensorA_SF"`
+	Sensor8           uint16              `sunspec:"offset=24,sf=SensorHz_SF"`
+	Relay1            uint16              `sunspec:"offset=25"`
+	Relay2            uint16              `sunspec:"offset=26"`
+	Relay3            uint16              `sunspec:"offset=27"`
+	ResetAccumulators uint16              `sunspec:"offset=28"`
+	Reset             uint16              `sunspec:"offset=29"`
 
 	Repeats []Block64020Repeat
 }
@@ -110,36 +110,36 @@ func init() {
 				Length: 30,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Aux0Tmp, Offset: 0, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Aux 0 temperature", Description: ""},
-					{Id: Aux1Tmp, Offset: 1, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Aux 1 temperature", Description: ""},
-					{Id: Aux2Tmp, Offset: 2, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Aux 2 temperature", Description: ""},
-					{Id: Aux3Tmp, Offset: 3, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Aux 3 temperature", Description: ""},
-					{Id: Aux4Tmp, Offset: 4, Type: typelabel.Int16, Units: "C", Length: 1, Label: "Aux 4 temperature", Description: ""},
-					{Id: MainTmp, Offset: 5, Type: typelabel.Int16, Units: "C", Length: 1, Mandatory: true, Label: "Main Temperature", Description: ""},
-					{Id: ProbeTmp, Offset: 6, Type: typelabel.Int16, Units: "C", Length: 1, Mandatory: true, Label: "Probe Temperature", Description: ""},
-					{Id: SensorV_SF, Offset: 7, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Voltage scale factor for the sensors", Description: ""},
-					{Id: SensorA_SF, Offset: 8, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Current scale factor for the sensors", Description: ""},
-					{Id: SensorHz_SF, Offset: 9, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true, Label: "Frequency scale factor for the sensors", Description: ""},
-					{Id: Sensor1Voltage, Offset: 10, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor1 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor2Voltage, Offset: 11, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor2 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor3Voltage, Offset: 12, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor3 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor4Voltage, Offset: 13, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor4 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor5Voltage, Offset: 14, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor5 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor6Voltage, Offset: 15, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor6 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor7Voltage, Offset: 16, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Length: 1, Label: "Sensor7 Voltage", Description: "scale of 0-10V"},
-					{Id: Sensor1Current, Offset: 17, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor1 Current", Description: "scale of 4-20mA"},
-					{Id: Sensor2Current, Offset: 18, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor2 Current", Description: "in 4-20mA or 4-20mA"},
-					{Id: Sensor3Current, Offset: 19, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor3 Current", Description: "in 4-20mA or 4-20mA"},
-					{Id: Sensor4Current, Offset: 20, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor4 Current", Description: "in 4-20mA or 4-20mA"},
-					{Id: Sensor5Current, Offset: 21, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor5 Current", Description: "in 4-20mA or 4-20mA"},
-					{Id: Sensor6Current, Offset: 22, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor6 Current", Description: "in 4-20mA or 4-20mA"},
-					{Id: Sensor7Current, Offset: 23, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Length: 1, Label: "Sensor7 Current", Description: "in 4-20mA or 4-20mA"},
-					{Id: Sensor8, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "SensorHz_SF", Units: "Hz", Length: 1, Label: "Sensor8 frequency", Description: "frequency in Hz"},
-					{Id: Relay1, Offset: 25, Type: typelabel.Uint16, Length: 1, Label: "Relay 1 state", Description: ""},
-					{Id: Relay2, Offset: 26, Type: typelabel.Uint16, Length: 1, Label: "Relay 2 state", Description: ""},
-					{Id: Relay3, Offset: 27, Type: typelabel.Uint16, Length: 1, Label: "Relay 3 state", Description: ""},
-					{Id: ResetAccumulators, Offset: 28, Type: typelabel.Uint16, Length: 1, Label: "Reset the accumulators", Description: "always 0 in reading, used the code 0xC0DA during the writing for resetting them"},
-					{Id: Reset, Offset: 29, Type: typelabel.Uint16, Length: 1, Label: "Reset the system", Description: "always 0 in reading, used the code 0xC0DA during the writing for resetting the system"},
+					{Id: Aux0Tmp, Offset: 0, Type: typelabel.Int16, Units: "C", Label: "Aux 0 temperature", Description: ""},
+					{Id: Aux1Tmp, Offset: 1, Type: typelabel.Int16, Units: "C", Label: "Aux 1 temperature", Description: ""},
+					{Id: Aux2Tmp, Offset: 2, Type: typelabel.Int16, Units: "C", Label: "Aux 2 temperature", Description: ""},
+					{Id: Aux3Tmp, Offset: 3, Type: typelabel.Int16, Units: "C", Label: "Aux 3 temperature", Description: ""},
+					{Id: Aux4Tmp, Offset: 4, Type: typelabel.Int16, Units: "C", Label: "Aux 4 temperature", Description: ""},
+					{Id: MainTmp, Offset: 5, Type: typelabel.Int16, Units: "C", Mandatory: true, Label: "Main Temperature", Description: ""},
+					{Id: ProbeTmp, Offset: 6, Type: typelabel.Int16, Units: "C", Mandatory: true, Label: "Probe Temperature", Description: ""},
+					{Id: SensorV_SF, Offset: 7, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Voltage scale factor for the sensors", Description: ""},
+					{Id: SensorA_SF, Offset: 8, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Current scale factor for the sensors", Description: ""},
+					{Id: SensorHz_SF, Offset: 9, Type: typelabel.ScaleFactor, Mandatory: true, Label: "Frequency scale factor for the sensors", Description: ""},
+					{Id: Sensor1Voltage, Offset: 10, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor1 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor2Voltage, Offset: 11, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor2 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor3Voltage, Offset: 12, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor3 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor4Voltage, Offset: 13, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor4 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor5Voltage, Offset: 14, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor5 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor6Voltage, Offset: 15, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor6 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor7Voltage, Offset: 16, Type: typelabel.Int16, ScaleFactor: "SensorV_SF", Units: "V", Label: "Sensor7 Voltage", Description: "scale of 0-10V"},
+					{Id: Sensor1Current, Offset: 17, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor1 Current", Description: "scale of 4-20mA"},
+					{Id: Sensor2Current, Offset: 18, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor2 Current", Description: "in 4-20mA or 4-20mA"},
+					{Id: Sensor3Current, Offset: 19, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor3 Current", Description: "in 4-20mA or 4-20mA"},
+					{Id: Sensor4Current, Offset: 20, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor4 Current", Description: "in 4-20mA or 4-20mA"},
+					{Id: Sensor5Current, Offset: 21, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor5 Current", Description: "in 4-20mA or 4-20mA"},
+					{Id: Sensor6Current, Offset: 22, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor6 Current", Description: "in 4-20mA or 4-20mA"},
+					{Id: Sensor7Current, Offset: 23, Type: typelabel.Int16, ScaleFactor: "SensorA_SF", Units: "A", Label: "Sensor7 Current", Description: "in 4-20mA or 4-20mA"},
+					{Id: Sensor8, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "SensorHz_SF", Units: "Hz", Label: "Sensor8 frequency", Description: "frequency in Hz"},
+					{Id: Relay1, Offset: 25, Type: typelabel.Uint16, Label: "Relay 1 state", Description: ""},
+					{Id: Relay2, Offset: 26, Type: typelabel.Uint16, Label: "Relay 2 state", Description: ""},
+					{Id: Relay3, Offset: 27, Type: typelabel.Uint16, Label: "Relay 3 state", Description: ""},
+					{Id: ResetAccumulators, Offset: 28, Type: typelabel.Uint16, Label: "Reset the accumulators", Description: "always 0 in reading, used the code 0xC0DA during the writing for resetting them"},
+					{Id: Reset, Offset: 29, Type: typelabel.Uint16, Label: "Reset the system", Description: "always 0 in reading, used the code 0xC0DA during the writing for resetting the system"},
 				},
 			},
 			{
@@ -148,7 +148,7 @@ func init() {
 				Points: []types.Point{
 					{Id: SerialNumber, Offset: 0, Type: typelabel.String, Length: 9, Mandatory: true, Label: "Serial number", Description: "strings of 16 characters"},
 					{Id: Firmware, Offset: 9, Type: typelabel.String, Length: 6, Mandatory: true, Label: "Firmware version", Description: "string of 11 characters"},
-					{Id: Hardware, Offset: 15, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Hardware version", Description: ""},
+					{Id: Hardware, Offset: 15, Type: typelabel.Uint16, Mandatory: true, Label: "Hardware version", Description: ""},
 				},
 			},
 		}})

--- a/models/model64101/model.go
+++ b/models/model64101/model.go
@@ -28,13 +28,13 @@ const (
 )
 
 type Block64101 struct {
-	Eltek_Country_Code   uint16 `sunspec:"offset=0,len=1"`
-	Eltek_Feeding_Phase  uint16 `sunspec:"offset=1,len=1"`
-	Eltek_APD_Method     uint16 `sunspec:"offset=2,len=1"`
-	Eltek_APD_Power_Ref  uint16 `sunspec:"offset=3,len=1"`
-	Eltek_RPS_Method     uint16 `sunspec:"offset=4,len=1"`
-	Eltek_RPS_Q_Ref      uint16 `sunspec:"offset=5,len=1"`
-	Eltek_RPS_CosPhi_Ref int16  `sunspec:"offset=6,len=1"`
+	Eltek_Country_Code   uint16 `sunspec:"offset=0"`
+	Eltek_Feeding_Phase  uint16 `sunspec:"offset=1"`
+	Eltek_APD_Method     uint16 `sunspec:"offset=2"`
+	Eltek_APD_Power_Ref  uint16 `sunspec:"offset=3"`
+	Eltek_RPS_Method     uint16 `sunspec:"offset=4"`
+	Eltek_RPS_Q_Ref      uint16 `sunspec:"offset=5"`
+	Eltek_RPS_CosPhi_Ref int16  `sunspec:"offset=6"`
 }
 
 func (block *Block64101) GetId() sunspec.ModelId {
@@ -53,13 +53,13 @@ func init() {
 				Length: 7,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Eltek_Country_Code, Offset: 0, Type: typelabel.Uint16, Length: 1},
-					{Id: Eltek_Feeding_Phase, Offset: 1, Type: typelabel.Uint16, Length: 1},
-					{Id: Eltek_APD_Method, Offset: 2, Type: typelabel.Uint16, Length: 1},
-					{Id: Eltek_APD_Power_Ref, Offset: 3, Type: typelabel.Uint16, Length: 1},
-					{Id: Eltek_RPS_Method, Offset: 4, Type: typelabel.Uint16, Length: 1},
-					{Id: Eltek_RPS_Q_Ref, Offset: 5, Type: typelabel.Uint16, Length: 1},
-					{Id: Eltek_RPS_CosPhi_Ref, Offset: 6, Type: typelabel.Int16, Length: 1},
+					{Id: Eltek_Country_Code, Offset: 0, Type: typelabel.Uint16},
+					{Id: Eltek_Feeding_Phase, Offset: 1, Type: typelabel.Uint16},
+					{Id: Eltek_APD_Method, Offset: 2, Type: typelabel.Uint16},
+					{Id: Eltek_APD_Power_Ref, Offset: 3, Type: typelabel.Uint16},
+					{Id: Eltek_RPS_Method, Offset: 4, Type: typelabel.Uint16},
+					{Id: Eltek_RPS_Q_Ref, Offset: 5, Type: typelabel.Uint16},
+					{Id: Eltek_RPS_CosPhi_Ref, Offset: 6, Type: typelabel.Int16},
 				},
 			},
 		}})

--- a/models/model64111/model.go
+++ b/models/model64111/model.go
@@ -44,29 +44,29 @@ const (
 )
 
 type Block64111 struct {
-	Port            uint16              `sunspec:"offset=0,len=1"`
-	V_SF            sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	A_SF            sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	P_SF            sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	AH_SF           sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	KWH_SF          sunspec.ScaleFactor `sunspec:"offset=5,len=1"`
-	BattV           uint16              `sunspec:"offset=6,len=1,sf=V_SF"`
-	ArrayV          uint16              `sunspec:"offset=7,len=1,sf=V_SF"`
-	OutputA         uint16              `sunspec:"offset=8,len=1,sf=A_SF"`
-	InputA          uint16              `sunspec:"offset=9,len=1,sf=P_SF"`
-	ChargerSt       sunspec.Enum16      `sunspec:"offset=10,len=1"`
-	OutputW         uint16              `sunspec:"offset=11,len=1,sf=P_SF"`
-	TodayMinBatV    uint16              `sunspec:"offset=12,len=1,sf=V_SF"`
-	TodayMaxBatV    uint16              `sunspec:"offset=13,len=1,sf=V_SF"`
-	VOCV            uint16              `sunspec:"offset=14,len=1,sf=V_SF"`
-	TodayMaxVOC     uint16              `sunspec:"offset=15,len=1,sf=V_SF"`
-	TodaykWhOutput  uint16              `sunspec:"offset=16,len=1,sf=KWH_SF"`
-	TodayAHOutput   uint16              `sunspec:"offset=17,len=1,sf=AH_SF"`
-	LifeTimeKWHOut  uint16              `sunspec:"offset=18,len=1,sf=P_SF"`
-	LifeTimeAHOut   uint16              `sunspec:"offset=19,len=1,sf=KWH_SF"`
-	LifeTimeMaxOut  uint16              `sunspec:"offset=20,len=1,sf=P_SF"`
-	LifeTimeMaxBatt uint16              `sunspec:"offset=21,len=1,sf=V_SF"`
-	LifeTimeMaxVOC  uint16              `sunspec:"offset=22,len=1,sf=V_SF"`
+	Port            uint16              `sunspec:"offset=0"`
+	V_SF            sunspec.ScaleFactor `sunspec:"offset=1"`
+	A_SF            sunspec.ScaleFactor `sunspec:"offset=2"`
+	P_SF            sunspec.ScaleFactor `sunspec:"offset=3"`
+	AH_SF           sunspec.ScaleFactor `sunspec:"offset=4"`
+	KWH_SF          sunspec.ScaleFactor `sunspec:"offset=5"`
+	BattV           uint16              `sunspec:"offset=6,sf=V_SF"`
+	ArrayV          uint16              `sunspec:"offset=7,sf=V_SF"`
+	OutputA         uint16              `sunspec:"offset=8,sf=A_SF"`
+	InputA          uint16              `sunspec:"offset=9,sf=P_SF"`
+	ChargerSt       sunspec.Enum16      `sunspec:"offset=10"`
+	OutputW         uint16              `sunspec:"offset=11,sf=P_SF"`
+	TodayMinBatV    uint16              `sunspec:"offset=12,sf=V_SF"`
+	TodayMaxBatV    uint16              `sunspec:"offset=13,sf=V_SF"`
+	VOCV            uint16              `sunspec:"offset=14,sf=V_SF"`
+	TodayMaxVOC     uint16              `sunspec:"offset=15,sf=V_SF"`
+	TodaykWhOutput  uint16              `sunspec:"offset=16,sf=KWH_SF"`
+	TodayAHOutput   uint16              `sunspec:"offset=17,sf=AH_SF"`
+	LifeTimeKWHOut  uint16              `sunspec:"offset=18,sf=P_SF"`
+	LifeTimeAHOut   uint16              `sunspec:"offset=19,sf=KWH_SF"`
+	LifeTimeMaxOut  uint16              `sunspec:"offset=20,sf=P_SF"`
+	LifeTimeMaxBatt uint16              `sunspec:"offset=21,sf=V_SF"`
+	LifeTimeMaxVOC  uint16              `sunspec:"offset=22,sf=V_SF"`
 }
 
 func (block *Block64111) GetId() sunspec.ModelId {
@@ -85,29 +85,29 @@ func init() {
 				Length: 23,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Port, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Port Number", Description: ""},
-					{Id: V_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: A_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: P_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: AH_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: KWH_SF, Offset: 5, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: BattV, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Battery Voltage", Description: ""},
-					{Id: ArrayV, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Array Voltage", Description: ""},
-					{Id: OutputA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Output Current", Description: ""},
-					{Id: InputA, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "A", Length: 1, Mandatory: true, Label: "Array Current", Description: ""},
-					{Id: ChargerSt, Offset: 10, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Operating State", Description: ""},
-					{Id: OutputW, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "W", Length: 1, Mandatory: true, Label: "Output Wattage", Description: ""},
-					{Id: TodayMinBatV, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Today's Minimum Battery Voltage", Description: ""},
-					{Id: TodayMaxBatV, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Today's Maximum Battery Voltage", Description: ""},
-					{Id: VOCV, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "VOC", Description: ""},
-					{Id: TodayMaxVOC, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Today's Maximum VOC", Description: ""},
-					{Id: TodaykWhOutput, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "KWH_SF", Units: "kWh", Length: 1, Mandatory: true, Label: "Today's kWh", Description: ""},
-					{Id: TodayAHOutput, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "AH_SF", Units: "AH", Length: 1, Mandatory: true, Label: "Today's AH", Description: ""},
-					{Id: LifeTimeKWHOut, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "kWh", Length: 1, Mandatory: true, Label: "Lifetime kWh", Description: ""},
-					{Id: LifeTimeAHOut, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "KWH_SF", Units: "kAH", Length: 1, Mandatory: true, Label: "Lifetime kAH", Description: ""},
-					{Id: LifeTimeMaxOut, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "W", Length: 1, Mandatory: true, Label: "Lifetime Maximum Output Wattage", Description: ""},
-					{Id: LifeTimeMaxBatt, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Lifetime Maximum Battery Voltage", Description: ""},
-					{Id: LifeTimeMaxVOC, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Lifetime Maximum VOC Voltage", Description: ""},
+					{Id: Port, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Port Number", Description: ""},
+					{Id: V_SF, Offset: 1, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: A_SF, Offset: 2, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: P_SF, Offset: 3, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: AH_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: KWH_SF, Offset: 5, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: BattV, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Battery Voltage", Description: ""},
+					{Id: ArrayV, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Array Voltage", Description: ""},
+					{Id: OutputA, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Output Current", Description: ""},
+					{Id: InputA, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "A", Mandatory: true, Label: "Array Current", Description: ""},
+					{Id: ChargerSt, Offset: 10, Type: typelabel.Enum16, Mandatory: true, Label: "Operating State", Description: ""},
+					{Id: OutputW, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "W", Mandatory: true, Label: "Output Wattage", Description: ""},
+					{Id: TodayMinBatV, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Today's Minimum Battery Voltage", Description: ""},
+					{Id: TodayMaxBatV, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Today's Maximum Battery Voltage", Description: ""},
+					{Id: VOCV, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "VOC", Description: ""},
+					{Id: TodayMaxVOC, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Today's Maximum VOC", Description: ""},
+					{Id: TodaykWhOutput, Offset: 16, Type: typelabel.Uint16, ScaleFactor: "KWH_SF", Units: "kWh", Mandatory: true, Label: "Today's kWh", Description: ""},
+					{Id: TodayAHOutput, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "AH_SF", Units: "AH", Mandatory: true, Label: "Today's AH", Description: ""},
+					{Id: LifeTimeKWHOut, Offset: 18, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "kWh", Mandatory: true, Label: "Lifetime kWh", Description: ""},
+					{Id: LifeTimeAHOut, Offset: 19, Type: typelabel.Uint16, ScaleFactor: "KWH_SF", Units: "kAH", Mandatory: true, Label: "Lifetime kAH", Description: ""},
+					{Id: LifeTimeMaxOut, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "P_SF", Units: "W", Mandatory: true, Label: "Lifetime Maximum Output Wattage", Description: ""},
+					{Id: LifeTimeMaxBatt, Offset: 21, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Lifetime Maximum Battery Voltage", Description: ""},
+					{Id: LifeTimeMaxVOC, Offset: 22, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Lifetime Maximum VOC Voltage", Description: ""},
 				},
 			},
 		}})

--- a/models/model64112/model.go
+++ b/models/model64112/model.go
@@ -85,70 +85,70 @@ const (
 )
 
 type Block64112 struct {
-	Port                          uint16              `sunspec:"offset=0,len=1"`
-	V_SF                          sunspec.ScaleFactor `sunspec:"offset=1,len=1"`
-	C_SF                          sunspec.ScaleFactor `sunspec:"offset=2,len=1"`
-	H_SF                          sunspec.ScaleFactor `sunspec:"offset=3,len=1"`
-	P_SF                          sunspec.ScaleFactor `sunspec:"offset=4,len=1"`
-	AH_SF                         sunspec.ScaleFactor `sunspec:"offset=5,len=1"`
-	KWH_SF                        sunspec.ScaleFactor `sunspec:"offset=6,len=1"`
-	CC_Config_fault               sunspec.Bitfield16  `sunspec:"offset=7,len=1"`
-	CC_Config_absorb_V            uint16              `sunspec:"offset=8,len=1,sf=V_SF"`
-	CC_Config_absorb_Hr           uint16              `sunspec:"offset=9,len=1,sf=H_SF"`
-	CC_Config_absorb_End_A        uint16              `sunspec:"offset=10,len=1,sf=V_SF"`
-	CC_Config_rebulk_V            uint16              `sunspec:"offset=11,len=1,sf=V_SF"`
-	CC_Config_float_V             uint16              `sunspec:"offset=12,len=1,sf=V_SF"`
-	CC_Config_max_Chg_A           uint16              `sunspec:"offset=13,len=1,sf=V_SF"`
-	CC_Config_equalize_V          uint16              `sunspec:"offset=14,len=1,sf=V_SF"`
-	CC_Config_equalize_Hr         uint16              `sunspec:"offset=15,len=1"`
-	CC_Config_auto_equalize       uint16              `sunspec:"offset=16,len=1"`
-	CC_Config_MPPT_mode           sunspec.Enum16      `sunspec:"offset=17,len=1"`
-	CC_Config_sweep_width         sunspec.Enum16      `sunspec:"offset=18,len=1"`
-	CC_Config_sweep_max           sunspec.Enum16      `sunspec:"offset=19,len=1"`
-	CC_Config_U_Pick_Duty_cyc     uint16              `sunspec:"offset=20,len=1,sf=V_SF"`
-	CC_Config_grid_tie            sunspec.Enum16      `sunspec:"offset=21,len=1"`
-	CC_Config_temp_comp           sunspec.Enum16      `sunspec:"offset=22,len=1"`
-	CC_Config_temp_comp_llimt     uint16              `sunspec:"offset=23,len=1,sf=V_SF"`
-	CC_Config_temp_comp_hlimt     uint16              `sunspec:"offset=24,len=1,sf=V_SF"`
-	CC_Config_auto_restart        sunspec.Enum16      `sunspec:"offset=25,len=1"`
-	CC_Config_wakeup_VOC          uint16              `sunspec:"offset=26,len=1,sf=V_SF"`
-	CC_Config_snooze_mode_A       uint16              `sunspec:"offset=27,len=1,sf=V_SF"`
-	CC_Config_wakeup_interval     uint16              `sunspec:"offset=28,len=1"`
-	CC_Config_AUX_mode            sunspec.Enum16      `sunspec:"offset=29,len=1"`
-	CC_Config_AUX_control         sunspec.Enum16      `sunspec:"offset=30,len=1"`
-	CC_Config_AUX_state           sunspec.Enum16      `sunspec:"offset=31,len=1"`
-	CC_Config_AUX_polarity        sunspec.Enum16      `sunspec:"offset=32,len=1"`
-	CC_Config_AUX_L_Batt_disc     uint16              `sunspec:"offset=33,len=1,sf=V_SF"`
-	CC_Config_AUX_L_Batt_rcon     uint16              `sunspec:"offset=34,len=1,sf=V_SF"`
-	CC_Config_AUX_L_Batt_dly      uint16              `sunspec:"offset=35,len=1"`
-	CC_Config_AUX_Vent_fan_V      uint16              `sunspec:"offset=36,len=1,sf=V_SF"`
-	CC_Config_AUX_PV_triggerV     uint16              `sunspec:"offset=37,len=1,sf=V_SF"`
-	CC_Config_AUX_PV_trg_h_tm     uint16              `sunspec:"offset=38,len=1"`
-	CC_Config_AUX_Nlite_ThrsV     uint16              `sunspec:"offset=39,len=1,sf=V_SF"`
-	CC_Config_AUX_Nlite_On_tm     uint16              `sunspec:"offset=40,len=1,sf=H_SF"`
-	CC_Config_AUX_Nlite_On_hist   uint16              `sunspec:"offset=41,len=1"`
-	CC_Config_AUX_Nlite_Off_hist  uint16              `sunspec:"offset=42,len=1"`
-	CC_Config_AUX_Error_batt_V    uint16              `sunspec:"offset=43,len=1,sf=V_SF"`
-	CC_Config_AUX_Divert_h_time   uint16              `sunspec:"offset=44,len=1,sf=V_SF"`
-	CC_Config_AUX_Divert_dly_time uint16              `sunspec:"offset=45,len=1"`
-	CC_Config_AUX_Divert_Rel_V    uint16              `sunspec:"offset=46,len=1,sf=V_SF"`
-	CC_Config_AUX_Divert_Hyst_V   uint16              `sunspec:"offset=47,len=1,sf=V_SF"`
-	CC_Config_MajorFWRev          uint16              `sunspec:"offset=48,len=1"`
-	CC_Config_MidFWRev            uint16              `sunspec:"offset=49,len=1"`
-	CC_Config_MinorFWRev          uint16              `sunspec:"offset=50,len=1"`
-	CC_Config_DataLog_Day_offset  uint16              `sunspec:"offset=51,len=1"`
-	CC_Config_DataLog_Cur_Day_off uint16              `sunspec:"offset=52,len=1"`
-	CC_Config_DataLog_Daily_AH    uint16              `sunspec:"offset=53,len=1"`
-	CC_Config_DataLog_Daily_KWH   uint16              `sunspec:"offset=54,len=1,sf=KWH_SF"`
-	CC_Config_DataLog_Max_Out_A   uint16              `sunspec:"offset=55,len=1,sf=V_SF"`
-	CC_Config_DataLog_Max_Out_W   uint16              `sunspec:"offset=56,len=1,sf=V_SF"`
-	CC_Config_DataLog_Absorb_T    uint16              `sunspec:"offset=57,len=1"`
-	CC_Config_DataLog_Float_T     uint16              `sunspec:"offset=58,len=1"`
-	CC_Config_DataLog_Min_Batt_V  uint16              `sunspec:"offset=59,len=1,sf=V_SF"`
-	CC_Config_DataLog_Max_Batt_V  uint16              `sunspec:"offset=60,len=1,sf=V_SF"`
-	CC_Config_DataLog_Max_Input_V uint16              `sunspec:"offset=61,len=1,sf=V_SF"`
-	CC_Config_DataLog_Clear       uint16              `sunspec:"offset=62,len=1"`
-	CC_Config_DataLog_Clr_Comp    uint16              `sunspec:"offset=63,len=1"`
+	Port                          uint16              `sunspec:"offset=0"`
+	V_SF                          sunspec.ScaleFactor `sunspec:"offset=1"`
+	C_SF                          sunspec.ScaleFactor `sunspec:"offset=2"`
+	H_SF                          sunspec.ScaleFactor `sunspec:"offset=3"`
+	P_SF                          sunspec.ScaleFactor `sunspec:"offset=4"`
+	AH_SF                         sunspec.ScaleFactor `sunspec:"offset=5"`
+	KWH_SF                        sunspec.ScaleFactor `sunspec:"offset=6"`
+	CC_Config_fault               sunspec.Bitfield16  `sunspec:"offset=7"`
+	CC_Config_absorb_V            uint16              `sunspec:"offset=8,sf=V_SF"`
+	CC_Config_absorb_Hr           uint16              `sunspec:"offset=9,sf=H_SF"`
+	CC_Config_absorb_End_A        uint16              `sunspec:"offset=10,sf=V_SF"`
+	CC_Config_rebulk_V            uint16              `sunspec:"offset=11,sf=V_SF"`
+	CC_Config_float_V             uint16              `sunspec:"offset=12,sf=V_SF"`
+	CC_Config_max_Chg_A           uint16              `sunspec:"offset=13,sf=V_SF"`
+	CC_Config_equalize_V          uint16              `sunspec:"offset=14,sf=V_SF"`
+	CC_Config_equalize_Hr         uint16              `sunspec:"offset=15"`
+	CC_Config_auto_equalize       uint16              `sunspec:"offset=16"`
+	CC_Config_MPPT_mode           sunspec.Enum16      `sunspec:"offset=17"`
+	CC_Config_sweep_width         sunspec.Enum16      `sunspec:"offset=18"`
+	CC_Config_sweep_max           sunspec.Enum16      `sunspec:"offset=19"`
+	CC_Config_U_Pick_Duty_cyc     uint16              `sunspec:"offset=20,sf=V_SF"`
+	CC_Config_grid_tie            sunspec.Enum16      `sunspec:"offset=21"`
+	CC_Config_temp_comp           sunspec.Enum16      `sunspec:"offset=22"`
+	CC_Config_temp_comp_llimt     uint16              `sunspec:"offset=23,sf=V_SF"`
+	CC_Config_temp_comp_hlimt     uint16              `sunspec:"offset=24,sf=V_SF"`
+	CC_Config_auto_restart        sunspec.Enum16      `sunspec:"offset=25"`
+	CC_Config_wakeup_VOC          uint16              `sunspec:"offset=26,sf=V_SF"`
+	CC_Config_snooze_mode_A       uint16              `sunspec:"offset=27,sf=V_SF"`
+	CC_Config_wakeup_interval     uint16              `sunspec:"offset=28"`
+	CC_Config_AUX_mode            sunspec.Enum16      `sunspec:"offset=29"`
+	CC_Config_AUX_control         sunspec.Enum16      `sunspec:"offset=30"`
+	CC_Config_AUX_state           sunspec.Enum16      `sunspec:"offset=31"`
+	CC_Config_AUX_polarity        sunspec.Enum16      `sunspec:"offset=32"`
+	CC_Config_AUX_L_Batt_disc     uint16              `sunspec:"offset=33,sf=V_SF"`
+	CC_Config_AUX_L_Batt_rcon     uint16              `sunspec:"offset=34,sf=V_SF"`
+	CC_Config_AUX_L_Batt_dly      uint16              `sunspec:"offset=35"`
+	CC_Config_AUX_Vent_fan_V      uint16              `sunspec:"offset=36,sf=V_SF"`
+	CC_Config_AUX_PV_triggerV     uint16              `sunspec:"offset=37,sf=V_SF"`
+	CC_Config_AUX_PV_trg_h_tm     uint16              `sunspec:"offset=38"`
+	CC_Config_AUX_Nlite_ThrsV     uint16              `sunspec:"offset=39,sf=V_SF"`
+	CC_Config_AUX_Nlite_On_tm     uint16              `sunspec:"offset=40,sf=H_SF"`
+	CC_Config_AUX_Nlite_On_hist   uint16              `sunspec:"offset=41"`
+	CC_Config_AUX_Nlite_Off_hist  uint16              `sunspec:"offset=42"`
+	CC_Config_AUX_Error_batt_V    uint16              `sunspec:"offset=43,sf=V_SF"`
+	CC_Config_AUX_Divert_h_time   uint16              `sunspec:"offset=44,sf=V_SF"`
+	CC_Config_AUX_Divert_dly_time uint16              `sunspec:"offset=45"`
+	CC_Config_AUX_Divert_Rel_V    uint16              `sunspec:"offset=46,sf=V_SF"`
+	CC_Config_AUX_Divert_Hyst_V   uint16              `sunspec:"offset=47,sf=V_SF"`
+	CC_Config_MajorFWRev          uint16              `sunspec:"offset=48"`
+	CC_Config_MidFWRev            uint16              `sunspec:"offset=49"`
+	CC_Config_MinorFWRev          uint16              `sunspec:"offset=50"`
+	CC_Config_DataLog_Day_offset  uint16              `sunspec:"offset=51"`
+	CC_Config_DataLog_Cur_Day_off uint16              `sunspec:"offset=52"`
+	CC_Config_DataLog_Daily_AH    uint16              `sunspec:"offset=53"`
+	CC_Config_DataLog_Daily_KWH   uint16              `sunspec:"offset=54,sf=KWH_SF"`
+	CC_Config_DataLog_Max_Out_A   uint16              `sunspec:"offset=55,sf=V_SF"`
+	CC_Config_DataLog_Max_Out_W   uint16              `sunspec:"offset=56,sf=V_SF"`
+	CC_Config_DataLog_Absorb_T    uint16              `sunspec:"offset=57"`
+	CC_Config_DataLog_Float_T     uint16              `sunspec:"offset=58"`
+	CC_Config_DataLog_Min_Batt_V  uint16              `sunspec:"offset=59,sf=V_SF"`
+	CC_Config_DataLog_Max_Batt_V  uint16              `sunspec:"offset=60,sf=V_SF"`
+	CC_Config_DataLog_Max_Input_V uint16              `sunspec:"offset=61,sf=V_SF"`
+	CC_Config_DataLog_Clear       uint16              `sunspec:"offset=62"`
+	CC_Config_DataLog_Clr_Comp    uint16              `sunspec:"offset=63"`
 }
 
 func (block *Block64112) GetId() sunspec.ModelId {
@@ -167,70 +167,70 @@ func init() {
 				Length: 64,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Port, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Port Number", Description: ""},
-					{Id: V_SF, Offset: 1, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: C_SF, Offset: 2, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: H_SF, Offset: 3, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: P_SF, Offset: 4, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: AH_SF, Offset: 5, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: KWH_SF, Offset: 6, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: CC_Config_fault, Offset: 7, Type: typelabel.Bitfield16, Length: 1, Mandatory: true, Label: "Faults", Description: ""},
-					{Id: CC_Config_absorb_V, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Absorb", Description: ""},
-					{Id: CC_Config_absorb_Hr, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "H_SF", Units: "Tmh", Length: 1, Mandatory: true, Label: "Absorb Time", Description: ""},
-					{Id: CC_Config_absorb_End_A, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Length: 1, Mandatory: true, Label: "Absorb End", Description: ""},
-					{Id: CC_Config_rebulk_V, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Rebulk", Description: ""},
-					{Id: CC_Config_float_V, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Float", Description: ""},
-					{Id: CC_Config_max_Chg_A, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Length: 1, Mandatory: true, Label: "Maximum Charge", Description: ""},
-					{Id: CC_Config_equalize_V, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Equalize", Description: ""},
-					{Id: CC_Config_equalize_Hr, Offset: 15, Type: typelabel.Uint16, Units: "Tmh", Length: 1, Mandatory: true, Label: "Equalize Time", Description: ""},
-					{Id: CC_Config_auto_equalize, Offset: 16, Type: typelabel.Uint16, Units: "Tmd", Length: 1, Mandatory: true, Label: "Auto Equalize Interval", Description: ""},
-					{Id: CC_Config_MPPT_mode, Offset: 17, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "MPPT mode", Description: ""},
-					{Id: CC_Config_sweep_width, Offset: 18, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Sweep Width", Description: ""},
-					{Id: CC_Config_sweep_max, Offset: 19, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Sweep Maximum", Description: ""},
-					{Id: CC_Config_U_Pick_Duty_cyc, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "Pct", Length: 1, Mandatory: true, Label: "U-Pick PWM Duty Cycle", Description: ""},
-					{Id: CC_Config_grid_tie, Offset: 21, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Grid Tie Mode", Description: ""},
-					{Id: CC_Config_temp_comp, Offset: 22, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Temp Comp Mode", Description: ""},
-					{Id: CC_Config_temp_comp_llimt, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Temp Comp Lower Limit", Description: ""},
-					{Id: CC_Config_temp_comp_hlimt, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Temp Comp Upper Limit", Description: ""},
-					{Id: CC_Config_auto_restart, Offset: 25, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Auto Restart Mode", Description: ""},
-					{Id: CC_Config_wakeup_VOC, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Wakeup VOC Change", Description: ""},
-					{Id: CC_Config_snooze_mode_A, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Length: 1, Mandatory: true, Label: "Snooze Mode", Description: ""},
-					{Id: CC_Config_wakeup_interval, Offset: 28, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "Wakeup Interval", Description: ""},
-					{Id: CC_Config_AUX_mode, Offset: 29, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "AUX Output Mode", Description: ""},
-					{Id: CC_Config_AUX_control, Offset: 30, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "AUX Output Control", Description: ""},
-					{Id: CC_Config_AUX_state, Offset: 31, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "AUX Output State", Description: ""},
-					{Id: CC_Config_AUX_polarity, Offset: 32, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "AUX Output Polarity", Description: ""},
-					{Id: CC_Config_AUX_L_Batt_disc, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Low Battery Disconnect", Description: ""},
-					{Id: CC_Config_AUX_L_Batt_rcon, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Low Battery Reconnect", Description: ""},
-					{Id: CC_Config_AUX_L_Batt_dly, Offset: 35, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "AUX Low Battery Disconnect Delay", Description: ""},
-					{Id: CC_Config_AUX_Vent_fan_V, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Vent Fan", Description: ""},
-					{Id: CC_Config_AUX_PV_triggerV, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX PV Trigger", Description: ""},
-					{Id: CC_Config_AUX_PV_trg_h_tm, Offset: 38, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "AUX PV Trigger Hold Time", Description: ""},
-					{Id: CC_Config_AUX_Nlite_ThrsV, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Night Light Threshold", Description: ""},
-					{Id: CC_Config_AUX_Nlite_On_tm, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "H_SF", Units: "Tmh", Length: 1, Mandatory: true, Label: "AUX Night Light On Time", Description: ""},
-					{Id: CC_Config_AUX_Nlite_On_hist, Offset: 41, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "AUX Night Light On Hysteresis", Description: ""},
-					{Id: CC_Config_AUX_Nlite_Off_hist, Offset: 42, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "AUX Night Light Off Hysteresis", Description: ""},
-					{Id: CC_Config_AUX_Error_batt_V, Offset: 43, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Error Output Low Battery", Description: ""},
-					{Id: CC_Config_AUX_Divert_h_time, Offset: 44, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "Tms", Length: 1, Mandatory: true, Label: "AUX Divert Hold Time", Description: ""},
-					{Id: CC_Config_AUX_Divert_dly_time, Offset: 45, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "AUX Divert Delay Time", Description: ""},
-					{Id: CC_Config_AUX_Divert_Rel_V, Offset: 46, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Divert Relative", Description: ""},
-					{Id: CC_Config_AUX_Divert_Hyst_V, Offset: 47, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "AUX Divert Hysteresis", Description: ""},
-					{Id: CC_Config_MajorFWRev, Offset: 48, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "FM CC Major Firmware Number", Description: ""},
-					{Id: CC_Config_MidFWRev, Offset: 49, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "FM CC Mid Firmware Number", Description: ""},
-					{Id: CC_Config_MinorFWRev, Offset: 50, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "FM CC Minor Firmware Number", Description: ""},
-					{Id: CC_Config_DataLog_Day_offset, Offset: 51, Type: typelabel.Uint16, Units: "Tmd", Length: 1, Mandatory: true, Label: "Set Data Log Day Offset", Description: ""},
-					{Id: CC_Config_DataLog_Cur_Day_off, Offset: 52, Type: typelabel.Uint16, Units: "Tmd", Length: 1, Mandatory: true, Label: "Current Data Log Day Offset", Description: ""},
-					{Id: CC_Config_DataLog_Daily_AH, Offset: 53, Type: typelabel.Uint16, Units: "Ah", Length: 1, Mandatory: true, Label: "Data Log Daily (Ah)", Description: ""},
-					{Id: CC_Config_DataLog_Daily_KWH, Offset: 54, Type: typelabel.Uint16, ScaleFactor: "KWH_SF", Units: "kWh", Length: 1, Mandatory: true, Label: "Data Log Daily (kWh)", Description: ""},
-					{Id: CC_Config_DataLog_Max_Out_A, Offset: 55, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Length: 1, Mandatory: true, Label: "Data Log Daily Maximum Output (A)", Description: ""},
-					{Id: CC_Config_DataLog_Max_Out_W, Offset: 56, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "W", Length: 1, Mandatory: true, Label: "Data Log Daily Maximum Output (W)", Description: ""},
-					{Id: CC_Config_DataLog_Absorb_T, Offset: 57, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "Data Log Daily Absorb Time", Description: ""},
-					{Id: CC_Config_DataLog_Float_T, Offset: 58, Type: typelabel.Uint16, Units: "Tms", Length: 1, Mandatory: true, Label: "Data Log Daily Float Time", Description: ""},
-					{Id: CC_Config_DataLog_Min_Batt_V, Offset: 59, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Data Log Daily Minimum Battery", Description: ""},
-					{Id: CC_Config_DataLog_Max_Batt_V, Offset: 60, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Data Log Daily Maximum Battery", Description: ""},
-					{Id: CC_Config_DataLog_Max_Input_V, Offset: 61, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Data Log Daily Maximum Input", Description: ""},
-					{Id: CC_Config_DataLog_Clear, Offset: 62, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Data Log Clear", Description: ""},
-					{Id: CC_Config_DataLog_Clr_Comp, Offset: 63, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Data Log Clear Complement", Description: ""},
+					{Id: Port, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Port Number", Description: ""},
+					{Id: V_SF, Offset: 1, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: C_SF, Offset: 2, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: H_SF, Offset: 3, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: P_SF, Offset: 4, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: AH_SF, Offset: 5, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: KWH_SF, Offset: 6, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: CC_Config_fault, Offset: 7, Type: typelabel.Bitfield16, Mandatory: true, Label: "Faults", Description: ""},
+					{Id: CC_Config_absorb_V, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Absorb", Description: ""},
+					{Id: CC_Config_absorb_Hr, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "H_SF", Units: "Tmh", Mandatory: true, Label: "Absorb Time", Description: ""},
+					{Id: CC_Config_absorb_End_A, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Mandatory: true, Label: "Absorb End", Description: ""},
+					{Id: CC_Config_rebulk_V, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Rebulk", Description: ""},
+					{Id: CC_Config_float_V, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Float", Description: ""},
+					{Id: CC_Config_max_Chg_A, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Mandatory: true, Label: "Maximum Charge", Description: ""},
+					{Id: CC_Config_equalize_V, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Equalize", Description: ""},
+					{Id: CC_Config_equalize_Hr, Offset: 15, Type: typelabel.Uint16, Units: "Tmh", Mandatory: true, Label: "Equalize Time", Description: ""},
+					{Id: CC_Config_auto_equalize, Offset: 16, Type: typelabel.Uint16, Units: "Tmd", Mandatory: true, Label: "Auto Equalize Interval", Description: ""},
+					{Id: CC_Config_MPPT_mode, Offset: 17, Type: typelabel.Enum16, Mandatory: true, Label: "MPPT mode", Description: ""},
+					{Id: CC_Config_sweep_width, Offset: 18, Type: typelabel.Enum16, Mandatory: true, Label: "Sweep Width", Description: ""},
+					{Id: CC_Config_sweep_max, Offset: 19, Type: typelabel.Enum16, Mandatory: true, Label: "Sweep Maximum", Description: ""},
+					{Id: CC_Config_U_Pick_Duty_cyc, Offset: 20, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "Pct", Mandatory: true, Label: "U-Pick PWM Duty Cycle", Description: ""},
+					{Id: CC_Config_grid_tie, Offset: 21, Type: typelabel.Enum16, Mandatory: true, Label: "Grid Tie Mode", Description: ""},
+					{Id: CC_Config_temp_comp, Offset: 22, Type: typelabel.Enum16, Mandatory: true, Label: "Temp Comp Mode", Description: ""},
+					{Id: CC_Config_temp_comp_llimt, Offset: 23, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Temp Comp Lower Limit", Description: ""},
+					{Id: CC_Config_temp_comp_hlimt, Offset: 24, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Temp Comp Upper Limit", Description: ""},
+					{Id: CC_Config_auto_restart, Offset: 25, Type: typelabel.Enum16, Mandatory: true, Label: "Auto Restart Mode", Description: ""},
+					{Id: CC_Config_wakeup_VOC, Offset: 26, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Wakeup VOC Change", Description: ""},
+					{Id: CC_Config_snooze_mode_A, Offset: 27, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Mandatory: true, Label: "Snooze Mode", Description: ""},
+					{Id: CC_Config_wakeup_interval, Offset: 28, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "Wakeup Interval", Description: ""},
+					{Id: CC_Config_AUX_mode, Offset: 29, Type: typelabel.Enum16, Mandatory: true, Label: "AUX Output Mode", Description: ""},
+					{Id: CC_Config_AUX_control, Offset: 30, Type: typelabel.Enum16, Mandatory: true, Label: "AUX Output Control", Description: ""},
+					{Id: CC_Config_AUX_state, Offset: 31, Type: typelabel.Enum16, Mandatory: true, Label: "AUX Output State", Description: ""},
+					{Id: CC_Config_AUX_polarity, Offset: 32, Type: typelabel.Enum16, Mandatory: true, Label: "AUX Output Polarity", Description: ""},
+					{Id: CC_Config_AUX_L_Batt_disc, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Low Battery Disconnect", Description: ""},
+					{Id: CC_Config_AUX_L_Batt_rcon, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Low Battery Reconnect", Description: ""},
+					{Id: CC_Config_AUX_L_Batt_dly, Offset: 35, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "AUX Low Battery Disconnect Delay", Description: ""},
+					{Id: CC_Config_AUX_Vent_fan_V, Offset: 36, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Vent Fan", Description: ""},
+					{Id: CC_Config_AUX_PV_triggerV, Offset: 37, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX PV Trigger", Description: ""},
+					{Id: CC_Config_AUX_PV_trg_h_tm, Offset: 38, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "AUX PV Trigger Hold Time", Description: ""},
+					{Id: CC_Config_AUX_Nlite_ThrsV, Offset: 39, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Night Light Threshold", Description: ""},
+					{Id: CC_Config_AUX_Nlite_On_tm, Offset: 40, Type: typelabel.Uint16, ScaleFactor: "H_SF", Units: "Tmh", Mandatory: true, Label: "AUX Night Light On Time", Description: ""},
+					{Id: CC_Config_AUX_Nlite_On_hist, Offset: 41, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "AUX Night Light On Hysteresis", Description: ""},
+					{Id: CC_Config_AUX_Nlite_Off_hist, Offset: 42, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "AUX Night Light Off Hysteresis", Description: ""},
+					{Id: CC_Config_AUX_Error_batt_V, Offset: 43, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Error Output Low Battery", Description: ""},
+					{Id: CC_Config_AUX_Divert_h_time, Offset: 44, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "Tms", Mandatory: true, Label: "AUX Divert Hold Time", Description: ""},
+					{Id: CC_Config_AUX_Divert_dly_time, Offset: 45, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "AUX Divert Delay Time", Description: ""},
+					{Id: CC_Config_AUX_Divert_Rel_V, Offset: 46, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Divert Relative", Description: ""},
+					{Id: CC_Config_AUX_Divert_Hyst_V, Offset: 47, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "AUX Divert Hysteresis", Description: ""},
+					{Id: CC_Config_MajorFWRev, Offset: 48, Type: typelabel.Uint16, Mandatory: true, Label: "FM CC Major Firmware Number", Description: ""},
+					{Id: CC_Config_MidFWRev, Offset: 49, Type: typelabel.Uint16, Mandatory: true, Label: "FM CC Mid Firmware Number", Description: ""},
+					{Id: CC_Config_MinorFWRev, Offset: 50, Type: typelabel.Uint16, Mandatory: true, Label: "FM CC Minor Firmware Number", Description: ""},
+					{Id: CC_Config_DataLog_Day_offset, Offset: 51, Type: typelabel.Uint16, Units: "Tmd", Mandatory: true, Label: "Set Data Log Day Offset", Description: ""},
+					{Id: CC_Config_DataLog_Cur_Day_off, Offset: 52, Type: typelabel.Uint16, Units: "Tmd", Mandatory: true, Label: "Current Data Log Day Offset", Description: ""},
+					{Id: CC_Config_DataLog_Daily_AH, Offset: 53, Type: typelabel.Uint16, Units: "Ah", Mandatory: true, Label: "Data Log Daily (Ah)", Description: ""},
+					{Id: CC_Config_DataLog_Daily_KWH, Offset: 54, Type: typelabel.Uint16, ScaleFactor: "KWH_SF", Units: "kWh", Mandatory: true, Label: "Data Log Daily (kWh)", Description: ""},
+					{Id: CC_Config_DataLog_Max_Out_A, Offset: 55, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "A", Mandatory: true, Label: "Data Log Daily Maximum Output (A)", Description: ""},
+					{Id: CC_Config_DataLog_Max_Out_W, Offset: 56, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "W", Mandatory: true, Label: "Data Log Daily Maximum Output (W)", Description: ""},
+					{Id: CC_Config_DataLog_Absorb_T, Offset: 57, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "Data Log Daily Absorb Time", Description: ""},
+					{Id: CC_Config_DataLog_Float_T, Offset: 58, Type: typelabel.Uint16, Units: "Tms", Mandatory: true, Label: "Data Log Daily Float Time", Description: ""},
+					{Id: CC_Config_DataLog_Min_Batt_V, Offset: 59, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Data Log Daily Minimum Battery", Description: ""},
+					{Id: CC_Config_DataLog_Max_Batt_V, Offset: 60, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Data Log Daily Maximum Battery", Description: ""},
+					{Id: CC_Config_DataLog_Max_Input_V, Offset: 61, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Data Log Daily Maximum Input", Description: ""},
+					{Id: CC_Config_DataLog_Clear, Offset: 62, Type: typelabel.Uint16, Mandatory: true, Label: "Data Log Clear", Description: ""},
+					{Id: CC_Config_DataLog_Clr_Comp, Offset: 63, Type: typelabel.Uint16, Mandatory: true, Label: "Data Log Clear Complement", Description: ""},
 				},
 			},
 		}})

--- a/models/model7/model.go
+++ b/models/model7/model.go
@@ -31,19 +31,19 @@ const (
 )
 
 type Block7Repeat struct {
-	DS uint16 `sunspec:"offset=0,len=1,access=rw"`
+	DS uint16 `sunspec:"offset=0,access=rw"`
 }
 
 type Block7 struct {
-	RqSeq uint16         `sunspec:"offset=0,len=1"`
-	Sts   sunspec.Enum16 `sunspec:"offset=1,len=1"`
-	Ts    uint32         `sunspec:"offset=2,len=2"`
-	Ms    uint16         `sunspec:"offset=4,len=1"`
-	Seq   uint16         `sunspec:"offset=5,len=1"`
-	Alm   sunspec.Enum16 `sunspec:"offset=6,len=1"`
-	Rsrvd sunspec.Pad    `sunspec:"offset=7,len=1"`
-	Alg   sunspec.Enum16 `sunspec:"offset=8,len=1"`
-	N     uint16         `sunspec:"offset=9,len=1,access=rw"`
+	RqSeq uint16         `sunspec:"offset=0"`
+	Sts   sunspec.Enum16 `sunspec:"offset=1"`
+	Ts    uint32         `sunspec:"offset=2"`
+	Ms    uint16         `sunspec:"offset=4"`
+	Seq   uint16         `sunspec:"offset=5"`
+	Alm   sunspec.Enum16 `sunspec:"offset=6"`
+	Rsrvd sunspec.Pad    `sunspec:"offset=7"`
+	Alg   sunspec.Enum16 `sunspec:"offset=8"`
+	N     uint16         `sunspec:"offset=9,access=rw"`
 
 	Repeats []Block7Repeat
 }
@@ -64,22 +64,22 @@ func init() {
 				Length: 10,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: RqSeq, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Request Sequence", Description: "Sequence number from the request"},
-					{Id: Sts, Offset: 1, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Status", Description: "Status of last write operation"},
-					{Id: Ts, Offset: 2, Type: typelabel.Uint32, Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 4, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 5, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of response"},
-					{Id: Alm, Offset: 6, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Alarm", Description: "Bitmask alarm code"},
-					{Id: Rsrvd, Offset: 7, Type: typelabel.Pad, Length: 1, Mandatory: true},
-					{Id: Alg, Offset: 8, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 9, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
+					{Id: RqSeq, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Request Sequence", Description: "Sequence number from the request"},
+					{Id: Sts, Offset: 1, Type: typelabel.Enum16, Mandatory: true, Label: "Status", Description: "Status of last write operation"},
+					{Id: Ts, Offset: 2, Type: typelabel.Uint32, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 4, Type: typelabel.Uint16, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 5, Type: typelabel.Uint16, Mandatory: true, Label: "Sequence", Description: "Sequence number of response"},
+					{Id: Alm, Offset: 6, Type: typelabel.Enum16, Mandatory: true, Label: "Alarm", Description: "Bitmask alarm code"},
+					{Id: Rsrvd, Offset: 7, Type: typelabel.Pad, Mandatory: true},
+					{Id: Alg, Offset: 8, Type: typelabel.Enum16, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 9, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "N", Description: "Number of registers comprising the digital signature."},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: DS, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "DS", Description: "Digital Signature"},
+					{Id: DS, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "DS", Description: "Digital Signature"},
 				},
 			},
 		}})

--- a/models/model8/model.go
+++ b/models/model8/model.go
@@ -24,12 +24,12 @@ const (
 )
 
 type Block8Repeat struct {
-	Cert uint16 `sunspec:"offset=0,len=1"`
+	Cert uint16 `sunspec:"offset=0"`
 }
 
 type Block8 struct {
-	Fmt sunspec.Enum16 `sunspec:"offset=0,len=1"`
-	N   uint16         `sunspec:"offset=1,len=1"`
+	Fmt sunspec.Enum16 `sunspec:"offset=0"`
+	N   uint16         `sunspec:"offset=1"`
 
 	Repeats []Block8Repeat
 }
@@ -50,15 +50,15 @@ func init() {
 				Length: 2,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Fmt, Offset: 0, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Format", Description: "X.509 format of the certificate. DER or PEM."},
-					{Id: N, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "N", Description: "Number of registers to follow for the certificate"},
+					{Id: Fmt, Offset: 0, Type: typelabel.Enum16, Mandatory: true, Label: "Format", Description: "X.509 format of the certificate. DER or PEM."},
+					{Id: N, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "N", Description: "Number of registers to follow for the certificate"},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: Cert, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Cert", Description: "X.509 Certificate of the device"},
+					{Id: Cert, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Cert", Description: "X.509 Certificate of the device"},
 				},
 			},
 		}})

--- a/models/model801/model.go
+++ b/models/model801/model.go
@@ -22,7 +22,7 @@ const (
 )
 
 type Block801 struct {
-	DEPRECATED sunspec.Enum16 `sunspec:"offset=0,len=1"`
+	DEPRECATED sunspec.Enum16 `sunspec:"offset=0"`
 }
 
 func (block *Block801) GetId() sunspec.ModelId {
@@ -41,7 +41,7 @@ func init() {
 				Length: 1,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: DEPRECATED, Offset: 0, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Deprecated Model", Description: "This model has been deprecated."},
+					{Id: DEPRECATED, Offset: 0, Type: typelabel.Enum16, Mandatory: true, Label: "Deprecated Model", Description: "This model has been deprecated."},
 				},
 			},
 		}})

--- a/models/model802/model.go
+++ b/models/model802/model.go
@@ -77,62 +77,62 @@ const (
 )
 
 type Block802 struct {
-	AHRtg            uint16              `sunspec:"offset=0,len=1,sf=AHRtg_SF"`
-	WHRtg            uint16              `sunspec:"offset=1,len=1,sf=WHRtg_SF"`
-	WChaRteMax       uint16              `sunspec:"offset=2,len=1,sf=WChaDisChaMax_SF"`
-	WDisChaRteMax    uint16              `sunspec:"offset=3,len=1,sf=WChaDisChaMax_SF"`
-	DisChaRte        uint16              `sunspec:"offset=4,len=1,sf=DisChaRte_SF"`
-	SoCMax           uint16              `sunspec:"offset=5,len=1,sf=SoC_SF"`
-	SoCMin           uint16              `sunspec:"offset=6,len=1,sf=SoC_SF"`
-	SocRsvMax        uint16              `sunspec:"offset=7,len=1,sf=SoC_SF,access=rw"`
-	SoCRsvMin        uint16              `sunspec:"offset=8,len=1,sf=SoC_SF,access=rw"`
-	SoC              uint16              `sunspec:"offset=9,len=1,sf=SoC_SF"`
-	DoD              uint16              `sunspec:"offset=10,len=1,sf=DoD_SF"`
-	SoH              uint16              `sunspec:"offset=11,len=1,sf=SoH_SF"`
-	NCyc             uint32              `sunspec:"offset=12,len=2"`
-	ChaSt            sunspec.Enum16      `sunspec:"offset=14,len=1"`
-	LocRemCtl        sunspec.Enum16      `sunspec:"offset=15,len=1"`
-	Hb               uint16              `sunspec:"offset=16,len=1"`
-	CtrlHb           uint16              `sunspec:"offset=17,len=1,access=rw"`
-	AlmRst           uint16              `sunspec:"offset=18,len=1,access=rw"`
-	Typ              sunspec.Enum16      `sunspec:"offset=19,len=1"`
-	State            sunspec.Enum16      `sunspec:"offset=20,len=1"`
-	StateVnd         sunspec.Enum16      `sunspec:"offset=21,len=1"`
-	WarrDt           uint32              `sunspec:"offset=22,len=2"`
-	Evt1             sunspec.Bitfield32  `sunspec:"offset=24,len=2"`
-	Evt2             sunspec.Bitfield32  `sunspec:"offset=26,len=2"`
-	EvtVnd1          sunspec.Bitfield32  `sunspec:"offset=28,len=2"`
-	EvtVnd2          sunspec.Bitfield32  `sunspec:"offset=30,len=2"`
-	V                uint16              `sunspec:"offset=32,len=1,sf=V_SF"`
-	VMax             uint16              `sunspec:"offset=33,len=1,sf=V_SF"`
-	VMin             uint16              `sunspec:"offset=34,len=1,sf=V_SF"`
-	CellVMax         uint16              `sunspec:"offset=35,len=1,sf=CellV_SF"`
-	CellVMaxStr      uint16              `sunspec:"offset=36,len=1"`
-	CellVMaxMod      uint16              `sunspec:"offset=37,len=1"`
-	CellVMin         uint16              `sunspec:"offset=38,len=1,sf=CellV_SF"`
-	CellVMinStr      uint16              `sunspec:"offset=39,len=1"`
-	CellVMinMod      uint16              `sunspec:"offset=40,len=1"`
-	CellVAvg         uint16              `sunspec:"offset=41,len=1,sf=CellV_SF"`
-	A                int16               `sunspec:"offset=42,len=1,sf=A_SF"`
-	AChaMax          uint16              `sunspec:"offset=43,len=1,sf=AMax_SF"`
-	ADisChaMax       uint16              `sunspec:"offset=44,len=1,sf=AMax_SF"`
-	W                int16               `sunspec:"offset=45,len=1,sf=W_SF"`
-	ReqInvState      sunspec.Enum16      `sunspec:"offset=46,len=1"`
-	ReqW             int16               `sunspec:"offset=47,len=1,sf=W_SF"`
-	SetOp            sunspec.Enum16      `sunspec:"offset=48,len=1,access=rw"`
-	SetInvState      sunspec.Enum16      `sunspec:"offset=49,len=1,access=rw"`
-	AHRtg_SF         sunspec.ScaleFactor `sunspec:"offset=50,len=1"`
-	WHRtg_SF         sunspec.ScaleFactor `sunspec:"offset=51,len=1"`
-	WChaDisChaMax_SF sunspec.ScaleFactor `sunspec:"offset=52,len=1"`
-	DisChaRte_SF     sunspec.ScaleFactor `sunspec:"offset=53,len=1"`
-	SoC_SF           sunspec.ScaleFactor `sunspec:"offset=54,len=1"`
-	DoD_SF           sunspec.ScaleFactor `sunspec:"offset=55,len=1"`
-	SoH_SF           sunspec.ScaleFactor `sunspec:"offset=56,len=1"`
-	V_SF             sunspec.ScaleFactor `sunspec:"offset=57,len=1"`
-	CellV_SF         sunspec.ScaleFactor `sunspec:"offset=58,len=1"`
-	A_SF             sunspec.ScaleFactor `sunspec:"offset=59,len=1"`
-	AMax_SF          sunspec.ScaleFactor `sunspec:"offset=60,len=1"`
-	W_SF             sunspec.ScaleFactor `sunspec:"offset=61,len=1"`
+	AHRtg            uint16              `sunspec:"offset=0,sf=AHRtg_SF"`
+	WHRtg            uint16              `sunspec:"offset=1,sf=WHRtg_SF"`
+	WChaRteMax       uint16              `sunspec:"offset=2,sf=WChaDisChaMax_SF"`
+	WDisChaRteMax    uint16              `sunspec:"offset=3,sf=WChaDisChaMax_SF"`
+	DisChaRte        uint16              `sunspec:"offset=4,sf=DisChaRte_SF"`
+	SoCMax           uint16              `sunspec:"offset=5,sf=SoC_SF"`
+	SoCMin           uint16              `sunspec:"offset=6,sf=SoC_SF"`
+	SocRsvMax        uint16              `sunspec:"offset=7,sf=SoC_SF,access=rw"`
+	SoCRsvMin        uint16              `sunspec:"offset=8,sf=SoC_SF,access=rw"`
+	SoC              uint16              `sunspec:"offset=9,sf=SoC_SF"`
+	DoD              uint16              `sunspec:"offset=10,sf=DoD_SF"`
+	SoH              uint16              `sunspec:"offset=11,sf=SoH_SF"`
+	NCyc             uint32              `sunspec:"offset=12"`
+	ChaSt            sunspec.Enum16      `sunspec:"offset=14"`
+	LocRemCtl        sunspec.Enum16      `sunspec:"offset=15"`
+	Hb               uint16              `sunspec:"offset=16"`
+	CtrlHb           uint16              `sunspec:"offset=17,access=rw"`
+	AlmRst           uint16              `sunspec:"offset=18,access=rw"`
+	Typ              sunspec.Enum16      `sunspec:"offset=19"`
+	State            sunspec.Enum16      `sunspec:"offset=20"`
+	StateVnd         sunspec.Enum16      `sunspec:"offset=21"`
+	WarrDt           uint32              `sunspec:"offset=22"`
+	Evt1             sunspec.Bitfield32  `sunspec:"offset=24"`
+	Evt2             sunspec.Bitfield32  `sunspec:"offset=26"`
+	EvtVnd1          sunspec.Bitfield32  `sunspec:"offset=28"`
+	EvtVnd2          sunspec.Bitfield32  `sunspec:"offset=30"`
+	V                uint16              `sunspec:"offset=32,sf=V_SF"`
+	VMax             uint16              `sunspec:"offset=33,sf=V_SF"`
+	VMin             uint16              `sunspec:"offset=34,sf=V_SF"`
+	CellVMax         uint16              `sunspec:"offset=35,sf=CellV_SF"`
+	CellVMaxStr      uint16              `sunspec:"offset=36"`
+	CellVMaxMod      uint16              `sunspec:"offset=37"`
+	CellVMin         uint16              `sunspec:"offset=38,sf=CellV_SF"`
+	CellVMinStr      uint16              `sunspec:"offset=39"`
+	CellVMinMod      uint16              `sunspec:"offset=40"`
+	CellVAvg         uint16              `sunspec:"offset=41,sf=CellV_SF"`
+	A                int16               `sunspec:"offset=42,sf=A_SF"`
+	AChaMax          uint16              `sunspec:"offset=43,sf=AMax_SF"`
+	ADisChaMax       uint16              `sunspec:"offset=44,sf=AMax_SF"`
+	W                int16               `sunspec:"offset=45,sf=W_SF"`
+	ReqInvState      sunspec.Enum16      `sunspec:"offset=46"`
+	ReqW             int16               `sunspec:"offset=47,sf=W_SF"`
+	SetOp            sunspec.Enum16      `sunspec:"offset=48,access=rw"`
+	SetInvState      sunspec.Enum16      `sunspec:"offset=49,access=rw"`
+	AHRtg_SF         sunspec.ScaleFactor `sunspec:"offset=50"`
+	WHRtg_SF         sunspec.ScaleFactor `sunspec:"offset=51"`
+	WChaDisChaMax_SF sunspec.ScaleFactor `sunspec:"offset=52"`
+	DisChaRte_SF     sunspec.ScaleFactor `sunspec:"offset=53"`
+	SoC_SF           sunspec.ScaleFactor `sunspec:"offset=54"`
+	DoD_SF           sunspec.ScaleFactor `sunspec:"offset=55"`
+	SoH_SF           sunspec.ScaleFactor `sunspec:"offset=56"`
+	V_SF             sunspec.ScaleFactor `sunspec:"offset=57"`
+	CellV_SF         sunspec.ScaleFactor `sunspec:"offset=58"`
+	A_SF             sunspec.ScaleFactor `sunspec:"offset=59"`
+	AMax_SF          sunspec.ScaleFactor `sunspec:"offset=60"`
+	W_SF             sunspec.ScaleFactor `sunspec:"offset=61"`
 }
 
 func (block *Block802) GetId() sunspec.ModelId {
@@ -151,62 +151,62 @@ func init() {
 				Length: 62,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: AHRtg, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "AHRtg_SF", Units: "Ah", Length: 1, Mandatory: true, Label: "Nameplate Charge Capacity", Description: "Nameplate charge capacity in amp-hours."},
-					{Id: WHRtg, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "WHRtg_SF", Units: "Wh", Length: 1, Mandatory: true, Label: "Nameplate Energy Capacity", Description: "Nameplate energy capacity in DC watt-hours."},
-					{Id: WChaRteMax, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaMax_SF", Units: "W", Length: 1, Mandatory: true, Label: "Nameplate Max Charge Rate", Description: "Maximum rate of energy transfer into the storage device in DC watts."},
-					{Id: WDisChaRteMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaMax_SF", Units: "W", Length: 1, Mandatory: true, Label: "Nameplate Max Discharge Rate", Description: "Maximum rate of energy transfer out of the storage device in DC watts."},
-					{Id: DisChaRte, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "DisChaRte_SF", Units: "%WHRtg", Length: 1, Label: "Self Discharge Rate", Description: "Self discharge rate.  Percentage of capacity (WHRtg) discharged per day."},
-					{Id: SoCMax, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Length: 1, Label: "Nameplate Max SoC", Description: "Manufacturer maximum state of charge, expressed as a percentage."},
-					{Id: SoCMin, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Length: 1, Label: "Nameplate Min SoC", Description: "Manufacturer minimum state of charge, expressed as a percentage."},
-					{Id: SocRsvMax, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Access: "rw", Length: 1, Label: "Max Reserve Percent", Description: "Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage."},
-					{Id: SoCRsvMin, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Access: "rw", Length: 1, Label: "Min Reserve Percent", Description: "Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage."},
-					{Id: SoC, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Length: 1, Mandatory: true, Label: "State of Charge", Description: "State of charge, expressed as a percentage."},
-					{Id: DoD, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "DoD_SF", Units: "%", Length: 1, Label: "Depth of Discharge", Description: "Depth of discharge, expressed as a percentage."},
-					{Id: SoH, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Length: 1, Label: "State of Health", Description: "Percentage of battery life remaining."},
-					{Id: NCyc, Offset: 12, Type: typelabel.Uint32, Length: 2, Label: "Cycle Count", Description: "Number of cycles executed in the battery."},
-					{Id: ChaSt, Offset: 14, Type: typelabel.Enum16, Length: 1, Label: "Charge Status", Description: "Charge status of storage device. Enumeration."},
-					{Id: LocRemCtl, Offset: 15, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Control Mode", Description: "Battery control mode. Enumeration."},
-					{Id: Hb, Offset: 16, Type: typelabel.Uint16, Length: 1, Label: "Battery Heartbeat", Description: "Value is incremented every second with periodic resets to zero."},
-					{Id: CtrlHb, Offset: 17, Type: typelabel.Uint16, Access: "rw", Length: 1, Label: "Controller Heartbeat", Description: "Value is incremented every second with periodic resets to zero."},
-					{Id: AlmRst, Offset: 18, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Alarm Reset", Description: "Used to reset any latched alarms.  1 = Reset."},
-					{Id: Typ, Offset: 19, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "Battery Type", Description: "Type of battery. Enumeration."},
-					{Id: State, Offset: 20, Type: typelabel.Enum16, Length: 1, Mandatory: true, Label: "State of the Battery Bank", Description: "State of the battery bank.  Enumeration."},
-					{Id: StateVnd, Offset: 21, Type: typelabel.Enum16, Length: 1, Label: "Vendor Battery Bank State", Description: "Vendor specific battery bank state.  Enumeration."},
-					{Id: WarrDt, Offset: 22, Type: typelabel.Uint32, Length: 2, Label: "Warranty Date", Description: "Date the device warranty expires."},
-					{Id: Evt1, Offset: 24, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Battery Event 1 Bitfield", Description: "Alarms and warnings.  Bit flags."},
-					{Id: Evt2, Offset: 26, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Battery Event 2 Bitfield", Description: "Alarms and warnings.  Bit flags."},
-					{Id: EvtVnd1, Offset: 28, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events."},
-					{Id: EvtVnd2, Offset: 30, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events."},
-					{Id: V, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "External Battery Voltage", Description: "DC Bus Voltage."},
-					{Id: VMax, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Max Battery Voltage", Description: "Instantaneous maximum battery voltage."},
-					{Id: VMin, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Min Battery Voltage", Description: "Instantaneous minimum battery voltage."},
-					{Id: CellVMax, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the bank."},
-					{Id: CellVMaxStr, Offset: 36, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage String", Description: "String containing the cell with maximum voltage."},
-					{Id: CellVMaxMod, Offset: 37, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Module", Description: "Module containing the cell with maximum voltage."},
-					{Id: CellVMin, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the bank."},
-					{Id: CellVMinStr, Offset: 39, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage String", Description: "String containing the cell with minimum voltage."},
-					{Id: CellVMinMod, Offset: 40, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Module", Description: "Module containing the cell with minimum voltage."},
-					{Id: CellVAvg, Offset: 41, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Average Cell Voltage", Description: "Average cell voltage for all cells in the bank."},
-					{Id: A, Offset: 42, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "Total DC Current", Description: "Total DC current flowing to/from the battery bank."},
-					{Id: AChaMax, Offset: 43, Type: typelabel.Uint16, ScaleFactor: "AMax_SF", Units: "A", Length: 1, Label: "Max Charge Current", Description: "Instantaneous maximum DC charge current."},
-					{Id: ADisChaMax, Offset: 44, Type: typelabel.Uint16, ScaleFactor: "AMax_SF", Units: "A", Length: 1, Label: "Max Discharge Current", Description: "Instantaneous maximum DC discharge current."},
-					{Id: W, Offset: 45, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Mandatory: true, Label: "Total Power", Description: "Total power flowing to/from the battery bank."},
-					{Id: ReqInvState, Offset: 46, Type: typelabel.Enum16, Length: 1, Label: "Inverter State Request", Description: "Request from battery to start or stop the inverter.  Enumeration."},
-					{Id: ReqW, Offset: 47, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Length: 1, Label: "Battery Power Request", Description: "AC Power requested by battery."},
-					{Id: SetOp, Offset: 48, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Set Operation", Description: "Instruct the battery bank to perform an operation such as connecting.  Enumeration."},
-					{Id: SetInvState, Offset: 49, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Set Inverter State", Description: "Set the current state of the inverter."},
-					{Id: AHRtg_SF, Offset: 50, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: WHRtg_SF, Offset: 51, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: WChaDisChaMax_SF, Offset: 52, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DisChaRte_SF, Offset: 53, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: SoC_SF, Offset: 54, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: DoD_SF, Offset: 55, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: SoH_SF, Offset: 56, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: V_SF, Offset: 57, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: CellV_SF, Offset: 58, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: A_SF, Offset: 59, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: AMax_SF, Offset: 60, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: W_SF, Offset: 61, Type: typelabel.ScaleFactor, Length: 1},
+					{Id: AHRtg, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "AHRtg_SF", Units: "Ah", Mandatory: true, Label: "Nameplate Charge Capacity", Description: "Nameplate charge capacity in amp-hours."},
+					{Id: WHRtg, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "WHRtg_SF", Units: "Wh", Mandatory: true, Label: "Nameplate Energy Capacity", Description: "Nameplate energy capacity in DC watt-hours."},
+					{Id: WChaRteMax, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaMax_SF", Units: "W", Mandatory: true, Label: "Nameplate Max Charge Rate", Description: "Maximum rate of energy transfer into the storage device in DC watts."},
+					{Id: WDisChaRteMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "WChaDisChaMax_SF", Units: "W", Mandatory: true, Label: "Nameplate Max Discharge Rate", Description: "Maximum rate of energy transfer out of the storage device in DC watts."},
+					{Id: DisChaRte, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "DisChaRte_SF", Units: "%WHRtg", Label: "Self Discharge Rate", Description: "Self discharge rate.  Percentage of capacity (WHRtg) discharged per day."},
+					{Id: SoCMax, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Label: "Nameplate Max SoC", Description: "Manufacturer maximum state of charge, expressed as a percentage."},
+					{Id: SoCMin, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Label: "Nameplate Min SoC", Description: "Manufacturer minimum state of charge, expressed as a percentage."},
+					{Id: SocRsvMax, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Access: "rw", Label: "Max Reserve Percent", Description: "Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage."},
+					{Id: SoCRsvMin, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Access: "rw", Label: "Min Reserve Percent", Description: "Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage."},
+					{Id: SoC, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%WHRtg", Mandatory: true, Label: "State of Charge", Description: "State of charge, expressed as a percentage."},
+					{Id: DoD, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "DoD_SF", Units: "%", Label: "Depth of Discharge", Description: "Depth of discharge, expressed as a percentage."},
+					{Id: SoH, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Label: "State of Health", Description: "Percentage of battery life remaining."},
+					{Id: NCyc, Offset: 12, Type: typelabel.Uint32, Label: "Cycle Count", Description: "Number of cycles executed in the battery."},
+					{Id: ChaSt, Offset: 14, Type: typelabel.Enum16, Label: "Charge Status", Description: "Charge status of storage device. Enumeration."},
+					{Id: LocRemCtl, Offset: 15, Type: typelabel.Enum16, Mandatory: true, Label: "Control Mode", Description: "Battery control mode. Enumeration."},
+					{Id: Hb, Offset: 16, Type: typelabel.Uint16, Label: "Battery Heartbeat", Description: "Value is incremented every second with periodic resets to zero."},
+					{Id: CtrlHb, Offset: 17, Type: typelabel.Uint16, Access: "rw", Label: "Controller Heartbeat", Description: "Value is incremented every second with periodic resets to zero."},
+					{Id: AlmRst, Offset: 18, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Alarm Reset", Description: "Used to reset any latched alarms.  1 = Reset."},
+					{Id: Typ, Offset: 19, Type: typelabel.Enum16, Mandatory: true, Label: "Battery Type", Description: "Type of battery. Enumeration."},
+					{Id: State, Offset: 20, Type: typelabel.Enum16, Mandatory: true, Label: "State of the Battery Bank", Description: "State of the battery bank.  Enumeration."},
+					{Id: StateVnd, Offset: 21, Type: typelabel.Enum16, Label: "Vendor Battery Bank State", Description: "Vendor specific battery bank state.  Enumeration."},
+					{Id: WarrDt, Offset: 22, Type: typelabel.Uint32, Label: "Warranty Date", Description: "Date the device warranty expires."},
+					{Id: Evt1, Offset: 24, Type: typelabel.Bitfield32, Mandatory: true, Label: "Battery Event 1 Bitfield", Description: "Alarms and warnings.  Bit flags."},
+					{Id: Evt2, Offset: 26, Type: typelabel.Bitfield32, Mandatory: true, Label: "Battery Event 2 Bitfield", Description: "Alarms and warnings.  Bit flags."},
+					{Id: EvtVnd1, Offset: 28, Type: typelabel.Bitfield32, Mandatory: true, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events."},
+					{Id: EvtVnd2, Offset: 30, Type: typelabel.Bitfield32, Mandatory: true, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events."},
+					{Id: V, Offset: 32, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "External Battery Voltage", Description: "DC Bus Voltage."},
+					{Id: VMax, Offset: 33, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Max Battery Voltage", Description: "Instantaneous maximum battery voltage."},
+					{Id: VMin, Offset: 34, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Min Battery Voltage", Description: "Instantaneous minimum battery voltage."},
+					{Id: CellVMax, Offset: 35, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the bank."},
+					{Id: CellVMaxStr, Offset: 36, Type: typelabel.Uint16, Label: "Max Cell Voltage String", Description: "String containing the cell with maximum voltage."},
+					{Id: CellVMaxMod, Offset: 37, Type: typelabel.Uint16, Label: "Max Cell Voltage Module", Description: "Module containing the cell with maximum voltage."},
+					{Id: CellVMin, Offset: 38, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the bank."},
+					{Id: CellVMinStr, Offset: 39, Type: typelabel.Uint16, Label: "Min Cell Voltage String", Description: "String containing the cell with minimum voltage."},
+					{Id: CellVMinMod, Offset: 40, Type: typelabel.Uint16, Label: "Min Cell Voltage Module", Description: "Module containing the cell with minimum voltage."},
+					{Id: CellVAvg, Offset: 41, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Average Cell Voltage", Description: "Average cell voltage for all cells in the bank."},
+					{Id: A, Offset: 42, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "Total DC Current", Description: "Total DC current flowing to/from the battery bank."},
+					{Id: AChaMax, Offset: 43, Type: typelabel.Uint16, ScaleFactor: "AMax_SF", Units: "A", Label: "Max Charge Current", Description: "Instantaneous maximum DC charge current."},
+					{Id: ADisChaMax, Offset: 44, Type: typelabel.Uint16, ScaleFactor: "AMax_SF", Units: "A", Label: "Max Discharge Current", Description: "Instantaneous maximum DC discharge current."},
+					{Id: W, Offset: 45, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Mandatory: true, Label: "Total Power", Description: "Total power flowing to/from the battery bank."},
+					{Id: ReqInvState, Offset: 46, Type: typelabel.Enum16, Label: "Inverter State Request", Description: "Request from battery to start or stop the inverter.  Enumeration."},
+					{Id: ReqW, Offset: 47, Type: typelabel.Int16, ScaleFactor: "W_SF", Units: "W", Label: "Battery Power Request", Description: "AC Power requested by battery."},
+					{Id: SetOp, Offset: 48, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Set Operation", Description: "Instruct the battery bank to perform an operation such as connecting.  Enumeration."},
+					{Id: SetInvState, Offset: 49, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Set Inverter State", Description: "Set the current state of the inverter."},
+					{Id: AHRtg_SF, Offset: 50, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: WHRtg_SF, Offset: 51, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: WChaDisChaMax_SF, Offset: 52, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DisChaRte_SF, Offset: 53, Type: typelabel.ScaleFactor},
+					{Id: SoC_SF, Offset: 54, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: DoD_SF, Offset: 55, Type: typelabel.ScaleFactor},
+					{Id: SoH_SF, Offset: 56, Type: typelabel.ScaleFactor},
+					{Id: V_SF, Offset: 57, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: CellV_SF, Offset: 58, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: A_SF, Offset: 59, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: AMax_SF, Offset: 60, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: W_SF, Offset: 61, Type: typelabel.ScaleFactor},
 				},
 			},
 		}})

--- a/models/model803/model.go
+++ b/models/model803/model.go
@@ -73,61 +73,61 @@ const (
 )
 
 type Block803Repeat struct {
-	StrNMod         uint16             `sunspec:"offset=0,len=1"`
-	StrSt           sunspec.Bitfield32 `sunspec:"offset=1,len=2"`
-	StrConFail      sunspec.Enum16     `sunspec:"offset=3,len=1"`
-	StrSoC          uint16             `sunspec:"offset=4,len=1,sf=SoC_SF"`
-	StrSoH          uint16             `sunspec:"offset=5,len=1,sf=SoH_SF"`
-	StrA            int16              `sunspec:"offset=6,len=1,sf=A_SF"`
-	StrCellVMax     uint16             `sunspec:"offset=7,len=1,sf=CellV_SF"`
-	StrCellVMaxMod  uint16             `sunspec:"offset=8,len=1"`
-	StrCellVMin     uint16             `sunspec:"offset=9,len=1,sf=CellV_SF"`
-	StrCellVMinMod  uint16             `sunspec:"offset=10,len=1"`
-	StrCellVAvg     uint16             `sunspec:"offset=11,len=1,sf=CellV_SF"`
-	StrModTmpMax    int16              `sunspec:"offset=12,len=1,sf=ModTmp_SF"`
-	StrModTmpMaxMod uint16             `sunspec:"offset=13,len=1"`
-	StrModTmpMin    int16              `sunspec:"offset=14,len=1,sf=ModTmp_SF"`
-	StrModTmpMinMod uint16             `sunspec:"offset=15,len=1"`
-	StrModTmpAvg    int16              `sunspec:"offset=16,len=1,sf=ModTmp_SF"`
-	StrDisRsn       sunspec.Enum16     `sunspec:"offset=17,len=1"`
-	StrConSt        sunspec.Bitfield32 `sunspec:"offset=18,len=2"`
-	StrEvt1         sunspec.Bitfield32 `sunspec:"offset=20,len=2"`
-	StrEvt2         sunspec.Bitfield32 `sunspec:"offset=22,len=2"`
-	StrEvtVnd1      sunspec.Bitfield32 `sunspec:"offset=24,len=2"`
-	StrEvtVnd2      sunspec.Bitfield32 `sunspec:"offset=26,len=2"`
-	StrSetEna       sunspec.Enum16     `sunspec:"offset=28,len=1,access=rw"`
-	StrSetCon       sunspec.Enum16     `sunspec:"offset=29,len=1,access=rw"`
-	Pad1            sunspec.Pad        `sunspec:"offset=30,len=1"`
-	Pad2            sunspec.Pad        `sunspec:"offset=31,len=1"`
+	StrNMod         uint16             `sunspec:"offset=0"`
+	StrSt           sunspec.Bitfield32 `sunspec:"offset=1"`
+	StrConFail      sunspec.Enum16     `sunspec:"offset=3"`
+	StrSoC          uint16             `sunspec:"offset=4,sf=SoC_SF"`
+	StrSoH          uint16             `sunspec:"offset=5,sf=SoH_SF"`
+	StrA            int16              `sunspec:"offset=6,sf=A_SF"`
+	StrCellVMax     uint16             `sunspec:"offset=7,sf=CellV_SF"`
+	StrCellVMaxMod  uint16             `sunspec:"offset=8"`
+	StrCellVMin     uint16             `sunspec:"offset=9,sf=CellV_SF"`
+	StrCellVMinMod  uint16             `sunspec:"offset=10"`
+	StrCellVAvg     uint16             `sunspec:"offset=11,sf=CellV_SF"`
+	StrModTmpMax    int16              `sunspec:"offset=12,sf=ModTmp_SF"`
+	StrModTmpMaxMod uint16             `sunspec:"offset=13"`
+	StrModTmpMin    int16              `sunspec:"offset=14,sf=ModTmp_SF"`
+	StrModTmpMinMod uint16             `sunspec:"offset=15"`
+	StrModTmpAvg    int16              `sunspec:"offset=16,sf=ModTmp_SF"`
+	StrDisRsn       sunspec.Enum16     `sunspec:"offset=17"`
+	StrConSt        sunspec.Bitfield32 `sunspec:"offset=18"`
+	StrEvt1         sunspec.Bitfield32 `sunspec:"offset=20"`
+	StrEvt2         sunspec.Bitfield32 `sunspec:"offset=22"`
+	StrEvtVnd1      sunspec.Bitfield32 `sunspec:"offset=24"`
+	StrEvtVnd2      sunspec.Bitfield32 `sunspec:"offset=26"`
+	StrSetEna       sunspec.Enum16     `sunspec:"offset=28,access=rw"`
+	StrSetCon       sunspec.Enum16     `sunspec:"offset=29,access=rw"`
+	Pad1            sunspec.Pad        `sunspec:"offset=30"`
+	Pad2            sunspec.Pad        `sunspec:"offset=31"`
 }
 
 type Block803 struct {
-	NStr         uint16              `sunspec:"offset=0,len=1"`
-	NStrCon      uint16              `sunspec:"offset=1,len=1"`
-	ModTmpMax    int16               `sunspec:"offset=2,len=1,sf=ModTmp_SF"`
-	ModTmpMaxStr uint16              `sunspec:"offset=3,len=1"`
-	ModTmpMaxMod uint16              `sunspec:"offset=4,len=1"`
-	ModTmpMin    int16               `sunspec:"offset=5,len=1,sf=ModTmp_SF"`
-	ModTmpMinStr uint16              `sunspec:"offset=6,len=1"`
-	ModTmpMinMod uint16              `sunspec:"offset=7,len=1"`
-	ModTmpAvg    int16               `sunspec:"offset=8,len=1"`
-	StrVMax      uint16              `sunspec:"offset=9,len=1,sf=V_SF"`
-	StrVMaxStr   uint16              `sunspec:"offset=10,len=1"`
-	StrVMin      uint16              `sunspec:"offset=11,len=1,sf=V_SF"`
-	StrVMinStr   uint16              `sunspec:"offset=12,len=1"`
-	StrVAvg      uint16              `sunspec:"offset=13,len=1,sf=V_SF"`
-	StrAMax      int16               `sunspec:"offset=14,len=1,sf=A_SF"`
-	StrAMaxStr   uint16              `sunspec:"offset=15,len=1"`
-	StrAMin      int16               `sunspec:"offset=16,len=1,sf=A_SF"`
-	StrAMinStr   uint16              `sunspec:"offset=17,len=1"`
-	StrAAvg      int16               `sunspec:"offset=18,len=1,sf=A_SF"`
-	NCellBal     uint16              `sunspec:"offset=19,len=1"`
-	CellV_SF     sunspec.ScaleFactor `sunspec:"offset=20,len=1"`
-	ModTmp_SF    sunspec.ScaleFactor `sunspec:"offset=21,len=1"`
-	A_SF         sunspec.ScaleFactor `sunspec:"offset=22,len=1"`
-	SoH_SF       sunspec.ScaleFactor `sunspec:"offset=23,len=1"`
-	SoC_SF       sunspec.ScaleFactor `sunspec:"offset=24,len=1"`
-	V_SF         sunspec.ScaleFactor `sunspec:"offset=25,len=1"`
+	NStr         uint16              `sunspec:"offset=0"`
+	NStrCon      uint16              `sunspec:"offset=1"`
+	ModTmpMax    int16               `sunspec:"offset=2,sf=ModTmp_SF"`
+	ModTmpMaxStr uint16              `sunspec:"offset=3"`
+	ModTmpMaxMod uint16              `sunspec:"offset=4"`
+	ModTmpMin    int16               `sunspec:"offset=5,sf=ModTmp_SF"`
+	ModTmpMinStr uint16              `sunspec:"offset=6"`
+	ModTmpMinMod uint16              `sunspec:"offset=7"`
+	ModTmpAvg    int16               `sunspec:"offset=8"`
+	StrVMax      uint16              `sunspec:"offset=9,sf=V_SF"`
+	StrVMaxStr   uint16              `sunspec:"offset=10"`
+	StrVMin      uint16              `sunspec:"offset=11,sf=V_SF"`
+	StrVMinStr   uint16              `sunspec:"offset=12"`
+	StrVAvg      uint16              `sunspec:"offset=13,sf=V_SF"`
+	StrAMax      int16               `sunspec:"offset=14,sf=A_SF"`
+	StrAMaxStr   uint16              `sunspec:"offset=15"`
+	StrAMin      int16               `sunspec:"offset=16,sf=A_SF"`
+	StrAMinStr   uint16              `sunspec:"offset=17"`
+	StrAAvg      int16               `sunspec:"offset=18,sf=A_SF"`
+	NCellBal     uint16              `sunspec:"offset=19"`
+	CellV_SF     sunspec.ScaleFactor `sunspec:"offset=20"`
+	ModTmp_SF    sunspec.ScaleFactor `sunspec:"offset=21"`
+	A_SF         sunspec.ScaleFactor `sunspec:"offset=22"`
+	SoH_SF       sunspec.ScaleFactor `sunspec:"offset=23"`
+	SoC_SF       sunspec.ScaleFactor `sunspec:"offset=24"`
+	V_SF         sunspec.ScaleFactor `sunspec:"offset=25"`
 
 	Repeats []Block803Repeat
 }
@@ -148,64 +148,64 @@ func init() {
 				Length: 26,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: NStr, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "String Count", Description: "Number of strings in the bank."},
-					{Id: NStrCon, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Connected String Count", Description: "Number of strings with contactor closed."},
-					{Id: ModTmpMax, Offset: 2, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Length: 1, Mandatory: true, Label: "Max Module Temperature", Description: "Maximum temperature for all modules in the bank."},
-					{Id: ModTmpMaxStr, Offset: 3, Type: typelabel.Uint16, Length: 1, Label: "Max Module Temperature String", Description: "String containing the module with maximum temperature."},
-					{Id: ModTmpMaxMod, Offset: 4, Type: typelabel.Uint16, Length: 1, Label: "Max Module Temperature Module", Description: "Module with maximum temperature."},
-					{Id: ModTmpMin, Offset: 5, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Min Module Temperature", Description: "Minimum temperature for all modules in the bank."},
-					{Id: ModTmpMinStr, Offset: 6, Type: typelabel.Uint16, Length: 1, Label: "Min Module Temperature String", Description: "String containing the module with minimum temperature."},
-					{Id: ModTmpMinMod, Offset: 7, Type: typelabel.Uint16, Length: 1, Label: "Min Module Temperature Module", Description: "Module with minimum temperature."},
-					{Id: ModTmpAvg, Offset: 8, Type: typelabel.Int16, Length: 1, Label: "Average Module Temperature", Description: "Average temperature for all modules in the bank."},
-					{Id: StrVMax, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Max String Voltage", Description: "Maximum string voltage for all strings in the bank."},
-					{Id: StrVMaxStr, Offset: 10, Type: typelabel.Uint16, Length: 1, Label: "Max String Voltage String", Description: "String with maximum voltage."},
-					{Id: StrVMin, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Min String Voltage", Description: "Minimum string voltage for all strings in the bank."},
-					{Id: StrVMinStr, Offset: 12, Type: typelabel.Uint16, Length: 1, Label: "Min String Voltage String", Description: "String with minimum voltage."},
-					{Id: StrVAvg, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "Average String Voltage", Description: "Average string voltage for all strings in the bank."},
-					{Id: StrAMax, Offset: 14, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Max String Current", Description: "Maximum current of any string in the bank."},
-					{Id: StrAMaxStr, Offset: 15, Type: typelabel.Uint16, Length: 1, Label: "Max String Current String", Description: "String with the maximum current."},
-					{Id: StrAMin, Offset: 16, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Min String Current", Description: "Minimum current of any string in the bank."},
-					{Id: StrAMinStr, Offset: 17, Type: typelabel.Uint16, Length: 1, Label: "Min String Current String", Description: "String with the minimum current."},
-					{Id: StrAAvg, Offset: 18, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Label: "Average String Current", Description: "Average string current for all strings in the bank."},
-					{Id: NCellBal, Offset: 19, Type: typelabel.Uint16, Length: 1, Label: "Battery Cell Balancing Count", Description: "Total number of cells that are currently being balanced."},
-					{Id: CellV_SF, Offset: 20, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: ModTmp_SF, Offset: 21, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: A_SF, Offset: 22, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: SoH_SF, Offset: 23, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: SoC_SF, Offset: 24, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: V_SF, Offset: 25, Type: typelabel.ScaleFactor, Length: 1},
+					{Id: NStr, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "String Count", Description: "Number of strings in the bank."},
+					{Id: NStrCon, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "Connected String Count", Description: "Number of strings with contactor closed."},
+					{Id: ModTmpMax, Offset: 2, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Mandatory: true, Label: "Max Module Temperature", Description: "Maximum temperature for all modules in the bank."},
+					{Id: ModTmpMaxStr, Offset: 3, Type: typelabel.Uint16, Label: "Max Module Temperature String", Description: "String containing the module with maximum temperature."},
+					{Id: ModTmpMaxMod, Offset: 4, Type: typelabel.Uint16, Label: "Max Module Temperature Module", Description: "Module with maximum temperature."},
+					{Id: ModTmpMin, Offset: 5, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Min Module Temperature", Description: "Minimum temperature for all modules in the bank."},
+					{Id: ModTmpMinStr, Offset: 6, Type: typelabel.Uint16, Label: "Min Module Temperature String", Description: "String containing the module with minimum temperature."},
+					{Id: ModTmpMinMod, Offset: 7, Type: typelabel.Uint16, Label: "Min Module Temperature Module", Description: "Module with minimum temperature."},
+					{Id: ModTmpAvg, Offset: 8, Type: typelabel.Int16, Label: "Average Module Temperature", Description: "Average temperature for all modules in the bank."},
+					{Id: StrVMax, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Max String Voltage", Description: "Maximum string voltage for all strings in the bank."},
+					{Id: StrVMaxStr, Offset: 10, Type: typelabel.Uint16, Label: "Max String Voltage String", Description: "String with maximum voltage."},
+					{Id: StrVMin, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Min String Voltage", Description: "Minimum string voltage for all strings in the bank."},
+					{Id: StrVMinStr, Offset: 12, Type: typelabel.Uint16, Label: "Min String Voltage String", Description: "String with minimum voltage."},
+					{Id: StrVAvg, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "Average String Voltage", Description: "Average string voltage for all strings in the bank."},
+					{Id: StrAMax, Offset: 14, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Max String Current", Description: "Maximum current of any string in the bank."},
+					{Id: StrAMaxStr, Offset: 15, Type: typelabel.Uint16, Label: "Max String Current String", Description: "String with the maximum current."},
+					{Id: StrAMin, Offset: 16, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Min String Current", Description: "Minimum current of any string in the bank."},
+					{Id: StrAMinStr, Offset: 17, Type: typelabel.Uint16, Label: "Min String Current String", Description: "String with the minimum current."},
+					{Id: StrAAvg, Offset: 18, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Label: "Average String Current", Description: "Average string current for all strings in the bank."},
+					{Id: NCellBal, Offset: 19, Type: typelabel.Uint16, Label: "Battery Cell Balancing Count", Description: "Total number of cells that are currently being balanced."},
+					{Id: CellV_SF, Offset: 20, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: ModTmp_SF, Offset: 21, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: A_SF, Offset: 22, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: SoH_SF, Offset: 23, Type: typelabel.ScaleFactor},
+					{Id: SoC_SF, Offset: 24, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: V_SF, Offset: 25, Type: typelabel.ScaleFactor},
 				},
 			},
 			{Name: "string",
 				Length: 32,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: StrNMod, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Count", Description: "Count of modules in the string."},
-					{Id: StrSt, Offset: 1, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "String Status", Description: "Current status of the string."},
-					{Id: StrConFail, Offset: 3, Type: typelabel.Enum16, Length: 1, Label: "Connection Failure Reason", Description: ""},
-					{Id: StrSoC, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Length: 1, Mandatory: true, Label: "String State of Charge", Description: "Battery string state of charge, expressed as a percentage."},
-					{Id: StrSoH, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Length: 1, Label: "String State of Health", Description: "Battery string state of health, expressed as a percentage."},
-					{Id: StrA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "String Current", Description: "String current measurement."},
-					{Id: StrCellVMax, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the string."},
-					{Id: StrCellVMaxMod, Offset: 8, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Module", Description: "Module containing the maximum cell voltage."},
-					{Id: StrCellVMin, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the string."},
-					{Id: StrCellVMinMod, Offset: 10, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Module", Description: "Module containing the minimum cell voltage."},
-					{Id: StrCellVAvg, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the string."},
-					{Id: StrModTmpMax, Offset: 12, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Max Module Temperature", Description: "Maximum temperature for all modules in the bank."},
-					{Id: StrModTmpMaxMod, Offset: 13, Type: typelabel.Uint16, Length: 1, Label: "Max Module Temperature Module", Description: "Module with the maximum temperature."},
-					{Id: StrModTmpMin, Offset: 14, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Min Module Temperature", Description: "Minimum temperature for all modules in the bank."},
-					{Id: StrModTmpMinMod, Offset: 15, Type: typelabel.Uint16, Length: 1, Label: "Min Module Temperature Module", Description: "Module with the minimum temperature."},
-					{Id: StrModTmpAvg, Offset: 16, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Average Module Temperature", Description: "Average temperature for all modules in the bank."},
-					{Id: StrDisRsn, Offset: 17, Type: typelabel.Enum16, Length: 1, Label: "Disabled Reason", Description: "Reason why the string is currently disabled."},
-					{Id: StrConSt, Offset: 18, Type: typelabel.Bitfield32, Length: 2, Label: "Contactor Status", Description: "Status of the contactor(s) for the string."},
-					{Id: StrEvt1, Offset: 20, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "String Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: StrEvt2, Offset: 22, Type: typelabel.Bitfield32, Length: 2, Label: "String Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: StrEvtVnd1, Offset: 24, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor String Event Bitfield 1", Description: "Vendor defined events."},
-					{Id: StrEvtVnd2, Offset: 26, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor String Event Bitfield 2", Description: "Vendor defined events."},
-					{Id: StrSetEna, Offset: 28, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Enable/Disable String", Description: "Enables and disables the string."},
-					{Id: StrSetCon, Offset: 29, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Connect/Disconnect String", Description: "Connects and disconnects the string."},
-					{Id: Pad1, Offset: 30, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
-					{Id: Pad2, Offset: 31, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: StrNMod, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Module Count", Description: "Count of modules in the string."},
+					{Id: StrSt, Offset: 1, Type: typelabel.Bitfield32, Mandatory: true, Label: "String Status", Description: "Current status of the string."},
+					{Id: StrConFail, Offset: 3, Type: typelabel.Enum16, Label: "Connection Failure Reason", Description: ""},
+					{Id: StrSoC, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Mandatory: true, Label: "String State of Charge", Description: "Battery string state of charge, expressed as a percentage."},
+					{Id: StrSoH, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Label: "String State of Health", Description: "Battery string state of health, expressed as a percentage."},
+					{Id: StrA, Offset: 6, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "String Current", Description: "String current measurement."},
+					{Id: StrCellVMax, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the string."},
+					{Id: StrCellVMaxMod, Offset: 8, Type: typelabel.Uint16, Label: "Max Cell Voltage Module", Description: "Module containing the maximum cell voltage."},
+					{Id: StrCellVMin, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the string."},
+					{Id: StrCellVMinMod, Offset: 10, Type: typelabel.Uint16, Label: "Min Cell Voltage Module", Description: "Module containing the minimum cell voltage."},
+					{Id: StrCellVAvg, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the string."},
+					{Id: StrModTmpMax, Offset: 12, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Max Module Temperature", Description: "Maximum temperature for all modules in the bank."},
+					{Id: StrModTmpMaxMod, Offset: 13, Type: typelabel.Uint16, Label: "Max Module Temperature Module", Description: "Module with the maximum temperature."},
+					{Id: StrModTmpMin, Offset: 14, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Min Module Temperature", Description: "Minimum temperature for all modules in the bank."},
+					{Id: StrModTmpMinMod, Offset: 15, Type: typelabel.Uint16, Label: "Min Module Temperature Module", Description: "Module with the minimum temperature."},
+					{Id: StrModTmpAvg, Offset: 16, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Average Module Temperature", Description: "Average temperature for all modules in the bank."},
+					{Id: StrDisRsn, Offset: 17, Type: typelabel.Enum16, Label: "Disabled Reason", Description: "Reason why the string is currently disabled."},
+					{Id: StrConSt, Offset: 18, Type: typelabel.Bitfield32, Label: "Contactor Status", Description: "Status of the contactor(s) for the string."},
+					{Id: StrEvt1, Offset: 20, Type: typelabel.Bitfield32, Mandatory: true, Label: "String Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: StrEvt2, Offset: 22, Type: typelabel.Bitfield32, Label: "String Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: StrEvtVnd1, Offset: 24, Type: typelabel.Bitfield32, Label: "Vendor String Event Bitfield 1", Description: "Vendor defined events."},
+					{Id: StrEvtVnd2, Offset: 26, Type: typelabel.Bitfield32, Label: "Vendor String Event Bitfield 2", Description: "Vendor defined events."},
+					{Id: StrSetEna, Offset: 28, Type: typelabel.Enum16, Access: "rw", Label: "Enable/Disable String", Description: "Enables and disables the string."},
+					{Id: StrSetCon, Offset: 29, Type: typelabel.Enum16, Access: "rw", Label: "Connect/Disconnect String", Description: "Connects and disconnects the string."},
+					{Id: Pad1, Offset: 30, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Pad2, Offset: 31, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
 				},
 			},
 		}})

--- a/models/model804/model.go
+++ b/models/model804/model.go
@@ -76,64 +76,64 @@ const (
 )
 
 type Block804Repeat struct {
-	ModNCell          uint16      `sunspec:"offset=0,len=1"`
-	ModSoC            uint16      `sunspec:"offset=1,len=1,sf=SoC_SF"`
-	ModSoH            uint16      `sunspec:"offset=2,len=1,sf=SoH_SF"`
-	ModCellVMax       uint16      `sunspec:"offset=3,len=1,sf=CellV_SF"`
-	ModCellVMaxCell   uint16      `sunspec:"offset=4,len=1"`
-	ModCellVMin       uint16      `sunspec:"offset=5,len=1,sf=CellV_SF"`
-	ModCellVMinCell   uint16      `sunspec:"offset=6,len=1,sf=CellV_SF"`
-	ModCellVAvg       uint16      `sunspec:"offset=7,len=1,sf=CellV_SF"`
-	ModCellTmpMax     int16       `sunspec:"offset=8,len=1,sf=ModTmp_SF"`
-	ModCellTmpMaxCell uint16      `sunspec:"offset=9,len=1"`
-	ModCellTmpMin     int16       `sunspec:"offset=10,len=1,sf=ModTmp_SF"`
-	ModCellTmpMinCell uint16      `sunspec:"offset=11,len=1"`
-	ModCellTmpAvg     int16       `sunspec:"offset=12,len=1,sf=ModTmp_SF"`
-	Pad5              sunspec.Pad `sunspec:"offset=13,len=1"`
-	Pad6              sunspec.Pad `sunspec:"offset=14,len=1"`
-	Pad7              sunspec.Pad `sunspec:"offset=15,len=1"`
+	ModNCell          uint16      `sunspec:"offset=0"`
+	ModSoC            uint16      `sunspec:"offset=1,sf=SoC_SF"`
+	ModSoH            uint16      `sunspec:"offset=2,sf=SoH_SF"`
+	ModCellVMax       uint16      `sunspec:"offset=3,sf=CellV_SF"`
+	ModCellVMaxCell   uint16      `sunspec:"offset=4"`
+	ModCellVMin       uint16      `sunspec:"offset=5,sf=CellV_SF"`
+	ModCellVMinCell   uint16      `sunspec:"offset=6,sf=CellV_SF"`
+	ModCellVAvg       uint16      `sunspec:"offset=7,sf=CellV_SF"`
+	ModCellTmpMax     int16       `sunspec:"offset=8,sf=ModTmp_SF"`
+	ModCellTmpMaxCell uint16      `sunspec:"offset=9"`
+	ModCellTmpMin     int16       `sunspec:"offset=10,sf=ModTmp_SF"`
+	ModCellTmpMinCell uint16      `sunspec:"offset=11"`
+	ModCellTmpAvg     int16       `sunspec:"offset=12,sf=ModTmp_SF"`
+	Pad5              sunspec.Pad `sunspec:"offset=13"`
+	Pad6              sunspec.Pad `sunspec:"offset=14"`
+	Pad7              sunspec.Pad `sunspec:"offset=15"`
 }
 
 type Block804 struct {
-	Idx          uint16              `sunspec:"offset=0,len=1"`
-	NMod         uint16              `sunspec:"offset=1,len=1"`
-	St           sunspec.Bitfield32  `sunspec:"offset=2,len=2"`
-	ConFail      sunspec.Enum16      `sunspec:"offset=4,len=1"`
-	NCellBal     uint16              `sunspec:"offset=5,len=1"`
-	SoC          uint16              `sunspec:"offset=6,len=1,sf=SoC_SF"`
-	DoD          uint16              `sunspec:"offset=7,len=1,sf=DoD_SF"`
-	NCyc         uint32              `sunspec:"offset=8,len=2"`
-	SoH          uint16              `sunspec:"offset=10,len=1,sf=SoH_SF"`
-	A            int16               `sunspec:"offset=11,len=1,sf=A_SF"`
-	V            uint16              `sunspec:"offset=12,len=1,sf=V_SF"`
-	CellVMax     uint16              `sunspec:"offset=13,len=1,sf=CellV_SF"`
-	CellVMaxMod  uint16              `sunspec:"offset=14,len=1"`
-	CellVMin     uint16              `sunspec:"offset=15,len=1,sf=CellV_SF"`
-	CellVMinMod  uint16              `sunspec:"offset=16,len=1"`
-	CellVAvg     uint16              `sunspec:"offset=17,len=1,sf=CellV_SF"`
-	ModTmpMax    int16               `sunspec:"offset=18,len=1,sf=ModTmp_SF"`
-	ModTmpMaxMod uint16              `sunspec:"offset=19,len=1"`
-	ModTmpMin    int16               `sunspec:"offset=20,len=1,sf=ModTmp_SF"`
-	ModTmpMinMod uint16              `sunspec:"offset=21,len=1"`
-	ModTmpAvg    int16               `sunspec:"offset=22,len=1,sf=ModTmp_SF"`
-	Pad1         sunspec.Pad         `sunspec:"offset=23,len=1"`
-	ConSt        sunspec.Bitfield32  `sunspec:"offset=24,len=2"`
-	Evt1         sunspec.Bitfield32  `sunspec:"offset=26,len=2"`
-	Evt2         sunspec.Bitfield32  `sunspec:"offset=28,len=2"`
-	EvtVnd1      sunspec.Bitfield32  `sunspec:"offset=30,len=2"`
-	EvtVnd2      sunspec.Bitfield32  `sunspec:"offset=32,len=2"`
-	SetEna       sunspec.Enum16      `sunspec:"offset=34,len=1,access=rw"`
-	SetCon       sunspec.Enum16      `sunspec:"offset=35,len=1,access=rw"`
-	SoC_SF       sunspec.ScaleFactor `sunspec:"offset=36,len=1"`
-	SoH_SF       sunspec.ScaleFactor `sunspec:"offset=37,len=1"`
-	DoD_SF       sunspec.ScaleFactor `sunspec:"offset=38,len=1"`
-	A_SF         sunspec.ScaleFactor `sunspec:"offset=39,len=1"`
-	V_SF         sunspec.ScaleFactor `sunspec:"offset=40,len=1"`
-	CellV_SF     sunspec.ScaleFactor `sunspec:"offset=41,len=1"`
-	ModTmp_SF    sunspec.ScaleFactor `sunspec:"offset=42,len=1"`
-	Pad2         sunspec.Pad         `sunspec:"offset=43,len=1"`
-	Pad3         sunspec.Pad         `sunspec:"offset=44,len=1"`
-	Pad4         sunspec.Pad         `sunspec:"offset=45,len=1"`
+	Idx          uint16              `sunspec:"offset=0"`
+	NMod         uint16              `sunspec:"offset=1"`
+	St           sunspec.Bitfield32  `sunspec:"offset=2"`
+	ConFail      sunspec.Enum16      `sunspec:"offset=4"`
+	NCellBal     uint16              `sunspec:"offset=5"`
+	SoC          uint16              `sunspec:"offset=6,sf=SoC_SF"`
+	DoD          uint16              `sunspec:"offset=7,sf=DoD_SF"`
+	NCyc         uint32              `sunspec:"offset=8"`
+	SoH          uint16              `sunspec:"offset=10,sf=SoH_SF"`
+	A            int16               `sunspec:"offset=11,sf=A_SF"`
+	V            uint16              `sunspec:"offset=12,sf=V_SF"`
+	CellVMax     uint16              `sunspec:"offset=13,sf=CellV_SF"`
+	CellVMaxMod  uint16              `sunspec:"offset=14"`
+	CellVMin     uint16              `sunspec:"offset=15,sf=CellV_SF"`
+	CellVMinMod  uint16              `sunspec:"offset=16"`
+	CellVAvg     uint16              `sunspec:"offset=17,sf=CellV_SF"`
+	ModTmpMax    int16               `sunspec:"offset=18,sf=ModTmp_SF"`
+	ModTmpMaxMod uint16              `sunspec:"offset=19"`
+	ModTmpMin    int16               `sunspec:"offset=20,sf=ModTmp_SF"`
+	ModTmpMinMod uint16              `sunspec:"offset=21"`
+	ModTmpAvg    int16               `sunspec:"offset=22,sf=ModTmp_SF"`
+	Pad1         sunspec.Pad         `sunspec:"offset=23"`
+	ConSt        sunspec.Bitfield32  `sunspec:"offset=24"`
+	Evt1         sunspec.Bitfield32  `sunspec:"offset=26"`
+	Evt2         sunspec.Bitfield32  `sunspec:"offset=28"`
+	EvtVnd1      sunspec.Bitfield32  `sunspec:"offset=30"`
+	EvtVnd2      sunspec.Bitfield32  `sunspec:"offset=32"`
+	SetEna       sunspec.Enum16      `sunspec:"offset=34,access=rw"`
+	SetCon       sunspec.Enum16      `sunspec:"offset=35,access=rw"`
+	SoC_SF       sunspec.ScaleFactor `sunspec:"offset=36"`
+	SoH_SF       sunspec.ScaleFactor `sunspec:"offset=37"`
+	DoD_SF       sunspec.ScaleFactor `sunspec:"offset=38"`
+	A_SF         sunspec.ScaleFactor `sunspec:"offset=39"`
+	V_SF         sunspec.ScaleFactor `sunspec:"offset=40"`
+	CellV_SF     sunspec.ScaleFactor `sunspec:"offset=41"`
+	ModTmp_SF    sunspec.ScaleFactor `sunspec:"offset=42"`
+	Pad2         sunspec.Pad         `sunspec:"offset=43"`
+	Pad3         sunspec.Pad         `sunspec:"offset=44"`
+	Pad4         sunspec.Pad         `sunspec:"offset=45"`
 
 	Repeats []Block804Repeat
 }
@@ -154,67 +154,67 @@ func init() {
 				Length: 46,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Idx, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "String Index", Description: "Index of the string within the bank."},
-					{Id: NMod, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Count", Description: "Count of modules in the string."},
-					{Id: St, Offset: 2, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "String Status", Description: "Current status of the string."},
-					{Id: ConFail, Offset: 4, Type: typelabel.Enum16, Length: 1, Label: "Connection Failure Reason", Description: ""},
-					{Id: NCellBal, Offset: 5, Type: typelabel.Uint16, Length: 1, Label: "String Cell Balancing Count", Description: "Number of cells currently being balanced in the string."},
-					{Id: SoC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Length: 1, Mandatory: true, Label: "String State of Charge", Description: "Battery string state of charge, expressed as a percentage."},
-					{Id: DoD, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "DoD_SF", Units: "%", Length: 1, Label: "String Depth of Discharge", Description: "Depth of discharge for the string, expressed as a percentage."},
-					{Id: NCyc, Offset: 8, Type: typelabel.Uint32, Length: 2, Label: "String Cycle Count", Description: "Number of discharge cycles executed upon the string."},
-					{Id: SoH, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Length: 1, Label: "String State of Health", Description: "Battery string state of health, expressed as a percentage."},
-					{Id: A, Offset: 11, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Length: 1, Mandatory: true, Label: "String Current", Description: "String current measurement."},
-					{Id: V, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Label: "String Voltage", Description: "String voltage measurement."},
-					{Id: CellVMax, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the string."},
-					{Id: CellVMaxMod, Offset: 14, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Module", Description: "Module containing the cell with maximum cell voltage."},
-					{Id: CellVMin, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the string."},
-					{Id: CellVMinMod, Offset: 16, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Module", Description: "Module containing the cell with minimum cell voltage."},
-					{Id: CellVAvg, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the string."},
-					{Id: ModTmpMax, Offset: 18, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Max Module Temperature", Description: "Maximum temperature for all modules in the string."},
-					{Id: ModTmpMaxMod, Offset: 19, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Max Module Temperature Module", Description: "Module with the maximum temperature."},
-					{Id: ModTmpMin, Offset: 20, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Min Module Temperature", Description: "Minimum temperature for all modules in the string."},
-					{Id: ModTmpMinMod, Offset: 21, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Min Module Temperature Module", Description: "Module with the minimum temperature."},
-					{Id: ModTmpAvg, Offset: 22, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Average Module Temperature", Description: "Average temperature for all modules in the string."},
-					{Id: Pad1, Offset: 23, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
-					{Id: ConSt, Offset: 24, Type: typelabel.Bitfield32, Length: 2, Label: "Contactor Status", Description: "Status of the contactor(s) for the string."},
-					{Id: Evt1, Offset: 26, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "String Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: Evt2, Offset: 28, Type: typelabel.Bitfield32, Length: 2, Label: "String Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: EvtVnd1, Offset: 30, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events."},
-					{Id: EvtVnd2, Offset: 32, Type: typelabel.Bitfield32, Length: 2, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events."},
-					{Id: SetEna, Offset: 34, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Enable/Disable String", Description: "Enables and disables the string.  Should reset to 0 upon completion."},
-					{Id: SetCon, Offset: 35, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Connect/Disconnect String", Description: "Connects and disconnects the string."},
-					{Id: SoC_SF, Offset: 36, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: SoH_SF, Offset: 37, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DoD_SF, Offset: 38, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: A_SF, Offset: 39, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: V_SF, Offset: 40, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: CellV_SF, Offset: 41, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: ModTmp_SF, Offset: 42, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Pad2, Offset: 43, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
-					{Id: Pad3, Offset: 44, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
-					{Id: Pad4, Offset: 45, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Idx, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "String Index", Description: "Index of the string within the bank."},
+					{Id: NMod, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "Module Count", Description: "Count of modules in the string."},
+					{Id: St, Offset: 2, Type: typelabel.Bitfield32, Mandatory: true, Label: "String Status", Description: "Current status of the string."},
+					{Id: ConFail, Offset: 4, Type: typelabel.Enum16, Label: "Connection Failure Reason", Description: ""},
+					{Id: NCellBal, Offset: 5, Type: typelabel.Uint16, Label: "String Cell Balancing Count", Description: "Number of cells currently being balanced in the string."},
+					{Id: SoC, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Mandatory: true, Label: "String State of Charge", Description: "Battery string state of charge, expressed as a percentage."},
+					{Id: DoD, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "DoD_SF", Units: "%", Label: "String Depth of Discharge", Description: "Depth of discharge for the string, expressed as a percentage."},
+					{Id: NCyc, Offset: 8, Type: typelabel.Uint32, Label: "String Cycle Count", Description: "Number of discharge cycles executed upon the string."},
+					{Id: SoH, Offset: 10, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Label: "String State of Health", Description: "Battery string state of health, expressed as a percentage."},
+					{Id: A, Offset: 11, Type: typelabel.Int16, ScaleFactor: "A_SF", Units: "A", Mandatory: true, Label: "String Current", Description: "String current measurement."},
+					{Id: V, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Label: "String Voltage", Description: "String voltage measurement."},
+					{Id: CellVMax, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the string."},
+					{Id: CellVMaxMod, Offset: 14, Type: typelabel.Uint16, Label: "Max Cell Voltage Module", Description: "Module containing the cell with maximum cell voltage."},
+					{Id: CellVMin, Offset: 15, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the string."},
+					{Id: CellVMinMod, Offset: 16, Type: typelabel.Uint16, Label: "Min Cell Voltage Module", Description: "Module containing the cell with minimum cell voltage."},
+					{Id: CellVAvg, Offset: 17, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the string."},
+					{Id: ModTmpMax, Offset: 18, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Max Module Temperature", Description: "Maximum temperature for all modules in the string."},
+					{Id: ModTmpMaxMod, Offset: 19, Type: typelabel.Uint16, Mandatory: true, Label: "Max Module Temperature Module", Description: "Module with the maximum temperature."},
+					{Id: ModTmpMin, Offset: 20, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Min Module Temperature", Description: "Minimum temperature for all modules in the string."},
+					{Id: ModTmpMinMod, Offset: 21, Type: typelabel.Uint16, Mandatory: true, Label: "Min Module Temperature Module", Description: "Module with the minimum temperature."},
+					{Id: ModTmpAvg, Offset: 22, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Average Module Temperature", Description: "Average temperature for all modules in the string."},
+					{Id: Pad1, Offset: 23, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: ConSt, Offset: 24, Type: typelabel.Bitfield32, Label: "Contactor Status", Description: "Status of the contactor(s) for the string."},
+					{Id: Evt1, Offset: 26, Type: typelabel.Bitfield32, Mandatory: true, Label: "String Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: Evt2, Offset: 28, Type: typelabel.Bitfield32, Label: "String Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: EvtVnd1, Offset: 30, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events."},
+					{Id: EvtVnd2, Offset: 32, Type: typelabel.Bitfield32, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events."},
+					{Id: SetEna, Offset: 34, Type: typelabel.Enum16, Access: "rw", Label: "Enable/Disable String", Description: "Enables and disables the string.  Should reset to 0 upon completion."},
+					{Id: SetCon, Offset: 35, Type: typelabel.Enum16, Access: "rw", Label: "Connect/Disconnect String", Description: "Connects and disconnects the string."},
+					{Id: SoC_SF, Offset: 36, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: SoH_SF, Offset: 37, Type: typelabel.ScaleFactor},
+					{Id: DoD_SF, Offset: 38, Type: typelabel.ScaleFactor},
+					{Id: A_SF, Offset: 39, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: V_SF, Offset: 40, Type: typelabel.ScaleFactor},
+					{Id: CellV_SF, Offset: 41, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: ModTmp_SF, Offset: 42, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Pad2, Offset: 43, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Pad3, Offset: 44, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Pad4, Offset: 45, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
 				},
 			},
 			{Name: "lithium_ion_string_module",
 				Length: 16,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ModNCell, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Cell Count", Description: "Count of all cells in the module."},
-					{Id: ModSoC, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Length: 1, Label: "Module SoC", Description: "Module state of charge, expressed as a percentage."},
-					{Id: ModSoH, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Length: 1, Label: "Module SoH", Description: "Module state of health, expressed as a percentage."},
-					{Id: ModCellVMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the module."},
-					{Id: ModCellVMaxCell, Offset: 4, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Cell", Description: "Cell with maximum voltage."},
-					{Id: ModCellVMin, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the module."},
-					{Id: ModCellVMinCell, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Min Cell Voltage Cell", Description: "Cell with minimum voltage."},
-					{Id: ModCellVAvg, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the module."},
-					{Id: ModCellTmpMax, Offset: 8, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Max Cell Temperature", Description: "Maximum temperature for all cells in the module."},
-					{Id: ModCellTmpMaxCell, Offset: 9, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Temperature Cell", Description: "Cell with maximum temperature."},
-					{Id: ModCellTmpMin, Offset: 10, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Min Cell Temperature", Description: "Minimum temperature for all cells in the module."},
-					{Id: ModCellTmpMinCell, Offset: 11, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Temperature Cell", Description: "Cell with minimum temperature."},
-					{Id: ModCellTmpAvg, Offset: 12, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Average Cell Temperature", Description: "Average temperature for all cells in the module."},
-					{Id: Pad5, Offset: 13, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
-					{Id: Pad6, Offset: 14, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
-					{Id: Pad7, Offset: 15, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: ModNCell, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Module Cell Count", Description: "Count of all cells in the module."},
+					{Id: ModSoC, Offset: 1, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Label: "Module SoC", Description: "Module state of charge, expressed as a percentage."},
+					{Id: ModSoH, Offset: 2, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Label: "Module SoH", Description: "Module state of health, expressed as a percentage."},
+					{Id: ModCellVMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the module."},
+					{Id: ModCellVMaxCell, Offset: 4, Type: typelabel.Uint16, Label: "Max Cell Voltage Cell", Description: "Cell with maximum voltage."},
+					{Id: ModCellVMin, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the module."},
+					{Id: ModCellVMinCell, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Min Cell Voltage Cell", Description: "Cell with minimum voltage."},
+					{Id: ModCellVAvg, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the module."},
+					{Id: ModCellTmpMax, Offset: 8, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Max Cell Temperature", Description: "Maximum temperature for all cells in the module."},
+					{Id: ModCellTmpMaxCell, Offset: 9, Type: typelabel.Uint16, Label: "Max Cell Temperature Cell", Description: "Cell with maximum temperature."},
+					{Id: ModCellTmpMin, Offset: 10, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Min Cell Temperature", Description: "Minimum temperature for all cells in the module."},
+					{Id: ModCellTmpMinCell, Offset: 11, Type: typelabel.Uint16, Label: "Min Cell Temperature Cell", Description: "Cell with minimum temperature."},
+					{Id: ModCellTmpAvg, Offset: 12, Type: typelabel.Int16, ScaleFactor: "ModTmp_SF", Units: "C", Mandatory: true, Label: "Average Cell Temperature", Description: "Average temperature for all cells in the module."},
+					{Id: Pad5, Offset: 13, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Pad6, Offset: 14, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Pad7, Offset: 15, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
 				},
 			},
 		}})

--- a/models/model805/model.go
+++ b/models/model805/model.go
@@ -50,38 +50,38 @@ const (
 )
 
 type Block805Repeat struct {
-	CellV   uint16             `sunspec:"offset=0,len=1,sf=CellV_SF"`
-	CellTmp int16              `sunspec:"offset=1,len=1,sf=Tmp_SF"`
-	CellSt  sunspec.Bitfield32 `sunspec:"offset=2,len=2"`
+	CellV   uint16             `sunspec:"offset=0,sf=CellV_SF"`
+	CellTmp int16              `sunspec:"offset=1,sf=Tmp_SF"`
+	CellSt  sunspec.Bitfield32 `sunspec:"offset=2"`
 }
 
 type Block805 struct {
-	StrIdx         uint16              `sunspec:"offset=0,len=1"`
-	ModIdx         uint16              `sunspec:"offset=1,len=1"`
-	NCell          uint16              `sunspec:"offset=2,len=1"`
-	SoC            uint16              `sunspec:"offset=3,len=1,sf=SoC_SF"`
-	DoD            uint16              `sunspec:"offset=4,len=1,sf=DoD_SF"`
-	SoH            uint16              `sunspec:"offset=5,len=1,sf=SoH_SF"`
-	NCyc           uint32              `sunspec:"offset=6,len=2"`
-	V              uint16              `sunspec:"offset=8,len=1,sf=V_SF"`
-	CellVMax       uint16              `sunspec:"offset=9,len=1,sf=CellV_SF"`
-	CellVMaxCell   uint16              `sunspec:"offset=10,len=1"`
-	CellVMin       uint16              `sunspec:"offset=11,len=1,sf=CellV_SF"`
-	CellVMinCell   uint16              `sunspec:"offset=12,len=1"`
-	CellVAvg       uint16              `sunspec:"offset=13,len=1,sf=CellV_SF"`
-	CellTmpMax     int16               `sunspec:"offset=14,len=1,sf=Tmp_SF"`
-	CellTmpMaxCell uint16              `sunspec:"offset=15,len=1"`
-	CellTmpMin     int16               `sunspec:"offset=16,len=1,sf=Tmp_SF"`
-	CellTmpMinCell uint16              `sunspec:"offset=17,len=1"`
-	CellTmpAvg     int16               `sunspec:"offset=18,len=1,sf=Tmp_SF"`
-	NCellBal       uint16              `sunspec:"offset=19,len=1"`
+	StrIdx         uint16              `sunspec:"offset=0"`
+	ModIdx         uint16              `sunspec:"offset=1"`
+	NCell          uint16              `sunspec:"offset=2"`
+	SoC            uint16              `sunspec:"offset=3,sf=SoC_SF"`
+	DoD            uint16              `sunspec:"offset=4,sf=DoD_SF"`
+	SoH            uint16              `sunspec:"offset=5,sf=SoH_SF"`
+	NCyc           uint32              `sunspec:"offset=6"`
+	V              uint16              `sunspec:"offset=8,sf=V_SF"`
+	CellVMax       uint16              `sunspec:"offset=9,sf=CellV_SF"`
+	CellVMaxCell   uint16              `sunspec:"offset=10"`
+	CellVMin       uint16              `sunspec:"offset=11,sf=CellV_SF"`
+	CellVMinCell   uint16              `sunspec:"offset=12"`
+	CellVAvg       uint16              `sunspec:"offset=13,sf=CellV_SF"`
+	CellTmpMax     int16               `sunspec:"offset=14,sf=Tmp_SF"`
+	CellTmpMaxCell uint16              `sunspec:"offset=15"`
+	CellTmpMin     int16               `sunspec:"offset=16,sf=Tmp_SF"`
+	CellTmpMinCell uint16              `sunspec:"offset=17"`
+	CellTmpAvg     int16               `sunspec:"offset=18,sf=Tmp_SF"`
+	NCellBal       uint16              `sunspec:"offset=19"`
 	SN             string              `sunspec:"offset=20,len=16"`
-	SoC_SF         sunspec.ScaleFactor `sunspec:"offset=36,len=1"`
-	SoH_SF         sunspec.ScaleFactor `sunspec:"offset=37,len=1"`
-	DoD_SF         sunspec.ScaleFactor `sunspec:"offset=38,len=1"`
-	V_SF           sunspec.ScaleFactor `sunspec:"offset=39,len=1"`
-	CellV_SF       sunspec.ScaleFactor `sunspec:"offset=40,len=1"`
-	Tmp_SF         sunspec.ScaleFactor `sunspec:"offset=41,len=1"`
+	SoC_SF         sunspec.ScaleFactor `sunspec:"offset=36"`
+	SoH_SF         sunspec.ScaleFactor `sunspec:"offset=37"`
+	DoD_SF         sunspec.ScaleFactor `sunspec:"offset=38"`
+	V_SF           sunspec.ScaleFactor `sunspec:"offset=39"`
+	CellV_SF       sunspec.ScaleFactor `sunspec:"offset=40"`
+	Tmp_SF         sunspec.ScaleFactor `sunspec:"offset=41"`
 
 	Repeats []Block805Repeat
 }
@@ -102,41 +102,41 @@ func init() {
 				Length: 42,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: StrIdx, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "String Index", Description: "Index of the string containing the module."},
-					{Id: ModIdx, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Index", Description: "Index of the module within the string."},
-					{Id: NCell, Offset: 2, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Cell Count", Description: "Count of all cells in the module."},
-					{Id: SoC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Length: 1, Label: "Module SoC", Description: "Module state of charge, expressed as a percentage."},
-					{Id: DoD, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "DoD_SF", Units: "%", Length: 1, Label: "Depth of Discharge", Description: "Depth of discharge for the module."},
-					{Id: SoH, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Length: 1, Label: "Module SoH", Description: "Module state of health, expressed as a percentage."},
-					{Id: NCyc, Offset: 6, Type: typelabel.Uint32, Length: 2, Label: "Cycle Count", Description: "Count of cycles executed."},
-					{Id: V, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Length: 1, Mandatory: true, Label: "Module Voltage", Description: "Voltage of the module."},
-					{Id: CellVMax, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the module."},
-					{Id: CellVMaxCell, Offset: 10, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Cell", Description: "Cell with the maximum voltage."},
-					{Id: CellVMin, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the module."},
-					{Id: CellVMinCell, Offset: 12, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Cell", Description: "Cell with the minimum voltage."},
-					{Id: CellVAvg, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the module."},
-					{Id: CellTmpMax, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Max Cell Temperature", Description: "Maximum temperature for all cells in the module."},
-					{Id: CellTmpMaxCell, Offset: 15, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Temperature Cell", Description: "Cell with the maximum cell temperature."},
-					{Id: CellTmpMin, Offset: 16, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Min Cell Temperature", Description: "Minimum temperature for all cells in the module."},
-					{Id: CellTmpMinCell, Offset: 17, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Temperature Cell", Description: "Cell with the minimum cell temperature."},
-					{Id: CellTmpAvg, Offset: 18, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Average Cell Temperature", Description: "Average temperature for all cells in the module."},
-					{Id: NCellBal, Offset: 19, Type: typelabel.Uint16, Length: 1, Label: "Balanced Cell Count", Description: "Number of cells currently being balanced in the module."},
+					{Id: StrIdx, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "String Index", Description: "Index of the string containing the module."},
+					{Id: ModIdx, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "Module Index", Description: "Index of the module within the string."},
+					{Id: NCell, Offset: 2, Type: typelabel.Uint16, Mandatory: true, Label: "Module Cell Count", Description: "Count of all cells in the module."},
+					{Id: SoC, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Label: "Module SoC", Description: "Module state of charge, expressed as a percentage."},
+					{Id: DoD, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "DoD_SF", Units: "%", Label: "Depth of Discharge", Description: "Depth of discharge for the module."},
+					{Id: SoH, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "SoH_SF", Units: "%", Label: "Module SoH", Description: "Module state of health, expressed as a percentage."},
+					{Id: NCyc, Offset: 6, Type: typelabel.Uint32, Label: "Cycle Count", Description: "Count of cycles executed."},
+					{Id: V, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "V_SF", Units: "V", Mandatory: true, Label: "Module Voltage", Description: "Voltage of the module."},
+					{Id: CellVMax, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the module."},
+					{Id: CellVMaxCell, Offset: 10, Type: typelabel.Uint16, Label: "Max Cell Voltage Cell", Description: "Cell with the maximum voltage."},
+					{Id: CellVMin, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the module."},
+					{Id: CellVMinCell, Offset: 12, Type: typelabel.Uint16, Label: "Min Cell Voltage Cell", Description: "Cell with the minimum voltage."},
+					{Id: CellVAvg, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the module."},
+					{Id: CellTmpMax, Offset: 14, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Max Cell Temperature", Description: "Maximum temperature for all cells in the module."},
+					{Id: CellTmpMaxCell, Offset: 15, Type: typelabel.Uint16, Label: "Max Cell Temperature Cell", Description: "Cell with the maximum cell temperature."},
+					{Id: CellTmpMin, Offset: 16, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Min Cell Temperature", Description: "Minimum temperature for all cells in the module."},
+					{Id: CellTmpMinCell, Offset: 17, Type: typelabel.Uint16, Label: "Min Cell Temperature Cell", Description: "Cell with the minimum cell temperature."},
+					{Id: CellTmpAvg, Offset: 18, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Average Cell Temperature", Description: "Average temperature for all cells in the module."},
+					{Id: NCellBal, Offset: 19, Type: typelabel.Uint16, Label: "Balanced Cell Count", Description: "Number of cells currently being balanced in the module."},
 					{Id: SN, Offset: 20, Type: typelabel.String, Length: 16, Label: "Serial Number", Description: "Serial number for the module."},
-					{Id: SoC_SF, Offset: 36, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: SoH_SF, Offset: 37, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: DoD_SF, Offset: 38, Type: typelabel.ScaleFactor, Length: 1},
-					{Id: V_SF, Offset: 39, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: CellV_SF, Offset: 40, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Tmp_SF, Offset: 41, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
+					{Id: SoC_SF, Offset: 36, Type: typelabel.ScaleFactor},
+					{Id: SoH_SF, Offset: 37, Type: typelabel.ScaleFactor},
+					{Id: DoD_SF, Offset: 38, Type: typelabel.ScaleFactor},
+					{Id: V_SF, Offset: 39, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: CellV_SF, Offset: 40, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Tmp_SF, Offset: 41, Type: typelabel.ScaleFactor, Mandatory: true},
 				},
 			},
 			{Name: "lithium-ion-module-cell",
 				Length: 4,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: CellV, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Cell Voltage", Description: "Cell terminal voltage."},
-					{Id: CellTmp, Offset: 1, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Cell Temperature", Description: "Cell temperature."},
-					{Id: CellSt, Offset: 2, Type: typelabel.Bitfield32, Length: 2, Label: "Cell Status", Description: "Status of the cell."},
+					{Id: CellV, Offset: 0, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Mandatory: true, Label: "Cell Voltage", Description: "Cell terminal voltage."},
+					{Id: CellTmp, Offset: 1, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Cell Temperature", Description: "Cell temperature."},
+					{Id: CellSt, Offset: 2, Type: typelabel.Bitfield32, Label: "Cell Status", Description: "Status of the cell."},
 				},
 			},
 		}})

--- a/models/model806/model.go
+++ b/models/model806/model.go
@@ -23,11 +23,11 @@ const (
 )
 
 type Block806Repeat struct {
-	BatStTBD uint16 `sunspec:"offset=0,len=1"`
+	BatStTBD uint16 `sunspec:"offset=0"`
 }
 
 type Block806 struct {
-	BatTBD uint16 `sunspec:"offset=0,len=1"`
+	BatTBD uint16 `sunspec:"offset=0"`
 
 	Repeats []Block806Repeat
 }
@@ -48,14 +48,14 @@ func init() {
 				Length: 1,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: BatTBD, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Battery Points To Be Determined", Description: ""},
+					{Id: BatTBD, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Battery Points To Be Determined", Description: ""},
 				},
 			},
 			{Name: "battery_string",
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: BatStTBD, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Battery String Points To Be Determined", Description: ""},
+					{Id: BatStTBD, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Battery String Points To Be Determined", Description: ""},
 				},
 			},
 		}})

--- a/models/model807/model.go
+++ b/models/model807/model.go
@@ -71,59 +71,59 @@ const (
 )
 
 type Block807Repeat struct {
-	ModIdx          uint16             `sunspec:"offset=0,len=1"`
-	ModNStk         uint16             `sunspec:"offset=1,len=1"`
-	ModSt           sunspec.Bitfield32 `sunspec:"offset=2,len=2"`
-	ModSoC          uint16             `sunspec:"offset=4,len=1,sf=SoC_SF"`
-	ModOCV          uint16             `sunspec:"offset=5,len=1,sf=OCV_SF"`
-	ModV            uint16             `sunspec:"offset=6,len=1,sf=ModV_SF"`
-	ModCellVMax     uint16             `sunspec:"offset=7,len=1,sf=CellV_SF"`
-	ModCellVMaxCell uint16             `sunspec:"offset=8,len=1"`
-	ModCellVMin     uint16             `sunspec:"offset=9,len=1,sf=CellV_SF"`
-	ModCellVMinCell uint16             `sunspec:"offset=10,len=1"`
-	ModCellVAvg     uint16             `sunspec:"offset=11,len=1,sf=CellV_SF"`
-	ModAnoTmp       uint16             `sunspec:"offset=12,len=1,sf=Tmp_SF"`
-	ModCatTmp       uint16             `sunspec:"offset=13,len=1,sf=Tmp_SF"`
-	ModConSt        sunspec.Bitfield32 `sunspec:"offset=14,len=2"`
-	ModEvt1         sunspec.Bitfield32 `sunspec:"offset=16,len=2"`
-	ModEvt2         sunspec.Bitfield32 `sunspec:"offset=18,len=2"`
-	ModConFail      sunspec.Enum16     `sunspec:"offset=20,len=1"`
-	ModSetEna       sunspec.Enum16     `sunspec:"offset=21,len=1,access=rw"`
-	ModSetCon       sunspec.Enum16     `sunspec:"offset=22,len=1,access=rw"`
-	ModDisRsn       sunspec.Enum16     `sunspec:"offset=23,len=1"`
+	ModIdx          uint16             `sunspec:"offset=0"`
+	ModNStk         uint16             `sunspec:"offset=1"`
+	ModSt           sunspec.Bitfield32 `sunspec:"offset=2"`
+	ModSoC          uint16             `sunspec:"offset=4,sf=SoC_SF"`
+	ModOCV          uint16             `sunspec:"offset=5,sf=OCV_SF"`
+	ModV            uint16             `sunspec:"offset=6,sf=ModV_SF"`
+	ModCellVMax     uint16             `sunspec:"offset=7,sf=CellV_SF"`
+	ModCellVMaxCell uint16             `sunspec:"offset=8"`
+	ModCellVMin     uint16             `sunspec:"offset=9,sf=CellV_SF"`
+	ModCellVMinCell uint16             `sunspec:"offset=10"`
+	ModCellVAvg     uint16             `sunspec:"offset=11,sf=CellV_SF"`
+	ModAnoTmp       uint16             `sunspec:"offset=12,sf=Tmp_SF"`
+	ModCatTmp       uint16             `sunspec:"offset=13,sf=Tmp_SF"`
+	ModConSt        sunspec.Bitfield32 `sunspec:"offset=14"`
+	ModEvt1         sunspec.Bitfield32 `sunspec:"offset=16"`
+	ModEvt2         sunspec.Bitfield32 `sunspec:"offset=18"`
+	ModConFail      sunspec.Enum16     `sunspec:"offset=20"`
+	ModSetEna       sunspec.Enum16     `sunspec:"offset=21,access=rw"`
+	ModSetCon       sunspec.Enum16     `sunspec:"offset=22,access=rw"`
+	ModDisRsn       sunspec.Enum16     `sunspec:"offset=23"`
 }
 
 type Block807 struct {
-	Idx         uint16              `sunspec:"offset=0,len=1"`
-	NMod        uint16              `sunspec:"offset=1,len=1"`
-	NModCon     uint16              `sunspec:"offset=2,len=1"`
-	ModVMax     uint16              `sunspec:"offset=3,len=1,sf=ModV_SF"`
-	ModVMaxMod  uint16              `sunspec:"offset=4,len=1"`
-	ModVMin     uint16              `sunspec:"offset=5,len=1,sf=ModV_SF"`
-	ModVMinMod  uint16              `sunspec:"offset=6,len=1"`
-	ModVAvg     uint16              `sunspec:"offset=7,len=1,sf=ModV_SF"`
-	CellVMax    uint16              `sunspec:"offset=8,len=1,sf=CellV_SF"`
-	CellVMaxMod uint16              `sunspec:"offset=9,len=1"`
-	CellVMaxStk uint16              `sunspec:"offset=10,len=1"`
-	CellVMin    uint16              `sunspec:"offset=11,len=1,sf=CellV_SF"`
-	CellVMinMod uint16              `sunspec:"offset=12,len=1"`
-	CellVMinStk uint16              `sunspec:"offset=13,len=1"`
-	CellVAvg    uint16              `sunspec:"offset=14,len=1,sf=CellV_SF"`
-	TmpMax      int16               `sunspec:"offset=15,len=1,sf=Tmp_SF"`
-	TmpMaxMod   uint16              `sunspec:"offset=16,len=1"`
-	TmpMin      int16               `sunspec:"offset=17,len=1,sf=Tmp_SF"`
-	TmpMinMod   uint16              `sunspec:"offset=18,len=1"`
-	TmpAvg      int16               `sunspec:"offset=19,len=1,sf=Tmp_SF"`
-	Evt1        sunspec.Bitfield32  `sunspec:"offset=20,len=2"`
-	Evt2        sunspec.Bitfield32  `sunspec:"offset=22,len=2"`
-	EvtVnd1     sunspec.Bitfield32  `sunspec:"offset=24,len=2"`
-	EvtVnd2     sunspec.Bitfield32  `sunspec:"offset=26,len=2"`
-	ModV_SF     sunspec.ScaleFactor `sunspec:"offset=28,len=1"`
-	CellV_SF    sunspec.ScaleFactor `sunspec:"offset=29,len=1"`
-	Tmp_SF      sunspec.ScaleFactor `sunspec:"offset=30,len=1"`
-	SoC_SF      sunspec.ScaleFactor `sunspec:"offset=31,len=1"`
-	OCV_SF      sunspec.ScaleFactor `sunspec:"offset=32,len=1"`
-	Pad1        sunspec.Pad         `sunspec:"offset=33,len=1"`
+	Idx         uint16              `sunspec:"offset=0"`
+	NMod        uint16              `sunspec:"offset=1"`
+	NModCon     uint16              `sunspec:"offset=2"`
+	ModVMax     uint16              `sunspec:"offset=3,sf=ModV_SF"`
+	ModVMaxMod  uint16              `sunspec:"offset=4"`
+	ModVMin     uint16              `sunspec:"offset=5,sf=ModV_SF"`
+	ModVMinMod  uint16              `sunspec:"offset=6"`
+	ModVAvg     uint16              `sunspec:"offset=7,sf=ModV_SF"`
+	CellVMax    uint16              `sunspec:"offset=8,sf=CellV_SF"`
+	CellVMaxMod uint16              `sunspec:"offset=9"`
+	CellVMaxStk uint16              `sunspec:"offset=10"`
+	CellVMin    uint16              `sunspec:"offset=11,sf=CellV_SF"`
+	CellVMinMod uint16              `sunspec:"offset=12"`
+	CellVMinStk uint16              `sunspec:"offset=13"`
+	CellVAvg    uint16              `sunspec:"offset=14,sf=CellV_SF"`
+	TmpMax      int16               `sunspec:"offset=15,sf=Tmp_SF"`
+	TmpMaxMod   uint16              `sunspec:"offset=16"`
+	TmpMin      int16               `sunspec:"offset=17,sf=Tmp_SF"`
+	TmpMinMod   uint16              `sunspec:"offset=18"`
+	TmpAvg      int16               `sunspec:"offset=19,sf=Tmp_SF"`
+	Evt1        sunspec.Bitfield32  `sunspec:"offset=20"`
+	Evt2        sunspec.Bitfield32  `sunspec:"offset=22"`
+	EvtVnd1     sunspec.Bitfield32  `sunspec:"offset=24"`
+	EvtVnd2     sunspec.Bitfield32  `sunspec:"offset=26"`
+	ModV_SF     sunspec.ScaleFactor `sunspec:"offset=28"`
+	CellV_SF    sunspec.ScaleFactor `sunspec:"offset=29"`
+	Tmp_SF      sunspec.ScaleFactor `sunspec:"offset=30"`
+	SoC_SF      sunspec.ScaleFactor `sunspec:"offset=31"`
+	OCV_SF      sunspec.ScaleFactor `sunspec:"offset=32"`
+	Pad1        sunspec.Pad         `sunspec:"offset=33"`
 
 	Repeats []Block807Repeat
 }
@@ -144,62 +144,62 @@ func init() {
 				Length: 34,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: Idx, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "String Index", Description: "Index of the string within the bank."},
-					{Id: NMod, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Count", Description: "Number of modules in this string."},
-					{Id: NModCon, Offset: 2, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Connected Module Count", Description: "Number of electrically connected modules in this string."},
-					{Id: ModVMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Max Module Voltage", Description: "Maximum voltage for all modules in the string."},
-					{Id: ModVMaxMod, Offset: 4, Type: typelabel.Uint16, Length: 1, Label: "Max Module Voltage Module", Description: "Module with the maximum voltage."},
-					{Id: ModVMin, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Min Module Voltage", Description: "Minimum voltage for all modules in the string."},
-					{Id: ModVMinMod, Offset: 6, Type: typelabel.Uint16, Length: 1, Label: "Min Module Voltage Module", Description: "Module with the minimum voltage."},
-					{Id: ModVAvg, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Average Module Voltage", Description: "Average voltage for all modules in the string."},
-					{Id: CellVMax, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the string."},
-					{Id: CellVMaxMod, Offset: 9, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Module", Description: "Module containing the cell with the maximum voltage."},
-					{Id: CellVMaxStk, Offset: 10, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Stack", Description: "Stack containing the cell with the maximum voltage."},
-					{Id: CellVMin, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the string."},
-					{Id: CellVMinMod, Offset: 12, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Module", Description: "Module containing the cell with the minimum voltage."},
-					{Id: CellVMinStk, Offset: 13, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Stack", Description: "Stack containing the cell with the minimum voltage."},
-					{Id: CellVAvg, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Average Cell Voltage", Description: "Average voltage for all cells in the string."},
-					{Id: TmpMax, Offset: 15, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Max Temperature", Description: "Maximum electrolyte temperature for all modules in the string."},
-					{Id: TmpMaxMod, Offset: 16, Type: typelabel.Uint16, Length: 1, Label: "Max Temperature Module", Description: "Module with the maximum temperature."},
-					{Id: TmpMin, Offset: 17, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Min Temperature", Description: "Minimum electrolyte temperature for all modules in the string."},
-					{Id: TmpMinMod, Offset: 18, Type: typelabel.Uint16, Length: 1, Label: "Min Temperature Module", Description: "Module with the minimum temperature."},
-					{Id: TmpAvg, Offset: 19, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Mandatory: true, Label: "Average Temperature", Description: "Average electrolyte temperature for all modules in the string."},
-					{Id: Evt1, Offset: 20, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "String Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: Evt2, Offset: 22, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "String Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: EvtVnd1, Offset: 24, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events."},
-					{Id: EvtVnd2, Offset: 26, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events."},
-					{Id: ModV_SF, Offset: 28, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: CellV_SF, Offset: 29, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Tmp_SF, Offset: 30, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: SoC_SF, Offset: 31, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: OCV_SF, Offset: 32, Type: typelabel.ScaleFactor, Length: 1, Mandatory: true},
-					{Id: Pad1, Offset: 33, Type: typelabel.Pad, Length: 1, Mandatory: true, Label: "Pad", Description: "Pad register."},
+					{Id: Idx, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "String Index", Description: "Index of the string within the bank."},
+					{Id: NMod, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "Module Count", Description: "Number of modules in this string."},
+					{Id: NModCon, Offset: 2, Type: typelabel.Uint16, Mandatory: true, Label: "Connected Module Count", Description: "Number of electrically connected modules in this string."},
+					{Id: ModVMax, Offset: 3, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Mandatory: true, Label: "Max Module Voltage", Description: "Maximum voltage for all modules in the string."},
+					{Id: ModVMaxMod, Offset: 4, Type: typelabel.Uint16, Label: "Max Module Voltage Module", Description: "Module with the maximum voltage."},
+					{Id: ModVMin, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Mandatory: true, Label: "Min Module Voltage", Description: "Minimum voltage for all modules in the string."},
+					{Id: ModVMinMod, Offset: 6, Type: typelabel.Uint16, Label: "Min Module Voltage Module", Description: "Module with the minimum voltage."},
+					{Id: ModVAvg, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Mandatory: true, Label: "Average Module Voltage", Description: "Average voltage for all modules in the string."},
+					{Id: CellVMax, Offset: 8, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Max Cell Voltage", Description: "Maximum voltage for all cells in the string."},
+					{Id: CellVMaxMod, Offset: 9, Type: typelabel.Uint16, Label: "Max Cell Voltage Module", Description: "Module containing the cell with the maximum voltage."},
+					{Id: CellVMaxStk, Offset: 10, Type: typelabel.Uint16, Label: "Max Cell Voltage Stack", Description: "Stack containing the cell with the maximum voltage."},
+					{Id: CellVMin, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Min Cell Voltage", Description: "Minimum voltage for all cells in the string."},
+					{Id: CellVMinMod, Offset: 12, Type: typelabel.Uint16, Label: "Min Cell Voltage Module", Description: "Module containing the cell with the minimum voltage."},
+					{Id: CellVMinStk, Offset: 13, Type: typelabel.Uint16, Label: "Min Cell Voltage Stack", Description: "Stack containing the cell with the minimum voltage."},
+					{Id: CellVAvg, Offset: 14, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Average Cell Voltage", Description: "Average voltage for all cells in the string."},
+					{Id: TmpMax, Offset: 15, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Max Temperature", Description: "Maximum electrolyte temperature for all modules in the string."},
+					{Id: TmpMaxMod, Offset: 16, Type: typelabel.Uint16, Label: "Max Temperature Module", Description: "Module with the maximum temperature."},
+					{Id: TmpMin, Offset: 17, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Min Temperature", Description: "Minimum electrolyte temperature for all modules in the string."},
+					{Id: TmpMinMod, Offset: 18, Type: typelabel.Uint16, Label: "Min Temperature Module", Description: "Module with the minimum temperature."},
+					{Id: TmpAvg, Offset: 19, Type: typelabel.Int16, ScaleFactor: "Tmp_SF", Units: "C", Mandatory: true, Label: "Average Temperature", Description: "Average electrolyte temperature for all modules in the string."},
+					{Id: Evt1, Offset: 20, Type: typelabel.Bitfield32, Mandatory: true, Label: "String Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: Evt2, Offset: 22, Type: typelabel.Bitfield32, Mandatory: true, Label: "String Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: EvtVnd1, Offset: 24, Type: typelabel.Bitfield32, Mandatory: true, Label: "Vendor Event Bitfield 1", Description: "Vendor defined events."},
+					{Id: EvtVnd2, Offset: 26, Type: typelabel.Bitfield32, Mandatory: true, Label: "Vendor Event Bitfield 2", Description: "Vendor defined events."},
+					{Id: ModV_SF, Offset: 28, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: CellV_SF, Offset: 29, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Tmp_SF, Offset: 30, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: SoC_SF, Offset: 31, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: OCV_SF, Offset: 32, Type: typelabel.ScaleFactor, Mandatory: true},
+					{Id: Pad1, Offset: 33, Type: typelabel.Pad, Mandatory: true, Label: "Pad", Description: "Pad register."},
 				},
 			},
 			{Name: "module",
 				Length: 24,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: ModIdx, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Index", Description: "Index of the module within the string."},
-					{Id: ModNStk, Offset: 1, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Stack Count", Description: "Number of stacks in this module."},
-					{Id: ModSt, Offset: 2, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Module Status", Description: "Current status of the module."},
-					{Id: ModSoC, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Length: 1, Mandatory: true, Label: "Module State of Charge", Description: "State of charge for this module."},
-					{Id: ModOCV, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "OCV_SF", Units: "V", Length: 1, Mandatory: true, Label: "Open Circuit Voltage", Description: "Open circuit voltage for this module."},
-					{Id: ModV, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Length: 1, Mandatory: true, Label: "External Voltage", Description: "External voltage fo this module."},
-					{Id: ModCellVMax, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Maximum Cell Voltage", Description: "Maximum voltage for all cells in this module."},
-					{Id: ModCellVMaxCell, Offset: 8, Type: typelabel.Uint16, Length: 1, Label: "Max Cell Voltage Cell", Description: "Cell with the maximum cell voltage."},
-					{Id: ModCellVMin, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Minimum Cell Voltage", Description: "Minimum voltage for all cells in this module."},
-					{Id: ModCellVMinCell, Offset: 10, Type: typelabel.Uint16, Length: 1, Label: "Min Cell Voltage Cell", Description: "Cell with the minimum cell voltage."},
-					{Id: ModCellVAvg, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Length: 1, Label: "Average Cell Voltage", Description: "Average voltage for all cells in this module."},
-					{Id: ModAnoTmp, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Anolyte Temperature", Description: ""},
-					{Id: ModCatTmp, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tmp_SF", Units: "C", Length: 1, Label: "Catholyte Temperature", Description: ""},
-					{Id: ModConSt, Offset: 14, Type: typelabel.Bitfield32, Length: 2, Label: "Contactor Status", Description: ""},
-					{Id: ModEvt1, Offset: 16, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Module Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: ModEvt2, Offset: 18, Type: typelabel.Bitfield32, Length: 2, Mandatory: true, Label: "Module Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
-					{Id: ModConFail, Offset: 20, Type: typelabel.Enum16, Length: 1, Label: "Connection Failure Reason", Description: ""},
-					{Id: ModSetEna, Offset: 21, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Enable/Disable Module", Description: "Enables and disables the module."},
-					{Id: ModSetCon, Offset: 22, Type: typelabel.Enum16, Access: "rw", Length: 1, Label: "Connect/Disconnect Module ", Description: "Connects and disconnects the module."},
-					{Id: ModDisRsn, Offset: 23, Type: typelabel.Enum16, Length: 1, Label: "Disabled Reason", Description: "Reason why the module is currently disabled."},
+					{Id: ModIdx, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Module Index", Description: "Index of the module within the string."},
+					{Id: ModNStk, Offset: 1, Type: typelabel.Uint16, Mandatory: true, Label: "Stack Count", Description: "Number of stacks in this module."},
+					{Id: ModSt, Offset: 2, Type: typelabel.Bitfield32, Mandatory: true, Label: "Module Status", Description: "Current status of the module."},
+					{Id: ModSoC, Offset: 4, Type: typelabel.Uint16, ScaleFactor: "SoC_SF", Units: "%", Mandatory: true, Label: "Module State of Charge", Description: "State of charge for this module."},
+					{Id: ModOCV, Offset: 5, Type: typelabel.Uint16, ScaleFactor: "OCV_SF", Units: "V", Mandatory: true, Label: "Open Circuit Voltage", Description: "Open circuit voltage for this module."},
+					{Id: ModV, Offset: 6, Type: typelabel.Uint16, ScaleFactor: "ModV_SF", Units: "V", Mandatory: true, Label: "External Voltage", Description: "External voltage fo this module."},
+					{Id: ModCellVMax, Offset: 7, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Maximum Cell Voltage", Description: "Maximum voltage for all cells in this module."},
+					{Id: ModCellVMaxCell, Offset: 8, Type: typelabel.Uint16, Label: "Max Cell Voltage Cell", Description: "Cell with the maximum cell voltage."},
+					{Id: ModCellVMin, Offset: 9, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Minimum Cell Voltage", Description: "Minimum voltage for all cells in this module."},
+					{Id: ModCellVMinCell, Offset: 10, Type: typelabel.Uint16, Label: "Min Cell Voltage Cell", Description: "Cell with the minimum cell voltage."},
+					{Id: ModCellVAvg, Offset: 11, Type: typelabel.Uint16, ScaleFactor: "CellV_SF", Units: "V", Label: "Average Cell Voltage", Description: "Average voltage for all cells in this module."},
+					{Id: ModAnoTmp, Offset: 12, Type: typelabel.Uint16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Anolyte Temperature", Description: ""},
+					{Id: ModCatTmp, Offset: 13, Type: typelabel.Uint16, ScaleFactor: "Tmp_SF", Units: "C", Label: "Catholyte Temperature", Description: ""},
+					{Id: ModConSt, Offset: 14, Type: typelabel.Bitfield32, Label: "Contactor Status", Description: ""},
+					{Id: ModEvt1, Offset: 16, Type: typelabel.Bitfield32, Mandatory: true, Label: "Module Event 1", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: ModEvt2, Offset: 18, Type: typelabel.Bitfield32, Mandatory: true, Label: "Module Event 2", Description: "Alarms, warnings and status values.  Bit flags."},
+					{Id: ModConFail, Offset: 20, Type: typelabel.Enum16, Label: "Connection Failure Reason", Description: ""},
+					{Id: ModSetEna, Offset: 21, Type: typelabel.Enum16, Access: "rw", Label: "Enable/Disable Module", Description: "Enables and disables the module."},
+					{Id: ModSetCon, Offset: 22, Type: typelabel.Enum16, Access: "rw", Label: "Connect/Disconnect Module ", Description: "Connects and disconnects the module."},
+					{Id: ModDisRsn, Offset: 23, Type: typelabel.Enum16, Label: "Disabled Reason", Description: "Reason why the module is currently disabled."},
 				},
 			},
 		}})

--- a/models/model808/model.go
+++ b/models/model808/model.go
@@ -23,11 +23,11 @@ const (
 )
 
 type Block808Repeat struct {
-	StackTBD uint16 `sunspec:"offset=0,len=1"`
+	StackTBD uint16 `sunspec:"offset=0"`
 }
 
 type Block808 struct {
-	ModuleTBD uint16 `sunspec:"offset=0,len=1"`
+	ModuleTBD uint16 `sunspec:"offset=0"`
 
 	Repeats []Block808Repeat
 }
@@ -48,14 +48,14 @@ func init() {
 				Length: 1,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: ModuleTBD, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Module Points To Be Determined", Description: ""},
+					{Id: ModuleTBD, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Module Points To Be Determined", Description: ""},
 				},
 			},
 			{Name: "stack",
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: StackTBD, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Stack Points To Be Determined", Description: ""},
+					{Id: StackTBD, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Stack Points To Be Determined", Description: ""},
 				},
 			},
 		}})

--- a/models/model809/model.go
+++ b/models/model809/model.go
@@ -23,11 +23,11 @@ const (
 )
 
 type Block809Repeat struct {
-	CellTBD uint16 `sunspec:"offset=0,len=1"`
+	CellTBD uint16 `sunspec:"offset=0"`
 }
 
 type Block809 struct {
-	StackTBD uint16 `sunspec:"offset=0,len=1"`
+	StackTBD uint16 `sunspec:"offset=0"`
 
 	Repeats []Block809Repeat
 }
@@ -48,14 +48,14 @@ func init() {
 				Length: 1,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: StackTBD, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Stack Points To Be Determined", Description: ""},
+					{Id: StackTBD, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Stack Points To Be Determined", Description: ""},
 				},
 			},
 			{Name: "cell",
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: CellTBD, Offset: 0, Type: typelabel.Uint16, Length: 1, Mandatory: true, Label: "Cell Points To Be Determined", Description: ""},
+					{Id: CellTBD, Offset: 0, Type: typelabel.Uint16, Mandatory: true, Label: "Cell Points To Be Determined", Description: ""},
 				},
 			},
 		}})

--- a/models/model9/model.go
+++ b/models/model9/model.go
@@ -113,101 +113,101 @@ const (
 )
 
 type Block9Repeat struct {
-	Cert uint16 `sunspec:"offset=0,len=1,access=rw"`
+	Cert uint16 `sunspec:"offset=0,access=rw"`
 }
 
 type Block9 struct {
-	CertUID  uint16         `sunspec:"offset=0,len=1,access=rw"`
-	CertRole uint16         `sunspec:"offset=1,len=1,access=rw"`
-	Fmt      sunspec.Enum16 `sunspec:"offset=2,len=1,access=rw"`
-	Typ      sunspec.Enum16 `sunspec:"offset=3,len=1,access=rw"`
-	TotLn    uint16         `sunspec:"offset=4,len=1,access=rw"`
-	FrgLn    uint16         `sunspec:"offset=5,len=1,access=rw"`
-	Frg1     uint16         `sunspec:"offset=6,len=1,access=rw"`
-	Frg2     uint16         `sunspec:"offset=7,len=1,access=rw"`
-	Frg3     uint16         `sunspec:"offset=8,len=1,access=rw"`
-	Frg4     uint16         `sunspec:"offset=9,len=1,access=rw"`
-	Frg5     uint16         `sunspec:"offset=10,len=1,access=rw"`
-	Frg6     uint16         `sunspec:"offset=11,len=1,access=rw"`
-	Frg7     uint16         `sunspec:"offset=12,len=1,access=rw"`
-	Frg8     uint16         `sunspec:"offset=13,len=1,access=rw"`
-	Frg9     uint16         `sunspec:"offset=14,len=1,access=rw"`
-	Frg10    uint16         `sunspec:"offset=15,len=1,access=rw"`
-	Frg11    uint16         `sunspec:"offset=16,len=1,access=rw"`
-	Frg12    uint16         `sunspec:"offset=17,len=1,access=rw"`
-	Frg13    uint16         `sunspec:"offset=18,len=1,access=rw"`
-	Frg14    uint16         `sunspec:"offset=19,len=1,access=rw"`
-	Frg15    uint16         `sunspec:"offset=20,len=1,access=rw"`
-	Frg16    uint16         `sunspec:"offset=21,len=1,access=rw"`
-	Frg17    uint16         `sunspec:"offset=22,len=1,access=rw"`
-	Frg18    uint16         `sunspec:"offset=23,len=1,access=rw"`
-	Frg19    uint16         `sunspec:"offset=24,len=1,access=rw"`
-	Frg20    uint16         `sunspec:"offset=25,len=1,access=rw"`
-	Frg21    uint16         `sunspec:"offset=26,len=1,access=rw"`
-	Frg22    uint16         `sunspec:"offset=27,len=1,access=rw"`
-	Frg23    uint16         `sunspec:"offset=28,len=1,access=rw"`
-	Frg24    uint16         `sunspec:"offset=29,len=1,access=rw"`
-	Frg25    uint16         `sunspec:"offset=30,len=1,access=rw"`
-	Frg26    uint16         `sunspec:"offset=31,len=1,access=rw"`
-	Frg27    uint16         `sunspec:"offset=32,len=1,access=rw"`
-	Frg28    uint16         `sunspec:"offset=33,len=1,access=rw"`
-	Frg29    uint16         `sunspec:"offset=34,len=1,access=rw"`
-	Frg30    uint16         `sunspec:"offset=35,len=1,access=rw"`
-	Frg31    uint16         `sunspec:"offset=36,len=1,access=rw"`
-	Frg32    uint16         `sunspec:"offset=37,len=1,access=rw"`
-	Frg33    uint16         `sunspec:"offset=38,len=1,access=rw"`
-	Frg34    uint16         `sunspec:"offset=39,len=1,access=rw"`
-	Frg35    uint16         `sunspec:"offset=40,len=1,access=rw"`
-	Frg36    uint16         `sunspec:"offset=41,len=1,access=rw"`
-	Frg37    uint16         `sunspec:"offset=42,len=1,access=rw"`
-	Frg38    uint16         `sunspec:"offset=43,len=1,access=rw"`
-	Frg39    uint16         `sunspec:"offset=44,len=1,access=rw"`
-	Frg40    uint16         `sunspec:"offset=45,len=1,access=rw"`
-	Frg41    uint16         `sunspec:"offset=46,len=1,access=rw"`
-	Frg42    uint16         `sunspec:"offset=47,len=1,access=rw"`
-	Frg43    uint16         `sunspec:"offset=48,len=1,access=rw"`
-	Frg44    uint16         `sunspec:"offset=49,len=1,access=rw"`
-	Frg45    uint16         `sunspec:"offset=50,len=1,access=rw"`
-	Frg46    uint16         `sunspec:"offset=51,len=1,access=rw"`
-	Frg47    uint16         `sunspec:"offset=52,len=1,access=rw"`
-	Frg48    uint16         `sunspec:"offset=53,len=1,access=rw"`
-	Frg49    uint16         `sunspec:"offset=54,len=1,access=rw"`
-	Frg50    uint16         `sunspec:"offset=55,len=1,access=rw"`
-	Frg51    uint16         `sunspec:"offset=56,len=1,access=rw"`
-	Frg52    uint16         `sunspec:"offset=57,len=1,access=rw"`
-	Frg53    uint16         `sunspec:"offset=58,len=1,access=rw"`
-	Frg54    uint16         `sunspec:"offset=59,len=1,access=rw"`
-	Frg55    uint16         `sunspec:"offset=60,len=1,access=rw"`
-	Frg56    uint16         `sunspec:"offset=61,len=1,access=rw"`
-	Frg57    uint16         `sunspec:"offset=62,len=1,access=rw"`
-	Frg58    uint16         `sunspec:"offset=63,len=1,access=rw"`
-	Frg59    uint16         `sunspec:"offset=64,len=1,access=rw"`
-	Frg60    uint16         `sunspec:"offset=65,len=1,access=rw"`
-	Frg61    uint16         `sunspec:"offset=66,len=1,access=rw"`
-	Frg62    uint16         `sunspec:"offset=67,len=1,access=rw"`
-	Frg63    uint16         `sunspec:"offset=68,len=1,access=rw"`
-	Frg64    uint16         `sunspec:"offset=69,len=1,access=rw"`
-	Frg65    uint16         `sunspec:"offset=70,len=1,access=rw"`
-	Frg66    uint16         `sunspec:"offset=71,len=1,access=rw"`
-	Frg67    uint16         `sunspec:"offset=72,len=1,access=rw"`
-	Frg68    uint16         `sunspec:"offset=73,len=1,access=rw"`
-	Frg69    uint16         `sunspec:"offset=74,len=1,access=rw"`
-	Frg70    uint16         `sunspec:"offset=75,len=1,access=rw"`
-	Frg71    uint16         `sunspec:"offset=76,len=1,access=rw"`
-	Frg72    uint16         `sunspec:"offset=77,len=1,access=rw"`
-	Frg73    uint16         `sunspec:"offset=78,len=1,access=rw"`
-	Frg74    uint16         `sunspec:"offset=79,len=1,access=rw"`
-	Frg75    uint16         `sunspec:"offset=80,len=1,access=rw"`
-	Frg78    uint16         `sunspec:"offset=81,len=1,access=rw"`
-	Frg79    uint16         `sunspec:"offset=82,len=1,access=rw"`
-	Frg80    uint16         `sunspec:"offset=83,len=1,access=rw"`
-	Ts       uint32         `sunspec:"offset=84,len=2,access=rw"`
-	Ms       uint16         `sunspec:"offset=86,len=1,access=rw"`
-	Seq      uint16         `sunspec:"offset=87,len=1,access=rw"`
-	UID      uint16         `sunspec:"offset=88,len=1,access=rw"`
-	Role     uint16         `sunspec:"offset=89,len=1,access=rw"`
-	Alg      sunspec.Enum16 `sunspec:"offset=90,len=1,access=rw"`
-	N        uint16         `sunspec:"offset=91,len=1,access=rw"`
+	CertUID  uint16         `sunspec:"offset=0,access=rw"`
+	CertRole uint16         `sunspec:"offset=1,access=rw"`
+	Fmt      sunspec.Enum16 `sunspec:"offset=2,access=rw"`
+	Typ      sunspec.Enum16 `sunspec:"offset=3,access=rw"`
+	TotLn    uint16         `sunspec:"offset=4,access=rw"`
+	FrgLn    uint16         `sunspec:"offset=5,access=rw"`
+	Frg1     uint16         `sunspec:"offset=6,access=rw"`
+	Frg2     uint16         `sunspec:"offset=7,access=rw"`
+	Frg3     uint16         `sunspec:"offset=8,access=rw"`
+	Frg4     uint16         `sunspec:"offset=9,access=rw"`
+	Frg5     uint16         `sunspec:"offset=10,access=rw"`
+	Frg6     uint16         `sunspec:"offset=11,access=rw"`
+	Frg7     uint16         `sunspec:"offset=12,access=rw"`
+	Frg8     uint16         `sunspec:"offset=13,access=rw"`
+	Frg9     uint16         `sunspec:"offset=14,access=rw"`
+	Frg10    uint16         `sunspec:"offset=15,access=rw"`
+	Frg11    uint16         `sunspec:"offset=16,access=rw"`
+	Frg12    uint16         `sunspec:"offset=17,access=rw"`
+	Frg13    uint16         `sunspec:"offset=18,access=rw"`
+	Frg14    uint16         `sunspec:"offset=19,access=rw"`
+	Frg15    uint16         `sunspec:"offset=20,access=rw"`
+	Frg16    uint16         `sunspec:"offset=21,access=rw"`
+	Frg17    uint16         `sunspec:"offset=22,access=rw"`
+	Frg18    uint16         `sunspec:"offset=23,access=rw"`
+	Frg19    uint16         `sunspec:"offset=24,access=rw"`
+	Frg20    uint16         `sunspec:"offset=25,access=rw"`
+	Frg21    uint16         `sunspec:"offset=26,access=rw"`
+	Frg22    uint16         `sunspec:"offset=27,access=rw"`
+	Frg23    uint16         `sunspec:"offset=28,access=rw"`
+	Frg24    uint16         `sunspec:"offset=29,access=rw"`
+	Frg25    uint16         `sunspec:"offset=30,access=rw"`
+	Frg26    uint16         `sunspec:"offset=31,access=rw"`
+	Frg27    uint16         `sunspec:"offset=32,access=rw"`
+	Frg28    uint16         `sunspec:"offset=33,access=rw"`
+	Frg29    uint16         `sunspec:"offset=34,access=rw"`
+	Frg30    uint16         `sunspec:"offset=35,access=rw"`
+	Frg31    uint16         `sunspec:"offset=36,access=rw"`
+	Frg32    uint16         `sunspec:"offset=37,access=rw"`
+	Frg33    uint16         `sunspec:"offset=38,access=rw"`
+	Frg34    uint16         `sunspec:"offset=39,access=rw"`
+	Frg35    uint16         `sunspec:"offset=40,access=rw"`
+	Frg36    uint16         `sunspec:"offset=41,access=rw"`
+	Frg37    uint16         `sunspec:"offset=42,access=rw"`
+	Frg38    uint16         `sunspec:"offset=43,access=rw"`
+	Frg39    uint16         `sunspec:"offset=44,access=rw"`
+	Frg40    uint16         `sunspec:"offset=45,access=rw"`
+	Frg41    uint16         `sunspec:"offset=46,access=rw"`
+	Frg42    uint16         `sunspec:"offset=47,access=rw"`
+	Frg43    uint16         `sunspec:"offset=48,access=rw"`
+	Frg44    uint16         `sunspec:"offset=49,access=rw"`
+	Frg45    uint16         `sunspec:"offset=50,access=rw"`
+	Frg46    uint16         `sunspec:"offset=51,access=rw"`
+	Frg47    uint16         `sunspec:"offset=52,access=rw"`
+	Frg48    uint16         `sunspec:"offset=53,access=rw"`
+	Frg49    uint16         `sunspec:"offset=54,access=rw"`
+	Frg50    uint16         `sunspec:"offset=55,access=rw"`
+	Frg51    uint16         `sunspec:"offset=56,access=rw"`
+	Frg52    uint16         `sunspec:"offset=57,access=rw"`
+	Frg53    uint16         `sunspec:"offset=58,access=rw"`
+	Frg54    uint16         `sunspec:"offset=59,access=rw"`
+	Frg55    uint16         `sunspec:"offset=60,access=rw"`
+	Frg56    uint16         `sunspec:"offset=61,access=rw"`
+	Frg57    uint16         `sunspec:"offset=62,access=rw"`
+	Frg58    uint16         `sunspec:"offset=63,access=rw"`
+	Frg59    uint16         `sunspec:"offset=64,access=rw"`
+	Frg60    uint16         `sunspec:"offset=65,access=rw"`
+	Frg61    uint16         `sunspec:"offset=66,access=rw"`
+	Frg62    uint16         `sunspec:"offset=67,access=rw"`
+	Frg63    uint16         `sunspec:"offset=68,access=rw"`
+	Frg64    uint16         `sunspec:"offset=69,access=rw"`
+	Frg65    uint16         `sunspec:"offset=70,access=rw"`
+	Frg66    uint16         `sunspec:"offset=71,access=rw"`
+	Frg67    uint16         `sunspec:"offset=72,access=rw"`
+	Frg68    uint16         `sunspec:"offset=73,access=rw"`
+	Frg69    uint16         `sunspec:"offset=74,access=rw"`
+	Frg70    uint16         `sunspec:"offset=75,access=rw"`
+	Frg71    uint16         `sunspec:"offset=76,access=rw"`
+	Frg72    uint16         `sunspec:"offset=77,access=rw"`
+	Frg73    uint16         `sunspec:"offset=78,access=rw"`
+	Frg74    uint16         `sunspec:"offset=79,access=rw"`
+	Frg75    uint16         `sunspec:"offset=80,access=rw"`
+	Frg78    uint16         `sunspec:"offset=81,access=rw"`
+	Frg79    uint16         `sunspec:"offset=82,access=rw"`
+	Frg80    uint16         `sunspec:"offset=83,access=rw"`
+	Ts       uint32         `sunspec:"offset=84,access=rw"`
+	Ms       uint16         `sunspec:"offset=86,access=rw"`
+	Seq      uint16         `sunspec:"offset=87,access=rw"`
+	UID      uint16         `sunspec:"offset=88,access=rw"`
+	Role     uint16         `sunspec:"offset=89,access=rw"`
+	Alg      sunspec.Enum16 `sunspec:"offset=90,access=rw"`
+	N        uint16         `sunspec:"offset=91,access=rw"`
 
 	Repeats []Block9Repeat
 }
@@ -228,104 +228,104 @@ func init() {
 				Length: 92,
 				Type:   types.BlockFixed,
 				Points: []types.Point{
-					{Id: CertUID, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Cert_UID", Description: "User ID for this certificate"},
-					{Id: CertRole, Offset: 1, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Cert_Role", Description: "Role for this certificate"},
-					{Id: Fmt, Offset: 2, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Format", Description: "Format of this certificate"},
-					{Id: Typ, Offset: 3, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Type", Description: "Type of this certificate"},
-					{Id: TotLn, Offset: 4, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Total Length", Description: "Total Length of the Certificate"},
-					{Id: FrgLn, Offset: 5, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Fragment length", Description: "Length of this fragment"},
-					{Id: Frg1, Offset: 6, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Frag1", Description: "First word of this fragment"},
-					{Id: Frg2, Offset: 7, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg3, Offset: 8, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg4, Offset: 9, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg5, Offset: 10, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg6, Offset: 11, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg7, Offset: 12, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg8, Offset: 13, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg9, Offset: 14, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg10, Offset: 15, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg11, Offset: 16, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg12, Offset: 17, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg13, Offset: 18, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg14, Offset: 19, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg15, Offset: 20, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg16, Offset: 21, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg17, Offset: 22, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg18, Offset: 23, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg19, Offset: 24, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg20, Offset: 25, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg21, Offset: 26, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg22, Offset: 27, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg23, Offset: 28, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg24, Offset: 29, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg25, Offset: 30, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg26, Offset: 31, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg27, Offset: 32, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg28, Offset: 33, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg29, Offset: 34, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg30, Offset: 35, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg31, Offset: 36, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg32, Offset: 37, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg33, Offset: 38, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg34, Offset: 39, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg35, Offset: 40, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg36, Offset: 41, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg37, Offset: 42, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg38, Offset: 43, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg39, Offset: 44, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg40, Offset: 45, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg41, Offset: 46, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg42, Offset: 47, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg43, Offset: 48, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg44, Offset: 49, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg45, Offset: 50, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg46, Offset: 51, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg47, Offset: 52, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg48, Offset: 53, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg49, Offset: 54, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg50, Offset: 55, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg51, Offset: 56, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg52, Offset: 57, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg53, Offset: 58, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg54, Offset: 59, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg55, Offset: 60, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg56, Offset: 61, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg57, Offset: 62, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg58, Offset: 63, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg59, Offset: 64, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg60, Offset: 65, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg61, Offset: 66, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg62, Offset: 67, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg63, Offset: 68, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg64, Offset: 69, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg65, Offset: 70, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg66, Offset: 71, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg67, Offset: 72, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg68, Offset: 73, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg69, Offset: 74, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg70, Offset: 75, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg71, Offset: 76, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg72, Offset: 77, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg73, Offset: 78, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg74, Offset: 79, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg75, Offset: 80, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg78, Offset: 81, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg79, Offset: 82, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
-					{Id: Frg80, Offset: 83, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Frag80", Description: "Last word of this fragment"},
-					{Id: Ts, Offset: 84, Type: typelabel.Uint32, Access: "rw", Length: 2, Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
-					{Id: Ms, Offset: 86, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
-					{Id: Seq, Offset: 87, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
-					{Id: UID, Offset: 88, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "UID", Description: "User ID for the request signature"},
-					{Id: Role, Offset: 89, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "Role", Description: "Signing key used 0-5"},
-					{Id: Alg, Offset: 90, Type: typelabel.Enum16, Access: "rw", Length: 1, Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
-					{Id: N, Offset: 91, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true, Label: "N", Description: "Number of registers to follow for the certificate"},
+					{Id: CertUID, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Cert_UID", Description: "User ID for this certificate"},
+					{Id: CertRole, Offset: 1, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Cert_Role", Description: "Role for this certificate"},
+					{Id: Fmt, Offset: 2, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Format", Description: "Format of this certificate"},
+					{Id: Typ, Offset: 3, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Type", Description: "Type of this certificate"},
+					{Id: TotLn, Offset: 4, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Total Length", Description: "Total Length of the Certificate"},
+					{Id: FrgLn, Offset: 5, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Fragment length", Description: "Length of this fragment"},
+					{Id: Frg1, Offset: 6, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Frag1", Description: "First word of this fragment"},
+					{Id: Frg2, Offset: 7, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg3, Offset: 8, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg4, Offset: 9, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg5, Offset: 10, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg6, Offset: 11, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg7, Offset: 12, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg8, Offset: 13, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg9, Offset: 14, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg10, Offset: 15, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg11, Offset: 16, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg12, Offset: 17, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg13, Offset: 18, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg14, Offset: 19, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg15, Offset: 20, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg16, Offset: 21, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg17, Offset: 22, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg18, Offset: 23, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg19, Offset: 24, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg20, Offset: 25, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg21, Offset: 26, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg22, Offset: 27, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg23, Offset: 28, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg24, Offset: 29, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg25, Offset: 30, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg26, Offset: 31, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg27, Offset: 32, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg28, Offset: 33, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg29, Offset: 34, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg30, Offset: 35, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg31, Offset: 36, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg32, Offset: 37, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg33, Offset: 38, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg34, Offset: 39, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg35, Offset: 40, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg36, Offset: 41, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg37, Offset: 42, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg38, Offset: 43, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg39, Offset: 44, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg40, Offset: 45, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg41, Offset: 46, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg42, Offset: 47, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg43, Offset: 48, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg44, Offset: 49, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg45, Offset: 50, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg46, Offset: 51, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg47, Offset: 52, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg48, Offset: 53, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg49, Offset: 54, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg50, Offset: 55, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg51, Offset: 56, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg52, Offset: 57, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg53, Offset: 58, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg54, Offset: 59, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg55, Offset: 60, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg56, Offset: 61, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg57, Offset: 62, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg58, Offset: 63, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg59, Offset: 64, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg60, Offset: 65, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg61, Offset: 66, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg62, Offset: 67, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg63, Offset: 68, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg64, Offset: 69, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg65, Offset: 70, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg66, Offset: 71, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg67, Offset: 72, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg68, Offset: 73, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg69, Offset: 74, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg70, Offset: 75, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg71, Offset: 76, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg72, Offset: 77, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg73, Offset: 78, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg74, Offset: 79, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg75, Offset: 80, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg78, Offset: 81, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg79, Offset: 82, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
+					{Id: Frg80, Offset: 83, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Frag80", Description: "Last word of this fragment"},
+					{Id: Ts, Offset: 84, Type: typelabel.Uint32, Access: "rw", Mandatory: true, Label: "Timestamp", Description: "Timestamp value is the number of seconds since January 1, 2000"},
+					{Id: Ms, Offset: 86, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Milliseconds", Description: "Millisecond counter 0-999"},
+					{Id: Seq, Offset: 87, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Sequence", Description: "Sequence number of request"},
+					{Id: UID, Offset: 88, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "UID", Description: "User ID for the request signature"},
+					{Id: Role, Offset: 89, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "Role", Description: "Signing key used 0-5"},
+					{Id: Alg, Offset: 90, Type: typelabel.Enum16, Access: "rw", Mandatory: true, Label: "Algorithm", Description: "Algorithm used to compute the digital signature"},
+					{Id: N, Offset: 91, Type: typelabel.Uint16, Access: "rw", Mandatory: true, Label: "N", Description: "Number of registers to follow for the certificate"},
 				},
 			},
 			{
 				Length: 1,
 				Type:   types.BlockRepeating,
 				Points: []types.Point{
-					{Id: Cert, Offset: 0, Type: typelabel.Uint16, Access: "rw", Length: 1, Mandatory: true},
+					{Id: Cert, Offset: 0, Type: typelabel.Uint16, Access: "rw", Mandatory: true},
 				},
 			},
 		}})

--- a/types/xml/decode.go
+++ b/types/xml/decode.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"io"
 
+	"github.com/andig/gosunspec/typelen"
 	"github.com/andig/gosunspec/types"
 )
 
@@ -130,7 +131,7 @@ func convert(doc *xmlModelDef) *types.Model {
 				Description: ps.Description,
 				Notes:       ps.Notes,
 				Offset:      xp.Offset,
-				Length:      xp.Length,
+				Length:      explicitLength(xp.Length, xp.Type),
 				Type:        xp.Type,
 				ScaleFactor: xp.ScaleFactor,
 				Units:       xp.Units,
@@ -142,6 +143,22 @@ func convert(doc *xmlModelDef) *types.Model {
 		m.Blocks = append(m.Blocks, b)
 	}
 	return m
+}
+
+// explicitLength returns the point length only when it overrides the
+// type's natural register count. SMDX XML declares len="1" on every
+// scalar point even though that's already the typelen default; keeping
+// it in the canonical Point would force a redundant ",len=1" into every
+// generated struct tag. Variable-width types (e.g. string, which has a
+// zero typelen) keep their declared length.
+func explicitLength(declared uint16, sstype string) uint16 {
+	if declared == 0 {
+		return 0
+	}
+	if uint16(typelen.Length(sstype)) == declared {
+		return 0
+	}
+	return declared
 }
 
 func convertSymbols(ss []xmlSymbol) []types.Symbol {


### PR DESCRIPTION
## Summary

Follow-up to #9.

The SMDX XML spec declares `len=\"1\"` on every scalar point even though that already matches the typelen default for the type (`typelen.Uint16 == 1`, `typelen.Int16 == 1`, etc.). The XML decoder added in #9 faithfully preserved that as `Length: 1` on the canonical `types.Point`, which in turn forced every generated struct tag to carry a redundant `,len=1`:

```diff
- DA  uint16      \`sunspec:\"offset=64,len=1,access=rw\"\`
+ DA  uint16      \`sunspec:\"offset=64,access=rw\"\`
- Pad sunspec.Pad \`sunspec:\"offset=65,len=1\"\`
+ Pad sunspec.Pad \`sunspec:\"offset=65\"\`
```

This drops the redundancy at the decoder boundary so `types.Point.Length` now means \"an explicit override of the type's natural register count\". Variable-width types (string has `typelen.String == 0`) keep their declared length unchanged — `Mn  string \`sunspec:\"offset=0,len=16\"\`` is preserved.

## Root cause

`types/xml/Decode` parsed every point's `<point ... len=\"N\">` into `types.Point{Length: N, ...}` without checking whether N matched the typelen default. The generator template emits `,len={{.Length}}` whenever `.Length > 0`, so any redundant len in the XML showed up in the generated tag.

The pre-#9 in-tree models did not have these redundant tags because they were generated against an older spec version that did not yet include `len=\"1\"` for scalars. Running master's pre-#9 generator against the *current* XML produces the same noise.

## Test plan

- [x] `go build ./...` passes
- [x] Existing tests pass except the two pre-existing PR #7 failures (`xml.TestCopyDevice`, `layout.TestRawLayoutReading`, both also fail on master)
- [x] `len=N` preserved for variable-width types (verified on model 1: `Mn/Md/SN` still carry `len=16`)
- [x] Runtime `Point.Length()` is unchanged — it falls back to `typelen.Length(type)` when `Length == 0`