### PR TITLE
Update README to reflect types/ restructuring and JSON generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ This package contains Go data types representing the [SunSpec][] information mod
 Subpackages implement particular use-cases that rely on this domain model:
 
  * [/impl](./impl) contains the types used by the remainder of the library
- * [/smdx](./smdx) contains types that represent (XML) SMDX models defined by the Sunspec specification
- * [/generators](./generators) implements code generators that transform the [SMDX models][SMDX] into Go code
- * [/models](./models) contains one generated package for each SMDX model
+ * [/types](./types) holds the canonical, encoding-neutral SunSpec model definition
+   (`Model`, `Block`, `Point`, `Symbol`) plus the global registry. Loaders for the
+   two on-disk spec formats live in [/types/xml](./types/xml) (legacy SMDX) and
+   [/types/json](./types/json) (the JSON spec maintained at
+   [github.com/sunspec/models][SMDX]).
+ * [/generators](./generators) contains code generators that emit a Go package per
+   SunSpec model: [/generators/json](./generators/json) reads from the JSON spec
+   (default), [/generators/xml](./generators/xml) reads from the legacy SMDX XML.
+ * [/models](./models) contains one generated package for each SunSpec model
  * [/xml](./xml) contains utilities for exchanging SunSpec data using XML format
  * [/modbus](./modbus) contains utilities for talking to SunSpec devices via Modbus TCP
 
@@ -19,15 +25,20 @@ This implementation is based on the original work from [crabmusket/gosunspec](ht
 
 This package uses typesafe representations of each model type. To avoid
 excessive manual maintenance, structs for each type of model defined by SunSpec
-are generated from the [SMDX model files][SMDX]. To regenerate this code, first
-initialise the spec submodule with:
+are generated from the upstream spec. To regenerate, first initialise the
+spec submodule:
 
     git submodule update --init spec
 
-And from the `spec` directory:
+Then regenerate from the JSON spec (default — covers all current models including
+the DER 7xx series and 64410-64415 that have no SMDX counterpart):
 
-    git pull origin master
+    make spec
 
-Then run the generators:
+To regenerate from the legacy SMDX/XML spec instead (covers only the older subset
+of models):
 
-    go generate ./models
+    make spec-xml
+
+Both generators produce the same `types.Model` shape via `types.RegisterModel`,
+so downstream code does not care which source format was used.


### PR DESCRIPTION
Follow-up docs PR for #8, #9, #10.

* `/smdx` is gone - canonical model types now live in `/types`, with the XML and JSON decoders in `/types/xml` and `/types/json`.
* `/generators` now has two siblings: `/generators/json` (default) and `/generators/xml`; both share the same template logic.
* Regeneration commands updated from `go generate ./models` to `make spec` (JSON) or `make spec-xml` (legacy XML).